### PR TITLE
Fix compilation on llvm

### DIFF
--- a/unit_tests/common/generic_metafunctions/test_cxx11_integer_sequence.cpp
+++ b/unit_tests/common/generic_metafunctions/test_cxx11_integer_sequence.cpp
@@ -46,7 +46,7 @@ struct get_component {
 
     template < typename... Ints >
     GT_FUNCTION constexpr static int apply(int first, Ints... rest) {
-        return Idx ? get_component<Idx - 1>::apply(rest...) : first;
+        return Idx ? get_component< Idx - 1 >::apply(rest...) : first;
     }
 };
 


### PR DESCRIPTION
Fixes the issue #682 by getting rid of std::get and std::make_tuple that are not have to be declared as constexpr in C++11 spec.
Additionally redundant empty construct of the struct that is never instantiated by design is removed. 