### PR TITLE
GC-21 fix pre-commit hook to stage changes after patch

### DIFF
--- a/tools/git_hooks/pre-commit
+++ b/tools/git_hooks/pre-commit
@@ -149,7 +149,7 @@ printf "\nThe following differences were found between the code to commit "
 printf "and the clang-format rules:\n\n"
 cat "$patch"
 
-printf "\nYou can apply these changes with:\n git apply $patch\n"
+printf "\nYou can apply these changes with:\n git apply --index $patch\n"
 printf "(may need to be called from the root directory of your repository)\n"
 printf "Aborting commit. Apply changes and commit again or skip checking with"
 printf " --no-verify (not recommended).\n"


### PR DESCRIPTION
Bug description: The git pre-commit hook does not stage the fixed files when applying the patch.

Solution: Add the "--index" flag which will apply the patch to the working tree and the index.
