### PR TITLE
Replace Fixed-Point Offset Computations by Floating-Point

### DIFF
--- a/include/gridtools/stencil-composition/structured_grids/backend_mic/iterate_domain_mic.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_mic/iterate_domain_mic.hpp
@@ -39,6 +39,7 @@
 #include <xmmintrin.h>
 #endif
 
+#include <cmath>
 #include <functional>
 
 #include <boost/fusion/functional/invocation/invoke.hpp>


### PR DESCRIPTION
This allows for non-power-of-two thread counts using the MC backend.