### PR TITLE
Remove GTASSERT macro (GC-339)

### DIFF
--- a/include/common/gt_assert.hpp
+++ b/include/common/gt_assert.hpp
@@ -34,12 +34,7 @@
   For information: http://eth-cscs.github.io/gridtools/
 */
 #pragma once
-#include "host_device.hpp"
 #include <stdexcept>
-
-#ifndef NDEBUG
-#include <stdio.h>
-#endif
 
 #ifdef __CUDACC__
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 200)
@@ -51,32 +46,6 @@
 #endif
 #else
 #include <cassert>
-#endif
-
-#ifdef __GNUC__
-
-#define GTASSERT(cond) gt_assert(cond, __LINE__, __FILE__)
-
-namespace gridtools {
-    GT_FUNCTION
-    void gt_assert(bool cond, int line, const char *filename) {
-#ifndef NDEBUG
-        if (!cond)
-            printf("Assert triggered in %s:%d \n", filename, line);
-#endif
-        assert(cond);
-    }
-}
-
-#else
-
-#define GTASSERT(cond) gt_assert(cond)
-
-namespace gridtools {
-    GT_FUNCTION
-    void gt_assert(bool cond) { assert(cond); }
-}
-
 #endif
 
 #ifdef __CUDA_ARCH__

--- a/include/stencil-composition/icosahedral_grids/iterate_domain.hpp
+++ b/include/stencil-composition/icosahedral_grids/iterate_domain.hpp
@@ -432,7 +432,7 @@ namespace gridtools {
                 compute_offset< storage_info_t >(strides().template get< storage_info_index_t::value >(), accessor);
 
 #ifndef NDEBUG
-            GTASSERT((pointer_oob_check< backend_traits_t,
+            assert((pointer_oob_check< backend_traits_t,
                 processing_elements_block_size_t,
                 local_domain_t,
                 arg_t,
@@ -470,7 +470,7 @@ namespace gridtools {
             const storage_info_t *storage_info =
                 boost::fusion::at< storage_info_index_t >(m_local_domain.m_local_storage_info_ptrs);
 
-            GTASSERT((pointer_oob_check< backend_traits_t,
+            assert((pointer_oob_check< backend_traits_t,
                 processing_elements_block_size_t,
                 local_domain_t,
                 arg_t,

--- a/include/stencil-composition/structured_grids/iterate_domain_cxx11.hpp
+++ b/include/stencil-composition/structured_grids/iterate_domain_cxx11.hpp
@@ -585,7 +585,7 @@ namespace gridtools {
             compute_offset< storage_info_t >(strides().template get< storage_info_index_t::value >(), accessor);
 
 #ifndef NDEBUG
-        GTASSERT((pointer_oob_check< backend_traits_t,
+        assert((pointer_oob_check< backend_traits_t,
             processing_elements_block_size_t,
             local_domain_t,
             arg_t,


### PR DESCRIPTION
Removes the malfunctioning and rarely used GTASSERT macro and replaces occurrences by normal asserts.