### PR TITLE
Fix rest_tuple (inline)

### DIFF
--- a/include/gridtools/distributed-boundaries/bound_bc.hpp
+++ b/include/gridtools/distributed-boundaries/bound_bc.hpp
@@ -117,7 +117,7 @@ namespace gridtools {
                     typename std::tuple_element< IDs, AllTuple >::type /*>::type*/ >::value >::type{})...);
         }
 
-        std::tuple<> rest_tuple(std::tuple<>, gt_integer_sequence< std::size_t >) { return {}; }
+        inline std::tuple<> rest_tuple(std::tuple<>, gt_integer_sequence< std::size_t >) { return {}; }
 
         /** \internal
             Small facility to obtain a tuple with the elements of am input  tuple execpt the first.


### PR DESCRIPTION
Function rest_tuple must be inlined, otherwise we'll get a linker error (multiple definitions of gridtools::_impl::rest_tuple).