### PR TITLE
Fix ij caches

### DIFF
--- a/include/gridtools/stencil-composition/caches/cache_metafunctions.hpp
+++ b/include/gridtools/stencil-composition/caches/cache_metafunctions.hpp
@@ -114,7 +114,7 @@ namespace gridtools {
     template <cache_type cacheType>
     struct cache_is_type {
         template <typename Cache>
-        struct apply : static_bool<Cache::cacheType == cacheType> {
+        struct apply : boost::integral_constant<bool, Cache::cacheType == cacheType> {
             GRIDTOOLS_STATIC_ASSERT((is_cache<Cache>::value), GT_INTERNAL_ERROR);
         };
     };


### PR DESCRIPTION
Fixes #992 (regression of  0d55c27).

For some reason we need `boost::integral_constant` here.