### PR TITLE
Fix cuda 8 issue

### DIFF
--- a/include/gridtools/c_bindings/generator.hpp
+++ b/include/gridtools/c_bindings/generator.hpp
@@ -419,7 +419,7 @@ namespace gridtools {
                             tmp_strm << ", ";
                         if (meta) {
                             const auto desc_name = "descriptor" + std::to_string(i);
-                            tmp_strm << desc_name << i;
+                            tmp_strm << desc_name;
                         } else {
                             tmp_strm << "arg" << i;
                         }


### PR DESCRIPTION
Replace `std::bind` with simple helper. This is needed because CUDA 8 seems to have trouble with the complexity of this code.