### PR TITLE
Serialbox2 compilation fix

### DIFF
--- a/include/storage/halo.hpp
+++ b/include/storage/halo.hpp
@@ -49,6 +49,9 @@ namespace gridtools {
     template < uint_t... Pad >
     struct halo {
         static const uint_t size = sizeof...(Pad);
+        static const array< uint_t, sizeof...(Pad) > m_pad;
+
+        GT_FUNCTION static constexpr uint_t get(const uint_t coordinate) { return m_pad[coordinate]; }
 
         template < ushort_t Coordinate >
         GT_FUNCTION static constexpr uint_t get() {
@@ -80,6 +83,11 @@ namespace gridtools {
                 return Pad3;
         }
     };
+#endif
+
+#ifdef CXX11_ENABLED
+    template < uint_t... Pad >
+    const array< uint_t, sizeof...(Pad) > halo< Pad... >::m_pad = {Pad...};
 #endif
 
     template < typename T >

--- a/include/storage/meta_storage_base.hpp
+++ b/include/storage/meta_storage_base.hpp
@@ -127,7 +127,6 @@ namespace gridtools {
         static const ushort_t space_dimensions = layout::length;
         typedef meta_storage_base< Index, Layout, IsTemporary > basic_type;
 
-      protected:
         array< uint_t, space_dimensions > m_dims;
         // control your instincts: changing the following
         // int_t to uint_t will prevent GCC from vectorizing (compiler bug)


### PR DESCRIPTION
These are the minimal changes to allow serialbox2 to compile with gridtools (https://github.com/eth-cscs/serialbox2/issues/11)