### PR TITLE
Run githook also in .cu files

### DIFF
--- a/tools/git_hooks/pre-commit
+++ b/tools/git_hooks/pre-commit
@@ -33,7 +33,7 @@ PARSE_EXTS=true
 
 # file types to parse. Only effective when PARSE_EXTS is true.
 # FILE_EXTS=".c .h .cpp .hpp"
-FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m"
+FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .cu .m"
 
 CHEVRON_FIXER="`pwd -P`/tools/chevron_fixer/chevron_fixer_file.sh"
 


### PR DESCRIPTION
Bug description: the git hook was not processing .cu files and we have some code in .cu in unittests. 