### PR TITLE
Python class Functor renamed to Stage.

### DIFF
--- a/python/gridtools/compiler.py
+++ b/python/gridtools/compiler.py
@@ -11,7 +11,7 @@ from gridtools.utils import Utilities
 
 class StencilCompiler ( ):
     """
-    A global class that takes care of compiling the defined stencils 
+    A global class that takes care of compiling the defined stencils
     using different backends.-
     """
     BASE_LIB_NAME = "libgridtools4py"
@@ -71,16 +71,16 @@ class StencilCompiler ( ):
     def analyze (self, stencil, **kwargs):
         """
         Performs a different analyses over the source code of the stencil
-        :param stencil:      the stencil on which the static analysis should be 
+        :param stencil:      the stencil on which the static analysis should be
                              performed
         :param kwargs:       the parameters passed to this stencil for execution
         :raise LookupError:  if the stencil has not been registered with this
                              Compiler
-        :raise NameError:    if no stencil stages could be extracted from the 
+        :raise NameError:    if no stencil stages could be extracted from the
                              source
         :raise RuntimeError: if the stencil's source code is not available,
                              e.g., if running from an interactive session
-        :raise ValueError:   if the last stage is independent, which is an 
+        :raise ValueError:   if the last stage is independent, which is an
                              invalid stencil
         :return:
         """
@@ -133,8 +133,8 @@ class StencilCompiler ( ):
             #
             current_dir         = getcwd ( )
             chdir (self.src_dir)
-            check_call (["make", 
-                         "--silent", 
+            check_call (["make",
+                         "--silent",
                          "--file=%s" % self.make_file])
             chdir (current_dir)
             #
@@ -153,7 +153,7 @@ class StencilCompiler ( ):
     def generate_code (self, stencil):
         """
         Generates native code for the received stencil
-        :param stencil: stencil object for which the code whould be generated 
+        :param stencil: stencil object for which the code whould be generated
         :return:
         """
         from os        import write, path, makedirs
@@ -192,7 +192,7 @@ class StencilCompiler ( ):
             logging.error ("Error while generating code:\n\t%s" % str (e))
             raise e
 
-    
+
     def is_registered (self, stencil):
         """
         Checks whether a stencil is registered with this compiler
@@ -221,7 +221,7 @@ class StencilCompiler ( ):
         """
         Registers the received Stencil object with this compiler
         :param stencil:   the stencil object to register
-        :raise TypeError: in case the stencil object does not extend 
+        :raise TypeError: in case the stencil object does not extend
                           MultiStageStencil
         :return:          a unique name for the given stencil
         """
@@ -291,7 +291,7 @@ class StencilCompiler ( ):
 
     def translate (self, stencil):
         """
-        Translates the received stencil to C++, using the gridtools interface, 
+        Translates the received stencil to C++, using the gridtools interface,
         returning a string tuple of rendered files (functors, cpp, make).-
         """
         from gridtools import JinjaEnv
@@ -399,7 +399,7 @@ class StencilInspector (ast.NodeVisitor):
                     from IPython.code import oinspect
                     src += oinspect.getsource (fun)
                 except Exception:
-                    raise RuntimeError ("Could not extract source code from '%s'" 
+                    raise RuntimeError ("Could not extract source code from '%s'"
                                         % self.inspected_stencil.__class__)
         #
         # then the kernel
@@ -417,7 +417,7 @@ class StencilInspector (ast.NodeVisitor):
                     from IPython.code import oinspect
                     src += oinspect.getsource (fun)
                 except Exception:
-                    raise RuntimeError ("Could not extract source code from '%s'" 
+                    raise RuntimeError ("Could not extract source code from '%s'"
                                         % self.inspected_stencil.__class__)
         return src
 
@@ -425,9 +425,9 @@ class StencilInspector (ast.NodeVisitor):
     def static_analysis (self, stencil):
         """
         Performs a static analysis over the source code of the received stencil
-        :param stencil:      the stencil on which the static analysis should be 
+        :param stencil:      the stencil on which the static analysis should be
                              performed
-        :raise NameError:    if no stencil stages could be extracted from the 
+        :raise NameError:    if no stencil stages could be extracted from the
                              source
         :raise RuntimeError: if the stencil's source code is not available,
                              e.g., if running from an interactive session
@@ -441,7 +441,7 @@ class StencilInspector (ast.NodeVisitor):
             self.inspected_stencil = stencil
             self.functor_defs      = list ( )
             st                     = self.inspected_stencil
-            
+
             if st.scope.py_src is None:
                 st.scope.py_src = self._extract_source ( )
 
@@ -476,7 +476,7 @@ class StencilInspector (ast.NodeVisitor):
         :raise RuntimeError: if more than one assignment per line is found
         :return:
         """
-        # 
+        #
         # expr = expr
         #
         if len (node.targets) > 1:
@@ -491,9 +491,9 @@ class StencilInspector (ast.NodeVisitor):
             if isinstance (lvalue_node, ast.Attribute):
                 lvalue = "%s.%s" % (lvalue_node.value.id,
                                     lvalue_node.attr)
-            # 
+            #
             # parameter or local variable assignment
-            # 
+            #
             elif isinstance (lvalue_node, ast.Name):
                 lvalue = lvalue_node.id
             else:
@@ -545,7 +545,7 @@ class StencilInspector (ast.NodeVisitor):
                 st.scope.add_constant (lvalue, None)
                 logging.debug ("Constant '%s' will be resolved later" % lvalue)
 
-    
+
     def visit_Expr (self, node):
         """
         Looks for named stages within a stencil
@@ -589,7 +589,7 @@ class StencilInspector (ast.NodeVisitor):
                                 stage.scope.add_alias (kw.arg,
                                                        kw.value.id)
                             else:
-                                raise TypeError ("Unknown type '%s' of keyword argument '%s'" 
+                                raise TypeError ("Unknown type '%s' of keyword argument '%s'"
                                                  % (kw.value.__class__, kw.arg))
 
 
@@ -607,7 +607,7 @@ class StencilInspector (ast.NodeVisitor):
         st    = self.inspected_stencil
         call  = node.iter
         stage = None
-        if (call.func.value.id == 'self' and 
+        if (call.func.value.id == 'self' and
             call.func.attr == 'get_interior_points'):
             if name_suffix is None:
                 stage = st.scope.add_stage (node,
@@ -636,7 +636,7 @@ class StencilInspector (ast.NodeVisitor):
         :return:
         """
         #
-        # the stencil constructor is the recommended place to define 
+        # the stencil constructor is the recommended place to define
         # (pre-calculated) constants and temporary data fields
         #
         if node.name == '__init__':
@@ -651,11 +651,11 @@ class StencilInspector (ast.NodeVisitor):
                     # Allow for the docstring to appear before the call to the parent constructor
                     if n.value.s.lstrip() != docstring:
                         pcix = pcix + 1
-                       
+
                 else:
                     pcix = pcix + 1
                 try:
-                    parent_call = (isinstance (n.value, ast.Call) and 
+                    parent_call = (isinstance (n.value, ast.Call) and
                                    isinstance (n.value.func.value, ast.Call) and
                                    n.value.func.attr == '__init__')
                     if parent_call:
@@ -700,4 +700,3 @@ class StencilInspector (ast.NodeVisitor):
         #
         else:
             self.functor_defs.append (node)
-

--- a/python/gridtools/stage.py
+++ b/python/gridtools/stage.py
@@ -10,7 +10,7 @@ from gridtools.symbol import Scope, SymbolInspector
 
 
 
-class FunctorBody (ast.NodeVisitor):
+class StageBody (ast.NodeVisitor):
     """
     Represents the Do( ) function of a stencil's functor in AST form.-
     """
@@ -32,7 +32,7 @@ class FunctorBody (ast.NodeVisitor):
             if len (nodes) > 0:
                 self.nodes = nodes
         except TypeError:
-            raise TypeError ("FunctorBody expects a list of AST nodes.")
+            raise TypeError ("StageBody expects a list of AST nodes.")
 
 
     def _analyze_assignment (self, lval_node, rval_node):
@@ -42,10 +42,10 @@ class FunctorBody (ast.NodeVisitor):
         :param rval_node: AST node of the expression appearing as RValue
         :return:
         """
-        lvalues = FunctorBody.symbol_inspector.search (lval_node, 
-                                                       self.scope)
-        rvalues = FunctorBody.symbol_inspector.search (rval_node, 
-                                                       self.scope)
+        lvalues = StageBody.symbol_inspector.search (lval_node, 
+                                                     self.scope)
+        rvalues = StageBody.symbol_inspector.search (rval_node, 
+                                                     self.scope)
         for lsymbol in lvalues:
             #
             # lvalues (and their aliases) are read/write
@@ -441,9 +441,9 @@ class FunctorBody (ast.NodeVisitor):
 
 
 
-class FunctorScope (Scope):
+class StageScope (Scope):
     """
-    Functor symbols are organized into scopes that represent code visibility
+    Stage symbols are organized into scopes that represent code visibility
     blocks.-
     """
     def get_ghost_cell (self):
@@ -460,7 +460,7 @@ class FunctorScope (Scope):
 
 
 
-class Functor ( ):
+class Stage ( ):
     """
     Represents a stage inside a stencil.-
     """
@@ -475,7 +475,7 @@ class Functor ( ):
         :return:
         """
         self.name          = name
-        self.scope         = FunctorScope ( )
+        self.scope         = StageScope ( )
         self.stencil_scope = stencil_scope
         #
         # the ghost-cell access pattern of this stage
@@ -491,13 +491,13 @@ class Functor ( ):
         if isinstance (node, ast.For):
             self.node = node 
         else:
-            raise TypeError ("Functor's root AST node should be 'ast.For'")
+            raise TypeError ("Stage's root AST node should be 'ast.For'")
         #
         # the body of this functor
         #
-        self.body = FunctorBody (self.node.body,
-                                 self.scope,
-                                 self.stencil_scope)
+        self.body = StageBody (self.node.body,
+                               self.scope,
+                               self.stencil_scope)
 
 
     def __hash__ (self):

--- a/python/gridtools/stencil.py
+++ b/python/gridtools/stencil.py
@@ -5,7 +5,7 @@ import numpy as np
 import networkx as nx
 
 from gridtools.symbol   import StencilScope
-from gridtools.functor  import Functor
+from gridtools.stage  import Stage
 from gridtools.compiler import StencilCompiler
 
 

--- a/python/gridtools/symbol.py
+++ b/python/gridtools/symbol.py
@@ -482,14 +482,14 @@ class StencilScope (Scope):
         :param suffix: suffix to add to the stage's name
         :return:       the corresponding Stage object
         """
-        from gridtools.functor import Functor
+        from gridtools.stage import Stage
 
         stage_name = '%s_%s_%03d' % (prefix,
                                      suffix,
                                      len (self.stage_execution))
-        stage_obj  = Functor (stage_name,
-                              node,
-                              self)
+        stage_obj  = Stage (stage_name,
+                            node,
+                            self)
         if stage_obj not in self.stage_execution:
             #
             # update the stage execution path

--- a/python/python_run_tests.sh
+++ b/python/python_run_tests.sh
@@ -25,7 +25,7 @@ if [ -n "${CMAKE_SOURCE_DIR}" ] && [ -n "${PYTHON_INSTALL_PREFIX}" ]; then
         echo "Error while activating virtualenv. EXIT NOW"
         exit  1
       fi
-    fi 
+    fi
 fi
 
 echo "Running Python tests ..."


### PR DESCRIPTION
Similarly, all "Functor*" classes where renamed accordingly, in order
for the interface to be more intuitive. Following this rule,
`functor.py' was renamed to`stage.py' as well.

Also removed some trailing spaces.
