### PR TITLE
Fix use of expression templates in function calls

### DIFF
--- a/include/stencil-composition/stencil-functions/call_interfaces.hpp
+++ b/include/stencil-composition/stencil-functions/call_interfaces.hpp
@@ -54,12 +54,12 @@ namespace gridtools {
         /** In the context of stencil_functions, this type represents
            the aggregator/domain/evaluator to be passed to a stencil
            function, called within a stencil operator or another
-           stencil function. In this version the accessors passed to
-           the function can have offsets different that 0.
+           stencil function. The accessors passed to
+           the function can have offsets.
 
            function_aggregator_offsets has a single ReturnType which
            corresponds to the output field of the called
-           stencil_operator. Such operator hasa single output field,
+           stencil_operator. Such operator has a single output field,
            as checked by the call template.
 
            \tparam CallerAggregator The argument passed to the callerd, also known as the Evaluator
@@ -130,6 +130,12 @@ namespace gridtools {
                 typename boost::enable_if_c< (Accessor::index_t::value == OutArg), ReturnType >::type &
                 operator()(Accessor const &) const {
                 return *m_result;
+            }
+
+            template < typename... Arguments, template < typename... Args > class Expression >
+            GT_FUNCTION constexpr auto operator()(Expression< Arguments... > const &arg) const
+                -> decltype(expressions::evaluation::value(*this, arg)) {
+                return expressions::evaluation::value((*this), arg);
             }
         };
 
@@ -227,8 +233,8 @@ namespace gridtools {
            In the context of stencil_functions, this type represents
            the aggregator/domain/evaluator to be passed to a stencil
            function, called within a stencil operator or another
-           stencil function. In this version the accessors passed to
-           the function can have offsets different that 0.
+           stencil function. The accessors passed to
+           the function can have offsets.
 
            function_aggregator_procedure_offsets does not have a
            single return value, as in
@@ -300,6 +306,12 @@ namespace gridtools {
                     Accessor::index_t::value >::type >::type::type >::type &
             operator()(Accessor const &) const {
                 return (boost::fusion::at_c< Accessor::index_t::value >(m_accessors_list).value());
+            }
+
+            template < typename... Arguments, template < typename... Args > class Expression >
+            GT_FUNCTION constexpr auto operator()(Expression< Arguments... > const &arg) const
+                -> decltype(expressions::evaluation::value(*this, arg)) {
+                return expressions::evaluation::value((*this), arg);
             }
         };
     } // namespace _impl

--- a/unit_tests/stencil-composition/structured_grids/test_cxx11_call_interfaces.cpp
+++ b/unit_tests/stencil-composition/structured_grids/test_cxx11_call_interfaces.cpp
@@ -68,6 +68,26 @@ namespace call_interface_functors {
         }
     };
 
+    struct copy_functor_with_expression {
+        typedef in_accessor< 0, extent<>, 3 > in;
+        typedef inout_accessor< 1, extent<>, 3 > out;
+        typedef boost::mpl::vector< in, out > arg_list;
+        template < typename Evaluation >
+        GT_FUNCTION static void Do(Evaluation &eval, x_interval) {
+            eval(out()) = eval(in() + 0.);
+        }
+    };
+
+    struct call_copy_functor_with_expression {
+        typedef in_accessor< 0, extent<>, 3 > in;
+        typedef inout_accessor< 1, extent<>, 3 > out;
+        typedef boost::mpl::vector< in, out > arg_list;
+        template < typename Evaluation >
+        GT_FUNCTION static void Do(Evaluation &eval, x_interval) {
+            eval(out()) = call< copy_functor_with_expression, x_interval >::with(eval, in());
+        }
+    };
+
     struct call_at_copy_functor {
         typedef in_accessor< 0, extent<>, 3 > in;
         typedef inout_accessor< 1, extent<>, 3 > out;
@@ -300,6 +320,18 @@ TEST_F(call_interface, call_to_copy_functor) {
         grid,
         gridtools::make_multistage(execute< forward >(),
             gridtools::make_stage< call_interface_functors::call_copy_functor >(p_in(), p_out())));
+
+    execute_computation(comp);
+
+    ASSERT_TRUE(verifier_.verify(grid, reference_unchanged, out, verifier_halos));
+}
+
+TEST_F(call_interface, call_to_copy_functor_with_expression) {
+    auto comp = gridtools::make_computation< gridtools::BACKEND >(
+        domain,
+        grid,
+        gridtools::make_multistage(execute< forward >(),
+            gridtools::make_stage< call_interface_functors::call_copy_functor_with_expression >(p_in(), p_out())));
 
     execute_computation(comp);
 
@@ -559,6 +591,26 @@ namespace call_proc_interface_functors {
         }
     };
 
+    struct copy_functor_with_expression {
+        typedef in_accessor< 0, extent<>, 3 > in;
+        typedef inout_accessor< 1, extent<>, 3 > out;
+        typedef boost::mpl::vector< in, out > arg_list;
+        template < typename Evaluation >
+        GT_FUNCTION static void Do(Evaluation &eval, x_interval) {
+            eval(out()) = eval(in() + 0.);
+        }
+    };
+
+    struct call_copy_functor_with_expression {
+        typedef in_accessor< 0, extent<>, 3 > in;
+        typedef inout_accessor< 1, extent<>, 3 > out;
+        typedef boost::mpl::vector< in, out > arg_list;
+        template < typename Evaluation >
+        GT_FUNCTION static void Do(Evaluation &eval, x_interval) {
+            call_proc< copy_functor_with_expression, x_interval >::with(eval, in(), out());
+        }
+    };
+
     struct copy_twice_functor {
         typedef in_accessor< 0, extent<>, 3 > in;
         typedef inout_accessor< 1, extent<>, 3 > out1;
@@ -685,6 +737,19 @@ namespace call_proc_interface_functors {
             }
         }
     };
+}
+
+TEST_F(call_proc_interface, call_to_copy_functor_with_expression) {
+    auto comp = gridtools::make_computation< gridtools::BACKEND >(
+        domain,
+        grid,
+        gridtools::make_multistage(execute< forward >(),
+            gridtools::make_stage< call_proc_interface_functors::call_copy_functor_with_expression >(
+                                       p_in(), p_out1())));
+
+    execute_computation(comp);
+
+    ASSERT_TRUE(verifier_.verify(grid, reference_unchanged, out1, verifier_halos));
 }
 
 TEST_F(call_proc_interface, call_to_copy_twice_functor) {


### PR DESCRIPTION
Bug description: Expressions inside Do-methods which were called using stencil functions were broken. They were not implemented for all code-paths and got lost in #720.

Details: Add overload for expressions and add a unit test.