### PR TITLE
Add a virtual dtor to 'comutation' because it is an abstract struct 

### DIFF
--- a/include/stencil-composition/computation.hpp
+++ b/include/stencil-composition/computation.hpp
@@ -39,7 +39,7 @@
 namespace gridtools {
     template < typename ReductionType = int >
     struct computation {
-        virtual computation() {}
+        virtual ~computation() {}
         virtual void ready() = 0;
         virtual void steady() = 0;
         virtual void finalize() = 0;


### PR DESCRIPTION
Additionally <string> include is added to make the header self consistent.