### PR TITLE
Build examples before tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,18 +73,18 @@ add_library(array_descriptor src/c_bindings/array_descriptor.f90)
 # ===============
 # examples and tests
 # ===============
-include (fix_test_case_name)
-if(NOT DISABLE_TESTING)
-  add_subdirectory(regression)
-  add_subdirectory(unit_tests)
-endif()
-
 if( INSTALL_GT_EXAMPLES )
    SET(COMPILE_EXAMPLES ON)
 endif()
 
 if( COMPILE_EXAMPLES )
   add_subdirectory(gt_examples)
+endif()
+
+include (fix_test_case_name)
+if(NOT DISABLE_TESTING)
+  add_subdirectory(regression)
+  add_subdirectory(unit_tests)
 endif()
 
 # ===============


### PR DESCRIPTION
Description: the examples are more heavy in compile time than most of the tests, by putting examples first, we are more efficiently using parallel compilation.