### PR TITLE
CMake: Require MPI for C++ only

### DIFF
--- a/cmake/definitions.cmake
+++ b/cmake/definitions.cmake
@@ -166,6 +166,7 @@ endif()
 if( USE_MPI )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GCL_MPI_")
   find_package(MPI)
+  # only test for C++, Fortran MPI is not required
   if (NOT MPI_CXX_FOUND)
     message(FATAL_ERROR "Could not find MPI")
   endif()


### PR DESCRIPTION
This allows MPI compilation even if no Fortran MPI compiler could be found by CMake. This simplifies the usage of mixed compiler environments, e.g. using Intel compiler and MPI for the C++ part but gfortran for the Fortran part.