### PR TITLE
add script to protect modularization

### DIFF
--- a/tools/check_modularization/check_modularization.sh
+++ b/tools/check_modularization/check_modularization.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# no_dependency "<of_module>" "<on_module>"
+# checks that <of_module> does not depend on <on_module>
+# i.e. <of_module> does not include any file from <on_module>
+function no_dependency() {
+    last_result=`grep -r "#include .*$2/.*hpp" include/$1 | wc -l`
+    if [ "$last_result" -gt 0 ]; then
+        echo "ERROR Modularization violated: found dependency of $1 on $2"
+        echo "`grep -r "#include .*$2/.*hpp" include/$1`"
+    fi
+    modularization_result=$(( modularization_result || last_result ))
+}
+
+function are_independent() {
+    no_dependency "$1" "$2"
+    no_dependency "$2" "$1"
+}
+modularization_result=0
+
+# list of non-dependencies
+no_dependency "common" "stencil-composition"
+no_dependency "common" "boundary-conditions"
+no_dependency "common" "communication"
+no_dependency "common" "storage"
+no_dependency "common" "tools"
+
+are_independent "stencil-composition" "boundary-conditions"
+are_independent "stencil-composition" "communication"
+are_independent "stencil-composition" "tools"
+
+are_independent "boundary-conditions" "communication" #maybe they can have a dependency later?
+are_independent "boundary-conditions" "storage"
+are_independent "boundary-conditions" "tools"
+
+are_independent "communication" "tools"
+no_dependency "communication" "storage"
+#are_independent "communication" "storage" #TODO: violated by partitioner
+
+no_dependency "storage" "stencil-composition"
+no_dependency "storage" "boundary-conditions"
+no_dependency "storage" "tools"
+
+# we cannot use an exit code here because the git hook will terminate immediately
+

--- a/tools/git_hooks/pre-commit
+++ b/tools/git_hooks/pre-commit
@@ -139,21 +139,36 @@ do
         sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
 done
 
+error_code=0
 # if no patch has been generated all is ok, clean up the file stub and exit
 if [ ! -s "$patch" ] ; then
     printf "Files in this commit comply with the clang-format rules.\n"
     rm -f "$patch"
-    exit 0
+else
+# a patch has been created, notify the user and exit
+    printf "\nThe following differences were found between the code to commit "
+    printf "and the clang-format rules:\n\n"
+    cat "$patch"
+
+    printf "\nYou can apply these changes with:\n git apply --index $patch\n"
+    printf "(may need to be called from the root directory of your repository)\n"
+
+    error_code=$((error_code || 1 ))
 fi
 
-# a patch has been created, notify the user and exit
-printf "\nThe following differences were found between the code to commit "
-printf "and the clang-format rules:\n\n"
-cat "$patch"
+# call the modularization checker (check will be applied on all files even if not included in commit)
+echo
+source $(pwd)/tools/check_modularization/check_modularization.sh
+if [ $modularization_result -eq 0 ]; then 
+    printf "Modularization check passed!\n"
+fi
 
-printf "\nYou can apply these changes with:\n git apply --index $patch\n"
-printf "(may need to be called from the root directory of your repository)\n"
-printf "Aborting commit. Apply changes and commit again or skip checking with"
-printf " --no-verify (not recommended).\n"
+# exit if errors
+error_code=$((error_code || modularization_result ))
+if [ "$error_code" -gt 0 ]; then
+    printf "\nAborting commit. Apply changes and commit again or skip checking with"
+    printf " --no-verify (not recommended).\n"
+fi
 
-exit 1
+exit $error_code
+


### PR DESCRIPTION
Feature description: Extends the pre-commit hook to check if modularization is violated.

Details: The script greps for `#include *<module1>/*` in files of `include/<module2>`.