### PR TITLE
Increase timelimit on kesch

### DIFF
--- a/jenkins/submit.kesch.slurm
+++ b/jenkins/submit.kesch.slurm
@@ -5,7 +5,7 @@
 #SBATCH --ntasks-per-node=<MPI_PPN>
 #SBATCH --output=<OUTPUTFILE>
 #SBATCH --partition=<QUEUE>
-#SBATCH --time=00:10:00
+#SBATCH --time=00:15:00
 #SBATCH --gres=gpu:<MPI_TASKS>
 #SBATCH --cpus-per-task=<CPUSPERTASK>
 


### PR DESCRIPTION
Description: The timelimit of 10:00 was not enough to complete all performance tests, therefore we increase the timelimit to 15:00.