### PR TITLE
remove stencil-composition dependency from common

### DIFF
--- a/include/common/dimension.hpp
+++ b/include/common/dimension.hpp
@@ -34,7 +34,7 @@
   For information: http://eth-cscs.github.io/gridtools/
 */
 #pragma once
-#include "common/host_device.hpp"
+#include "host_device.hpp"
 
 namespace gridtools {
     /**

--- a/include/common/layout_map_cxx03.hpp
+++ b/include/common/layout_map_cxx03.hpp
@@ -44,7 +44,6 @@ For information: http://eth-cscs.github.io/gridtools/
 #include "../common/host_device.hpp"
 #include "../common/defs.hpp"
 #include "../common/array.hpp"
-#include "stencil-composition/accessor_fwd.hpp"
 
 /**
    @file

--- a/include/common/offset_tuple.hpp
+++ b/include/common/offset_tuple.hpp
@@ -38,7 +38,7 @@
 #include <boost/mpl/fold.hpp>
 #include <boost/mpl/find.hpp>
 #include "defs.hpp"
-#include "../stencil-composition/dimension.hpp"
+#include "dimension.hpp"
 #include "generic_metafunctions/logical_ops.hpp"
 #include "generic_metafunctions/variadic_to_vector.hpp"
 #include "generic_metafunctions/accumulate.hpp"

--- a/include/stencil-composition/structured_grids/accessor.hpp
+++ b/include/stencil-composition/structured_grids/accessor.hpp
@@ -37,7 +37,7 @@
 #pragma once
 #include "../accessor_base.hpp"
 #include "../arg.hpp"
-#include "../dimension.hpp"
+#include "../../common/dimension.hpp"
 #include "../../common/generic_metafunctions/all_integrals.hpp"
 #include "../../common/generic_metafunctions/static_if.hpp"
 

--- a/include/stencil-composition/structured_grids/accessor_cxx11.hpp
+++ b/include/stencil-composition/structured_grids/accessor_cxx11.hpp
@@ -37,7 +37,7 @@
 #pragma once
 #include "../accessor_base.hpp"
 #include "../arg.hpp"
-#include "../dimension.hpp"
+#include "../../common/dimension.hpp"
 #include "../../common/generic_metafunctions/all_integrals.hpp"
 #include "../../common/generic_metafunctions/static_if.hpp"
 


### PR DESCRIPTION
 Bug description: We had few dependencies from common to stencil-composition, which should not happen to respect the modularity and avoid circular dependencies between modules. 
I moved the dimension into common. 