### PR TITLE
Extend Axis Symmetrically and Allow Out-of-Domain Intervals in Negative Direction (GC-461)

### DIFF
--- a/include/gridtools/stencil-composition/axis.hpp
+++ b/include/gridtools/stencil-composition/axis.hpp
@@ -46,10 +46,11 @@ namespace gridtools {
      * Defines an axis_interval_t which is the former user-defined axis type and a full_interval which spans the whole
      * axis.
      * @param NIntervals Number of intervals the axis should support
-     * @param ExtraOffsetsBeyondFullInterval Special case when access of k-values beyond the full_interval (i.e. the
-     * last splitter value) are needed. (Note that the default interval will span the whole axis_interval_t.)
+     * @param ExtraOffsetsAroundFullInterval Special case when access of k-values around the full_interval (i.e. after
+     * the last or before the first splitter value) are needed. (Note that the default interval will span the whole
+     * axis_interval_t.)
      */
-    template < size_t NIntervals, int_t ExtraOffsetsBeyondFullInterval = 0 >
+    template < size_t NIntervals, int_t ExtraOffsetsAroundFullInterval = 0 >
     class axis {
       private:
         template < size_t... IntervalIDs >
@@ -65,7 +66,8 @@ namespace gridtools {
       public:
         static const uint_t max_offsets_ = cLevelOffsetLimit;
 
-        using axis_interval_t = interval< level< 0, 1 >, level< NIntervals, 1 + ExtraOffsetsBeyondFullInterval > >;
+        using axis_interval_t = interval< level< 0, _impl::add_offset(1, -ExtraOffsetsAroundFullInterval) >,
+            level< NIntervals, _impl::add_offset(1, ExtraOffsetsAroundFullInterval) > >;
 
         using full_interval = interval< level< 0, 1 >, level< NIntervals, -1 > >;
 

--- a/include/gridtools/stencil-composition/execution_policy.hpp
+++ b/include/gridtools/stencil-composition/execution_policy.hpp
@@ -87,8 +87,6 @@ namespace gridtools {
 
             template < typename IterationPolicy, typename Interval >
             GT_FUNCTION void k_loop(int_t from, int_t to) const {
-                assert(from >= 0);
-                assert(to >= 0);
                 assert(to >= from);
                 typedef typename run_esf_functor_h_t::template apply< RunFunctorArguments, Interval >::type
                     run_esf_functor_t;

--- a/include/gridtools/stencil-composition/functor_do_methods.hpp
+++ b/include/gridtools/stencil-composition/functor_do_methods.hpp
@@ -111,7 +111,7 @@ namespace gridtools {
         // make sure the second interval starts where the first ends
         // (check the index values are continuous and both indexes are associated to the same splitter)
         BOOST_STATIC_CONSTANT(bool,
-            value = ((DoMethod1ToIndex::value + 1 == DoMethod2FromIndex::value) &&
+            value = ((_impl::add_offset(DoMethod1ToIndex::value, 1) == DoMethod2FromIndex::value) &&
                      (index_to_level< DoMethod1ToIndex >::type::Splitter::value ==
                          index_to_level< DoMethod2FromIndex >::type::Splitter::value)));
         typedef boost::mpl::integral_c< bool, value > type;


### PR DESCRIPTION
The COSMO dycore uses intervals below axis::full_interval, this is enabled by replacing the existing template argument ExtraOffsetsBelowFullInterval by ExtraOffsetsAroundFullInterval and extending interval_t symmetrically.