### PR TITLE
Extend computation interface with getter for performance meters

### DIFF
--- a/include/stencil-composition/backend_host/timer_host.hpp
+++ b/include/stencil-composition/backend_host/timer_host.hpp
@@ -23,7 +23,11 @@ namespace gridtools {
         /**
         * Start the stop watch
         */
-        void start_impl() { startTime_ = omp_get_wtime(); }
+        void start_impl() { 
+#if defined(_OPENMP)            
+            startTime_ = omp_get_wtime();
+#endif            
+        }
 
         /**
         * Pause the stop watch

--- a/include/stencil-composition/computation.hpp
+++ b/include/stencil-composition/computation.hpp
@@ -8,6 +8,7 @@ namespace gridtools {
         virtual void finalize() = 0;
         virtual ReductionType run() = 0;
         virtual std::string print_meter() = 0;
+        virtual double get_meter() = 0;
     };
 
 } // namespace gridtools

--- a/include/stencil-composition/intermediate.hpp
+++ b/include/stencil-composition/intermediate.hpp
@@ -677,6 +677,8 @@ namespace gridtools {
         }
 
         virtual std::string print_meter() { return m_meter.to_string(); }
+        
+        virtual double get_meter() { return m_meter.total_time(); }
 
         mss_local_domain_list_t const &mss_local_domain_list() const { return m_mss_local_domain_list; }
     };


### PR DESCRIPTION
As discussed with @cosunae it would be convenient for the Dycore to have a query method for the total time of the performance meters.
