### PR TITLE
fix timer_dummy

### DIFF
--- a/include/stencil-composition/timer_dummy.hpp
+++ b/include/stencil-composition/timer_dummy.hpp
@@ -52,7 +52,7 @@ namespace gridtools {
         /**
         * Reset counters
         */
-        __host__ void reset_impl(double const & /*time_*/) {}
+        __host__ void set_impl(double const & /*time_*/) {}
 
         /**
         * Start the stop watch


### PR DESCRIPTION
Bug description: A method in timer_dummy has the wrong name (problem shows only if meters are disabled; it is default but not tested in jenkins).

Solution: Rename reset_impl to set_impl.