### PR TITLE
Add CUDA error checking in debug mode after kernel calls

### DIFF
--- a/include/common/gpu_clone.hpp
+++ b/include/common/gpu_clone.hpp
@@ -103,10 +103,17 @@ namespace gridtools {
                 reinterpret_cast< const mask_object< const DerivedType > * >(
                     (static_cast< const DerivedType * >(this)));
 
-            // clang-format off
-            construct<<<1,1>>>(*maskT);
-            // clang-format on
-            cudaDeviceSynchronize();
+            construct<<< 1, 1 >>>(*maskT);
+
+            cudaDeviceSynchronize(); // if you want to remove this, then move it in the #ifndef NDEBUG
+
+#ifndef NDEBUG
+            cudaError_t error = cudaGetLastError();
+            if (error != cudaSuccess) {
+                fprintf(stderr, "CUDA ERROR: %s in %s at line %d\n", cudaGetErrorString(error), __FILE__, __LINE__);
+                exit(-1);
+            }
+#endif
         }
 
         /** Member function to update the object from the gpu calling the copy constructor of the

--- a/include/stencil-composition/icosahedral_grids/backend_cuda/execute_kernel_functor_cuda.hpp
+++ b/include/stencil-composition/icosahedral_grids/backend_cuda/execute_kernel_functor_cuda.hpp
@@ -354,6 +354,15 @@ namespace gridtools {
                     local_domain_t ><<< blocks, threads >>> //<<<nbx*nby, ntx*nty>>>
                     (local_domain_gp, grid_gp, m_grid.i_low_bound(), m_grid.j_low_bound(), (nx), (ny));
 
+#ifndef NDEBUG
+                cudaDeviceSynchronize();
+                cudaError_t error = cudaGetLastError();
+                if (error != cudaSuccess) {
+                    fprintf(stderr, "CUDA ERROR: %s in %s at line %d\n", cudaGetErrorString(error), __FILE__, __LINE__);
+                    exit(-1);
+                }
+#endif
+
                 // TODOCOSUNA we do not need this. It will block the host, and we want to continue doing other stuff
                 cudaDeviceSynchronize();
             }

--- a/include/stencil-composition/structured_grids/backend_cuda/execute_kernel_functor_cuda.hpp
+++ b/include/stencil-composition/structured_grids/backend_cuda/execute_kernel_functor_cuda.hpp
@@ -322,6 +322,14 @@ namespace gridtools {
                     local_domain_t ><<< blocks, threads >>> //<<<nbx*nby, ntx*nty>>>
                     (local_domain_gp, grid_gp, m_grid.i_low_bound(), m_grid.j_low_bound(), (nx), (ny));
 
+#ifndef NDEBUG
+                cudaDeviceSynchronize();
+                cudaError_t error = cudaGetLastError();
+                if (error != cudaSuccess) {
+                    fprintf(stderr, "CUDA ERROR: %s in %s at line %d\n", cudaGetErrorString(error), __FILE__, __LINE__);
+                    exit(-1);
+                }
+#endif
                 // TODOCOSUNA we do not need this. It will block the host, and we want to continue doing other stuff
                 cudaDeviceSynchronize();
             }


### PR DESCRIPTION
Bug description: CUDA errors are not checked after kernel calls. This needs a cudaDeviceSynchronize() in debug mode.

Details: Actually the cudaDeviceSynchronize() are already there and should be removed, see comment in code. Fixes #533.