### PR TITLE
install bindings.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,8 @@ install(FILES "${PROJECT_BINARY_DIR}/cmake/GridToolsConfig.cmake"
   "${PROJECT_BINARY_DIR}/cmake/GridToolsConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_PREFIX}" COMPONENT dev)
 
+# TODO this needs to be cleaned up when cleaning up the CMakeLists (FindGridtools)
+# We need to define which files go where (e.g. bindings.cmake)
 install(DIRECTORY "include" DESTINATION "${CMAKE_INSTALL_PREFIX}" )
 install(TARGETS
         gcl
@@ -117,7 +119,11 @@ install(FILES
     "${PROJECT_BINARY_DIR}/mod/gt_handle.mod"
     "${PROJECT_BINARY_DIR}/mod/array_descriptor.mod"
     DESTINATION "${CMAKE_INSTALL_PREFIX}/include/gridtools")
+install(FILES
+    "${PROJECT_SOURCE_DIR}/cmake/bindings.cmake"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}")
 # Install the export set for use with the install-tree
+# TODO should this really be installed to PROJECT_BINARY_DIR (why not install?)
 install(EXPORT GridTools DESTINATION
     "${PROJECT_BINARY_DIR}/cmake" COMPONENT dev)
 message("compile definitions: ${COMPILE_DEFINITIONS}")


### PR DESCRIPTION
The bindings.cmake needs to be installed because this file can be included by other projects