### PR TITLE
allocate temporaries with vertical levels from 0 til top

### DIFF
--- a/include/stencil-composition/heap_allocated_temps.hpp
+++ b/include/stencil-composition/heap_allocated_temps.hpp
@@ -95,7 +95,7 @@ namespace gridtools {
                     instantiate_tmps(metadata_,
                                             grid.direction_i().total_length(),
                                             grid.direction_j().total_length(),
-                                            grid.value_at_top() - grid.value_at_bottom() + 1));
+                                            grid.value_at_top() + 1));
             }
         };
 
@@ -173,7 +173,7 @@ namespace gridtools {
                     instantiate_tmps(metadata_,
                                             grid.i_low_bound(),
                                             grid.j_low_bound(),
-                                            grid.value_at_top() - grid.value_at_bottom() + 1,
+                                            grid.value_at_top() + 1,
                                             backend_type::n_i_pes()(grid.i_high_bound() - grid.i_low_bound()),
                                             backend_type::n_j_pes()(grid.j_high_bound() - grid.j_low_bound())));
             }


### PR DESCRIPTION
This is a quick fix for a bug reported by Fabian. 

For solving a tridiagonal solve on a w field which is staggered in the vertical, he uses a different grid definition (in the vertical) to emulate the staggering. In his case:

```
        grid_.value_list[0] = 1; // instead of 0
        grid_.value_list[1] = d3 - 1;
```

The heap_allocated_temps will allocate temporaries with sizes of d3-1, but anyhow our iteration space will start iterating at 1, and will position all indexes of all storages (and temporaries) at vertical level 1. 
The fix allocates temporaries with size d3, no matter if the iteration space does never access it. 

Is it ok? any comments?
