### PR TITLE
Allow to use for_each on device (GC-352)

### DIFF
--- a/include/common/generic_metafunctions/for_each.hpp
+++ b/include/common/generic_metafunctions/for_each.hpp
@@ -45,7 +45,7 @@ namespace gridtools {
         template < template < class... > class L, class... Ts >
         struct for_each_f< L< Ts... > > {
             template < class Fun >
-            GT_FUNCTION_WARNING void operator()(Fun const &fun) const {
+            GT_FUNCTION void operator()(Fun const &fun) const {
                 (void)(int[]){((void)fun(Ts{}), 0)...};
             }
         };
@@ -53,7 +53,7 @@ namespace gridtools {
 
     /// Calls fun(T{}) for each element of the type list List.
     template < class List, class Fun >
-    GT_FUNCTION_WARNING Fun for_each(Fun const &fun) {
+    GT_FUNCTION Fun for_each(Fun const &fun) {
         _impl::for_each_f< List >{}(fun);
         return fun;
     };


### PR DESCRIPTION
Changed for_each function attribute macro form GT_FUNCTION_WARNING to GT_FUNCTION.