### PR TITLE
get rid of uint

### DIFF
--- a/include/stencil-composition/expandable_parameters/intermediate_expand.hpp
+++ b/include/stencil-composition/expandable_parameters/intermediate_expand.hpp
@@ -273,7 +273,7 @@ namespace gridtools {
         GRIDTOOLS_STATIC_ASSERT(
             (std::is_same< ReductionType, notype >::value), "Reduction is not allowed with expandable parameters");
 
-        template < uint N >
+        template < uint_t N >
         using converted_intermediate = intermediate< Backend,
             MssDescriptorArray,
             _impl::expand_detail::converted_aggregator_type< N, Aggregator >,

--- a/include/storage/data_view.hpp
+++ b/include/storage/data_view.hpp
@@ -197,7 +197,7 @@ namespace gridtools {
          *
          * \tparam Dim The index of the dimension
          */
-        template < uint Dim >
+        template < uint_t Dim >
         GT_FUNCTION constexpr int length() const {
             return m_storage_info->template length< Dim >();
         }
@@ -207,7 +207,7 @@ namespace gridtools {
          *
          * \tparam Dim The index of the dimension
          */
-        template < uint Dim >
+        template < uint_t Dim >
         GT_FUNCTION constexpr int total_length() const {
             return m_storage_info->template total_length< Dim >();
         }
@@ -218,7 +218,7 @@ namespace gridtools {
          *
          * \tparam Dim The index of the dimension
          */
-        template < uint Dim >
+        template < uint_t Dim >
         GT_FUNCTION constexpr int total_begin() const {
             return m_storage_info->template total_begin< Dim >();
         }
@@ -228,7 +228,7 @@ namespace gridtools {
          *
          * \tparam Dim The index of the dimension
          */
-        template < uint Dim >
+        template < uint_t Dim >
         GT_FUNCTION constexpr int begin() const {
             return m_storage_info->template begin< Dim >();
         }
@@ -239,7 +239,7 @@ namespace gridtools {
          *
          * \tparam Dim The index of the dimension
          */
-        template < uint Dim >
+        template < uint_t Dim >
         GT_FUNCTION constexpr int total_end() const {
             return m_storage_info->template total_end< Dim >();
         }
@@ -249,7 +249,7 @@ namespace gridtools {
          *
          * \tparam Dim The index of the dimension
          */
-        template < uint Dim >
+        template < uint_t Dim >
         GT_FUNCTION constexpr int end() const {
             return m_storage_info->template end< Dim >();
         }


### PR DESCRIPTION
Get rid of usage non-standard `uint` alias  