### PR TITLE
Unset GT_BROKEN_TEMPLATE_ALIASES for cuda 9.0 and cuda 9.1

### DIFF
--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -143,7 +143,7 @@ namespace gridtools {
 #if defined(__CUDACC_VER_MAJOR__)
 // CUDA 9.0 and 9.1 have an different problem (not related to the exponential complexity of template alias
 // instantiation) see https://github.com/eth-cscs/gridtools/issues/976
-#define GT_BROKEN_TEMPLATE_ALIASES (__CUDACC_VER_MAJOR__ < 9 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ < 2))
+#define GT_BROKEN_TEMPLATE_ALIASES (__CUDACC_VER_MAJOR__ < 9)
 #elif defined(__INTEL_COMPILER)
 #define GT_BROKEN_TEMPLATE_ALIASES (__INTEL_COMPILER < 1800)
 #elif defined(__clang__)

--- a/include/gridtools/common/generic_metafunctions/meta.hpp
+++ b/include/gridtools/common/generic_metafunctions/meta.hpp
@@ -735,9 +735,9 @@ namespace gridtools {
              *  Zip lists
              */
             template <class List, class... Lists>
-            GT_META_DEFINE_ALIAS(zip,
-                lfold,
-                (transform<meta::push_back>::type::apply, typename transform<list, List>::type, list<Lists...>));
+            struct zip
+                : lfold<transform<meta::push_back>::type::apply, typename transform<list, List>::type, list<Lists...>> {
+            };
 
             // transform, generic version
             template <template <class...> class F, class List, class... Lists>

--- a/unit_tests/common/test_tuple_util.cpp
+++ b/unit_tests/common/test_tuple_util.cpp
@@ -44,7 +44,7 @@
 
 #include <gridtools/common/defs.hpp>
 
-#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ < 9
+#if defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ < 9 || __CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ < 2)
 #define NO_CONSTEXPR
 #endif
 


### PR DESCRIPTION
- `meta::zip` metafunction is now unconditionally defined as a struct (not as a template alias to `lfold`).   