### PR TITLE
improve error msg about temporaries

### DIFF
--- a/include/stencil-composition/intermediate.hpp
+++ b/include/stencil-composition/intermediate.hpp
@@ -175,7 +175,7 @@ namespace gridtools {
                     "Could not find a temporary, defined in the user aggregator_type, in the list of storage types "
                     "used in "
                     "all mss/esfs. \n"
-                    " Check that all temporaries are actually used in at least one user functor");
+                    " Check that all temporaries are actually used in at least one user functor as inout_accessor");
 
                 typedef typename boost::mpl::deref< iter >::type::first type;
             };


### PR DESCRIPTION
Emphasize that all temporaries have to be used at least once as
**inout_accessors**.

It is a trivial edit but this inaccuracy cost me some time:
When I implement a new stencil I first setup all the arguments and temporaries. Then I implement the first stage and try to compile. I ensured that all the temporaries were used to prevent triggering the error but couldn't figure out why I had still problems. I finally found that the temporaries have to be used as inout_accessor (which completely makes sense...).
