### PR TITLE
Fix issue #354

### DIFF
--- a/include/common/defs.hpp
+++ b/include/common/defs.hpp
@@ -49,6 +49,14 @@
 #define DEPRECATED(func) func
 #endif
 
+#ifdef __GNUC__
+#define GT_FORCE_INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define GT_FORCE_INLINE inline __forceinline
+#else
+#define GT_FORCE_INLINE inline
+#endif
+
 /** Macro to enable additional checks that may catch some errors in user code
  */
 #ifndef PEDANTIC_DISABLED

--- a/include/common/host_device.hpp
+++ b/include/common/host_device.hpp
@@ -13,7 +13,7 @@
 #ifdef __CUDACC__
 #define GT_FUNCTION __host__ __device__ __forceinline__
 #else
-#define GT_FUNCTION inline
+#define GT_FUNCTION GT_FORCE_INLINE
 #endif
 
 #define GT_FUNCTION_WARNING __host__ __device__


### PR DESCRIPTION
It appears gcc 4.9 does not inline the stencil functions resulting in huge performance penalties. Forcing the inlining of the stencil functions will fix the performance degradation for the dycore stencils (#354). 

| Stencil | gcc 4.9 (no inlining) | gcc 4.9 (inlining) | gcc 5.3 |
| --- | --: | --: | --: |
| HD2Stencil | 0.022 s | 0.0056 s (3.9x) | 0.0028 s (7.9x) |
| HDSmagorinsky | 0.035  s | 0.011 s (3.2x) | 0.007 s (5.0x) |

Auto-vectorization seems to be still broken in gcc 4.9.
