### PR TITLE
Remove cmake files from ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,6 @@
 
 *.exe
 
-CMakeFiles/
-CTestTestfile.cmake
-Makefile
-cmake_install.cmake
-
 include/workarounds/
 
 # ignore everything in the root folder


### PR DESCRIPTION
Bug description: If we ignore all cmake files (which are produced by an in-source cmake run) we cannot do a "git clean".