### PR TITLE
Fix Possible Suboptimal KNL Performance

### DIFF
--- a/include/gridtools/stencil-composition/backend_mic/backend_traits_mic.hpp
+++ b/include/gridtools/stencil-composition/backend_mic/backend_traits_mic.hpp
@@ -90,7 +90,7 @@ namespace gridtools {
 
             GRIDTOOLS_STATIC_ASSERT((is_run_functor_arguments<RunFunctorArgs>::value), GT_INTERNAL_ERROR);
             template <typename LocalDomain, typename Grid, typename ReductionData, typename ExecutionInfo>
-            static void run(LocalDomain const &local_domain,
+            GT_FUNCTION static void run(LocalDomain const &local_domain,
                 Grid const &grid,
                 ReductionData &reduction_data,
                 const ExecutionInfo &execution_info) {

--- a/include/gridtools/stencil-composition/mss_functor.hpp
+++ b/include/gridtools/stencil-composition/mss_functor.hpp
@@ -160,7 +160,7 @@ namespace gridtools {
          * operations defined on that functor.
          */
         template <typename Index>
-        void operator()(Index const &) const {
+        GT_FUNCTION_HOST void operator()(Index const &) const {
             GRIDTOOLS_STATIC_ASSERT((Index::value < boost::mpl::size<MssComponentsArray>::value), GT_INTERNAL_ERROR);
             typedef typename boost::mpl::at<MssComponentsArray, Index>::type mss_components_t;
 


### PR DESCRIPTION
This forces inlining of mss_functior::operator() and backend_traits_mic::mss_loop::run(), which can result in up to 20 percent better performance on the Intel compiler in some cases. Other backends performance does not seem to be affected.