### PR TITLE
Rename platform -> target

### DIFF
--- a/gt_examples/stencil-composition/backend_select.hpp
+++ b/gt_examples/stencil-composition/backend_select.hpp
@@ -40,14 +40,14 @@
 
 #ifdef BACKEND_HOST
 #ifdef BACKEND_STRATEGY_NAIVE
-using backend_t = gridtools::backend<gridtools::platform::x86, GRIDBACKEND, gridtools::strategy::naive>;
+using backend_t = gridtools::backend<gridtools::target::x86, GRIDBACKEND, gridtools::strategy::naive>;
 #else
-using backend_t = gridtools::backend<gridtools::platform::x86, GRIDBACKEND, gridtools::strategy::block>;
+using backend_t = gridtools::backend<gridtools::target::x86, GRIDBACKEND, gridtools::strategy::block>;
 #endif
 #elif defined(BACKEND_MIC)
-using backend_t = gridtools::backend<gridtools::platform::mc, GRIDBACKEND, gridtools::strategy::block>;
+using backend_t = gridtools::backend<gridtools::target::mc, GRIDBACKEND, gridtools::strategy::block>;
 #elif defined(BACKEND_CUDA)
-using backend_t = gridtools::backend<gridtools::platform::cuda, GRIDBACKEND, gridtools::strategy::block>;
+using backend_t = gridtools::backend<gridtools::target::cuda, GRIDBACKEND, gridtools::strategy::block>;
 #else
 #error "no backend selected"
 #endif

--- a/include/gridtools/boundary-conditions/boundary.hpp
+++ b/include/gridtools/boundary-conditions/boundary.hpp
@@ -58,18 +58,18 @@ namespace gridtools {
         struct select_apply;
 
         template <typename BoundaryFunction, typename Predicate>
-        struct select_apply<platform::x86, BoundaryFunction, Predicate> {
+        struct select_apply<target::x86, BoundaryFunction, Predicate> {
             using type = boundary_apply<BoundaryFunction, Predicate>;
         };
 
         template <typename BoundaryFunction, typename Predicate>
-        struct select_apply<platform::mc, BoundaryFunction, Predicate> {
+        struct select_apply<target::mc, BoundaryFunction, Predicate> {
             using type = boundary_apply<BoundaryFunction, Predicate>;
         };
 
 #ifdef __CUDACC__
         template <typename BoundaryFunction, typename Predicate>
-        struct select_apply<platform::cuda, BoundaryFunction, Predicate>
+        struct select_apply<target::cuda, BoundaryFunction, Predicate>
 
         {
             using type = boundary_apply_gpu<BoundaryFunction, Predicate>;
@@ -80,14 +80,14 @@ namespace gridtools {
         struct proper_view;
 
         template <access_mode AM, typename DataF>
-        struct proper_view<platform::x86, AM, DataF> {
+        struct proper_view<target::x86, AM, DataF> {
             using proper_view_t = decltype(make_host_view<AM, DataF>(std::declval<DataF>()));
 
             static proper_view_t make(DataF const &df) { return make_host_view<AM>(df); }
         };
 
         template <access_mode AM, typename DataF>
-        struct proper_view<platform::mc, AM, DataF> {
+        struct proper_view<target::mc, AM, DataF> {
             using proper_view_t = decltype(make_host_view<AM, DataF>(std::declval<DataF>()));
 
             static proper_view_t make(DataF const &df) { return make_host_view<AM>(df); }
@@ -95,7 +95,7 @@ namespace gridtools {
 
 #ifdef __CUDACC__
         template <access_mode AM, typename DataF>
-        struct proper_view<platform::cuda, AM, DataF> {
+        struct proper_view<target::cuda, AM, DataF> {
             using proper_view_t = decltype(make_device_view<AM, DataF>(std::declval<DataF>()));
 
             static proper_view_t make(DataF const &df) { return make_device_view<AM>(df); }
@@ -112,7 +112,7 @@ namespace gridtools {
        @brief Main interface for boundary condition application.
 
        \tparam BoundaryFunction The boundary condition functor
-       \tparam Arch The platform where the data is (e.g., Host or Cuda)
+       \tparam Arch The target where the data is (e.g., Host or Cuda)
        \tparam Predicate Runtime predicate for deciding if to apply boundary conditions or not on certain regions based
        on runtime values (useful to deal with non-priodic distributed examples
      */

--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -160,12 +160,12 @@ namespace gridtools {
         @{
     */
 
-    /** tags specifying the platform to use */
-    namespace platform {
+    /** tags specifying the target to use */
+    namespace target {
         struct cuda {};
         struct mc {};
         struct x86 {};
-    } // namespace platform
+    } // namespace target
 
     /** tags specifying the strategy to use */
     namespace strategy {

--- a/include/gridtools/distributed-boundaries/comm_traits.hpp
+++ b/include/gridtools/distributed-boundaries/comm_traits.hpp
@@ -58,12 +58,12 @@ namespace gridtools {
     struct comm_traits {
         template <typename GCLArch, typename = void>
         struct compute_arch_of {
-            using type = platform::x86;
+            using type = target::x86;
         };
 
         template <typename T>
         struct compute_arch_of<gcl_gpu, T> {
-            using type = platform::cuda;
+            using type = target::cuda;
         };
 
         using proc_layout = gridtools::layout_map<0, 1, 2>;

--- a/include/gridtools/stencil-composition/backend_base.hpp
+++ b/include/gridtools/stencil-composition/backend_base.hpp
@@ -109,7 +109,7 @@ namespace gridtools {
     struct backend_base {
 
 #ifdef __CUDACC__
-        GRIDTOOLS_STATIC_ASSERT((std::is_same<BackendId, platform::cuda>::value),
+        GRIDTOOLS_STATIC_ASSERT((std::is_same<BackendId, target::cuda>::value),
             "Beware: you are compiling with nvcc, and most probably "
             "want to use the cuda backend, but the backend you are "
             "instantiating is another one!!");

--- a/include/gridtools/stencil-composition/backend_cuda/backend_traits_cuda.hpp
+++ b/include/gridtools/stencil-composition/backend_cuda/backend_traits_cuda.hpp
@@ -61,7 +61,7 @@ namespace gridtools {
 
     /** @brief traits struct defining the types which are specific to the CUDA backend*/
     template <>
-    struct backend_traits_from_id<platform::cuda> {
+    struct backend_traits_from_id<target::cuda> {
 
         /** This is the functor used to generate view instances. According to the given storage
            an appropriate view is returned. When using the CUDA backend we return device view instances.

--- a/include/gridtools/stencil-composition/backend_cuda/basic_token_execution_cuda.hpp
+++ b/include/gridtools/stencil-composition/backend_cuda/basic_token_execution_cuda.hpp
@@ -78,7 +78,7 @@ namespace gridtools {
      *   20 ---------          20 ---------      ---
      */
     template <class FromLevel, class ToLevel, class GridBackend, class Strategy, uint_t BlockSize, class Grid>
-    GT_FUNCTION pair<int, int> get_k_interval(backend_ids<platform::cuda, GridBackend, Strategy>,
+    GT_FUNCTION pair<int, int> get_k_interval(backend_ids<target::cuda, GridBackend, Strategy>,
         enumtype::execute<enumtype::parallel, BlockSize>,
         Grid const &grid) {
         return make_pair(math::max(blockIdx.z * BlockSize, grid.template value_at<FromLevel>()),
@@ -87,7 +87,7 @@ namespace gridtools {
 
     template <class FromLevel, class ToLevel, class GridBackend, class Strategy, class ExecutionEngine, class Grid>
     GT_FUNCTION pair<int, int> get_k_interval(
-        backend_ids<platform::cuda, GridBackend, Strategy>, ExecutionEngine, Grid const &grid) {
+        backend_ids<target::cuda, GridBackend, Strategy>, ExecutionEngine, Grid const &grid) {
         return make_pair(grid.template value_at<FromLevel>(), grid.template value_at<ToLevel>());
     }
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/backend_cuda/block.hpp
+++ b/include/gridtools/stencil-composition/backend_cuda/block.hpp
@@ -41,11 +41,11 @@
 
 namespace gridtools {
     template <class GridType>
-    GT_FUNCTION constexpr uint_t block_i_size(backend_ids<platform::cuda, GridType, strategy::block> const &) {
+    GT_FUNCTION constexpr uint_t block_i_size(backend_ids<target::cuda, GridType, strategy::block> const &) {
         return GT_DEFAULT_TILE_I;
     }
     template <class GridType>
-    GT_FUNCTION constexpr uint_t block_j_size(backend_ids<platform::cuda, GridType, strategy::block> const &) {
+    GT_FUNCTION constexpr uint_t block_j_size(backend_ids<target::cuda, GridType, strategy::block> const &) {
         return GT_DEFAULT_TILE_J;
     }
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/backend_cuda/tmp_storage.hpp
+++ b/include/gridtools/stencil-composition/backend_cuda/tmp_storage.hpp
@@ -60,7 +60,7 @@ namespace gridtools {
                 class GridType,
                 int_t UsedHalo = -MaxExtent::iminus::value,
                 uint_t StorageHalo = StorageInfo::halo_t::template at<
-                    coord_i<backend_ids<platform::cuda, GridType, strategy::block>>::value>()>
+                    coord_i<backend_ids<target::cuda, GridType, strategy::block>>::value>()>
             GT_FUNCTION constexpr uint_t additional_i_offset() {
                 return StorageHalo > UsedHalo ? StorageHalo - UsedHalo : 0;
             }
@@ -68,7 +68,7 @@ namespace gridtools {
 
         template <class StorageInfo, class MaxExtent, class GridType>
         uint_t get_i_size(
-            backend_ids<platform::cuda, GridType, strategy::block> const &, uint_t block_size, uint_t total_size) {
+            backend_ids<target::cuda, GridType, strategy::block> const &, uint_t block_size, uint_t total_size) {
             GRIDTOOLS_STATIC_ASSERT(is_extent<MaxExtent>::value, GT_INTERNAL_ERROR);
             static constexpr auto additional_offset = _impl::additional_i_offset<StorageInfo, MaxExtent, GridType>();
             auto full_block_size = _impl::full_block_i_size<StorageInfo, MaxExtent>(block_size);
@@ -78,7 +78,7 @@ namespace gridtools {
 
         template <class StorageInfo, class MaxExtent, class GridType>
         GT_FUNCTION int_t get_i_block_offset(
-            backend_ids<platform::cuda, GridType, strategy::block> const &, uint_t block_size, uint_t block_no) {
+            backend_ids<target::cuda, GridType, strategy::block> const &, uint_t block_size, uint_t block_no) {
             GRIDTOOLS_STATIC_ASSERT(is_extent<MaxExtent>::value, GT_INTERNAL_ERROR);
             static constexpr auto additional_offset = _impl::additional_i_offset<StorageInfo, MaxExtent, GridType>();
             auto full_block_size = _impl::full_block_i_size<StorageInfo, MaxExtent>(block_size);
@@ -87,9 +87,9 @@ namespace gridtools {
 
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         uint_t get_j_size(
-            backend_ids<platform::cuda, GridType, strategy::block> const &, uint_t block_size, uint_t total_size) {
+            backend_ids<target::cuda, GridType, strategy::block> const &, uint_t block_size, uint_t total_size) {
             static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_j<backend_ids<platform::cuda, GridType, strategy::block>>::value>();
+                coord_j<backend_ids<target::cuda, GridType, strategy::block>>::value>();
             auto full_block_size = block_size + 2 * halo;
             auto num_blocks = (total_size + block_size - 1) / block_size;
             return full_block_size * num_blocks;
@@ -97,9 +97,9 @@ namespace gridtools {
 
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         GT_FUNCTION int_t get_j_block_offset(
-            backend_ids<platform::cuda, GridType, strategy::block> const &, uint_t block_size, uint_t block_no) {
+            backend_ids<target::cuda, GridType, strategy::block> const &, uint_t block_size, uint_t block_no) {
             static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_j<backend_ids<platform::cuda, GridType, strategy::block>>::value>();
+                coord_j<backend_ids<target::cuda, GridType, strategy::block>>::value>();
             return block_no * (block_size + 2 * halo) + halo;
         }
     } // namespace tmp_storage

--- a/include/gridtools/stencil-composition/backend_host/backend_traits_host.hpp
+++ b/include/gridtools/stencil-composition/backend_host/backend_traits_host.hpp
@@ -54,7 +54,7 @@
 namespace gridtools {
     /**Traits struct, containing the types which are specific for the host backend*/
     template <>
-    struct backend_traits_from_id<platform::x86> {
+    struct backend_traits_from_id<target::x86> {
 
         /** This is the functor used to generate view instances. According to the given storage an appropriate view is
          * returned. When using the Host backend we return host view instances.

--- a/include/gridtools/stencil-composition/backend_host/basic_token_execution_host.hpp
+++ b/include/gridtools/stencil-composition/backend_host/basic_token_execution_host.hpp
@@ -45,7 +45,7 @@
 namespace gridtools {
     template <class FromLevel, class ToLevel, class GridBackend, class Strategy, class ExecutionEngine, class Grid>
     GT_FUNCTION pair<int, int> get_k_interval(
-        backend_ids<platform::x86, GridBackend, Strategy>, ExecutionEngine, Grid const &grid) {
+        backend_ids<target::x86, GridBackend, Strategy>, ExecutionEngine, Grid const &grid) {
         return make_pair(grid.template value_at<FromLevel>(), grid.template value_at<ToLevel>());
     }
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/backend_host/block.hpp
+++ b/include/gridtools/stencil-composition/backend_host/block.hpp
@@ -42,30 +42,30 @@
 
 namespace gridtools {
     template <class GridType>
-    GT_FUNCTION constexpr uint_t block_i_size(backend_ids<platform::x86, GridType, strategy::block> const &) {
+    GT_FUNCTION constexpr uint_t block_i_size(backend_ids<target::x86, GridType, strategy::block> const &) {
         return GT_DEFAULT_TILE_I;
     }
     template <class GridType>
-    GT_FUNCTION constexpr uint_t block_j_size(backend_ids<platform::x86, GridType, strategy::block> const &) {
+    GT_FUNCTION constexpr uint_t block_j_size(backend_ids<target::x86, GridType, strategy::block> const &) {
         return GT_DEFAULT_TILE_J;
     }
 
     template <class GridType>
-    GT_FUNCTION constexpr uint_t block_i_size(backend_ids<platform::x86, GridType, strategy::naive> const &) {
+    GT_FUNCTION constexpr uint_t block_i_size(backend_ids<target::x86, GridType, strategy::naive> const &) {
         return 0;
     }
     template <class GridType>
-    GT_FUNCTION constexpr uint_t block_j_size(backend_ids<platform::x86, GridType, strategy::naive> const &) {
+    GT_FUNCTION constexpr uint_t block_j_size(backend_ids<target::x86, GridType, strategy::naive> const &) {
         return 0;
     }
 
     template <class GridType, class Grid>
-    uint_t block_i_size(backend_ids<platform::x86, GridType, strategy::naive> const &, Grid const &grid) {
+    uint_t block_i_size(backend_ids<target::x86, GridType, strategy::naive> const &, Grid const &grid) {
         GRIDTOOLS_STATIC_ASSERT(is_grid<Grid>::value, GT_INTERNAL_ERROR);
         return grid.i_high_bound() - grid.i_low_bound() + 1;
     }
     template <class GridType, class Grid>
-    uint_t block_j_size(backend_ids<platform::x86, GridType, strategy::naive> const &, Grid const &grid) {
+    uint_t block_j_size(backend_ids<target::x86, GridType, strategy::naive> const &, Grid const &grid) {
         GRIDTOOLS_STATIC_ASSERT(is_grid<Grid>::value, GT_INTERNAL_ERROR);
         return grid.j_high_bound() - grid.j_low_bound() + 1;
     }

--- a/include/gridtools/stencil-composition/backend_host/tmp_storage.hpp
+++ b/include/gridtools/stencil-composition/backend_host/tmp_storage.hpp
@@ -46,66 +46,66 @@ namespace gridtools {
         // strategy::naive specialisations
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         uint_t get_i_size(
-            backend_ids<platform::x86, GridType, strategy::naive> const &, uint_t /*block_size*/, uint_t total_size) {
-            static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_i<backend_ids<platform::x86, GridType, strategy::naive>>::value>();
+            backend_ids<target::x86, GridType, strategy::naive> const &, uint_t /*block_size*/, uint_t total_size) {
+            static constexpr auto halo =
+                StorageInfo::halo_t::template at<coord_i<backend_ids<target::x86, GridType, strategy::naive>>::value>();
             return total_size + 2 * halo;
         }
 
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         GT_FUNCTION int_t get_i_block_offset(
-            backend_ids<platform::x86, GridType, strategy::naive> const &, uint_t /*block_size*/, uint_t /*block_no*/) {
-            static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_i<backend_ids<platform::x86, GridType, strategy::naive>>::value>();
+            backend_ids<target::x86, GridType, strategy::naive> const &, uint_t /*block_size*/, uint_t /*block_no*/) {
+            static constexpr auto halo =
+                StorageInfo::halo_t::template at<coord_i<backend_ids<target::x86, GridType, strategy::naive>>::value>();
             return halo;
         }
 
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         uint_t get_j_size(
-            backend_ids<platform::x86, GridType, strategy::naive> const &, uint_t /*block_size*/, uint_t total_size) {
-            static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_j<backend_ids<platform::x86, GridType, strategy::naive>>::value>();
+            backend_ids<target::x86, GridType, strategy::naive> const &, uint_t /*block_size*/, uint_t total_size) {
+            static constexpr auto halo =
+                StorageInfo::halo_t::template at<coord_j<backend_ids<target::x86, GridType, strategy::naive>>::value>();
             return total_size + 2 * halo;
         }
 
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         GT_FUNCTION int_t get_j_block_offset(
-            backend_ids<platform::x86, GridType, strategy::naive> const &, uint_t /*block_size*/, uint_t /*block_no*/) {
-            static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_j<backend_ids<platform::x86, GridType, strategy::naive>>::value>();
+            backend_ids<target::x86, GridType, strategy::naive> const &, uint_t /*block_size*/, uint_t /*block_no*/) {
+            static constexpr auto halo =
+                StorageInfo::halo_t::template at<coord_j<backend_ids<target::x86, GridType, strategy::naive>>::value>();
             return halo;
         }
 
         // Block specialisations
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         uint_t get_i_size(
-            backend_ids<platform::x86, GridType, strategy::block> const &, uint_t block_size, uint_t /*total_size*/) {
-            static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_i<backend_ids<platform::x86, GridType, strategy::block>>::value>();
+            backend_ids<target::x86, GridType, strategy::block> const &, uint_t block_size, uint_t /*total_size*/) {
+            static constexpr auto halo =
+                StorageInfo::halo_t::template at<coord_i<backend_ids<target::x86, GridType, strategy::block>>::value>();
             return (block_size + 2 * halo) * omp_get_max_threads();
         }
 
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         GT_FUNCTION int_t get_i_block_offset(
-            backend_ids<platform::x86, GridType, strategy::block> const &, uint_t block_size, uint_t /*block_no*/) {
-            static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_i<backend_ids<platform::x86, GridType, strategy::block>>::value>();
+            backend_ids<target::x86, GridType, strategy::block> const &, uint_t block_size, uint_t /*block_no*/) {
+            static constexpr auto halo =
+                StorageInfo::halo_t::template at<coord_i<backend_ids<target::x86, GridType, strategy::block>>::value>();
             return (block_size + 2 * halo) * omp_get_thread_num() + halo;
         }
 
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         uint_t get_j_size(
-            backend_ids<platform::x86, GridType, strategy::block> const &, uint_t block_size, uint_t /*total_size*/) {
-            static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_j<backend_ids<platform::x86, GridType, strategy::block>>::value>();
+            backend_ids<target::x86, GridType, strategy::block> const &, uint_t block_size, uint_t /*total_size*/) {
+            static constexpr auto halo =
+                StorageInfo::halo_t::template at<coord_j<backend_ids<target::x86, GridType, strategy::block>>::value>();
             return block_size + 2 * halo;
         }
 
         template <class StorageInfo, class /*MaxExtent*/, class GridType>
         GT_FUNCTION int_t get_j_block_offset(
-            backend_ids<platform::x86, GridType, strategy::block> const &, uint_t /*block_size*/, uint_t /*block_no*/) {
-            static constexpr auto halo = StorageInfo::halo_t::template at<
-                coord_j<backend_ids<platform::x86, GridType, strategy::block>>::value>();
+            backend_ids<target::x86, GridType, strategy::block> const &, uint_t /*block_size*/, uint_t /*block_no*/) {
+            static constexpr auto halo =
+                StorageInfo::halo_t::template at<coord_j<backend_ids<target::x86, GridType, strategy::block>>::value>();
             return halo;
         }
     } // namespace tmp_storage

--- a/include/gridtools/stencil-composition/backend_mic/backend_traits_mic.hpp
+++ b/include/gridtools/stencil-composition/backend_mic/backend_traits_mic.hpp
@@ -56,7 +56,7 @@
 namespace gridtools {
     /**Traits struct, containing the types which are specific for the mic backend*/
     template <>
-    struct backend_traits_from_id<platform::mc> {
+    struct backend_traits_from_id<target::mc> {
 
         /** This is the functor used to generate view instances. According to the given storage an appropriate view is
          * returned. When using the Host backend we return host view instances.

--- a/include/gridtools/stencil-composition/icosahedral_grids/backend.hpp
+++ b/include/gridtools/stencil-composition/icosahedral_grids/backend.hpp
@@ -50,15 +50,15 @@ namespace gridtools {
         template <class>
         struct default_layout;
         template <>
-        struct default_layout<platform::cuda> {
+        struct default_layout<target::cuda> {
             using type = layout_map<3, 2, 1, 0>;
         };
         template <>
-        struct default_layout<platform::x86> {
+        struct default_layout<target::x86> {
             using type = layout_map<0, 1, 2, 3>;
         };
         template <>
-        struct default_layout<platform::mc> {
+        struct default_layout<target::mc> {
             using type = layout_map<0, 1, 2, 3>;
         };
     } // namespace _impl

--- a/include/gridtools/stencil-composition/icosahedral_grids/backend_cuda/execute_kernel_functor_cuda.hpp
+++ b/include/gridtools/stencil-composition/icosahedral_grids/backend_cuda/execute_kernel_functor_cuda.hpp
@@ -77,7 +77,7 @@ namespace gridtools {
 
             using iterate_domain_t = iterate_domain_cuda<iterate_domain_arguments_t>;
 
-            typedef backend_traits_from_id<platform::cuda> backend_traits_t;
+            typedef backend_traits_from_id<target::cuda> backend_traits_t;
             typedef typename iterate_domain_t::strides_cached_t strides_t;
 
             const uint_t nx = (uint_t)(grid.i_high_bound() - grid.i_low_bound() + 1);

--- a/include/gridtools/stencil-composition/icosahedral_grids/backend_cuda/grid_traits_cuda.hpp
+++ b/include/gridtools/stencil-composition/icosahedral_grids/backend_cuda/grid_traits_cuda.hpp
@@ -42,7 +42,7 @@
 
 namespace gridtools {
     template <class Args>
-    struct kernel_functor_executor<backend_ids<platform::cuda, grid_type::icosahedral, strategy::block>, Args> {
+    struct kernel_functor_executor<backend_ids<target::cuda, grid_type::icosahedral, strategy::block>, Args> {
         using type = icgrid::execute_kernel_functor_cuda<Args>;
     };
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/icosahedral_grids/backend_host/execute_kernel_functor_host.hpp
+++ b/include/gridtools/stencil-composition/icosahedral_grids/backend_host/execute_kernel_functor_host.hpp
@@ -139,7 +139,7 @@ namespace gridtools {
 
             using iterate_domain_t = iterate_domain_host<iterate_domain_arguments_t>;
 
-            typedef backend_traits_from_id<platform::x86> backend_traits_t;
+            typedef backend_traits_from_id<target::x86> backend_traits_t;
             typedef typename iterate_domain_t::strides_cached_t strides_t;
             using interval_t = GT_META_CALL(meta::first, typename RunFunctorArguments::loop_intervals_t);
             using from_t = GT_META_CALL(meta::first, interval_t);

--- a/include/gridtools/stencil-composition/icosahedral_grids/backend_host/grid_traits_host.hpp
+++ b/include/gridtools/stencil-composition/icosahedral_grids/backend_host/grid_traits_host.hpp
@@ -42,7 +42,7 @@
 
 namespace gridtools {
     template <class Strategy, class Args>
-    struct kernel_functor_executor<backend_ids<platform::x86, grid_type::icosahedral, Strategy>, Args> {
+    struct kernel_functor_executor<backend_ids<target::x86, grid_type::icosahedral, Strategy>, Args> {
         using type = icgrid::execute_kernel_functor_host<Args>;
     };
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/icosahedral_grids/grid_traits_backend_fwd.hpp
+++ b/include/gridtools/stencil-composition/icosahedral_grids/grid_traits_backend_fwd.hpp
@@ -37,7 +37,7 @@
 
 namespace gridtools {
     namespace icgrid {
-        template <enumtype::platform BackendId>
+        template <enumtype::target BackendId>
         struct grid_traits_arch;
     }
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/structured_grids/backend_cuda/execute_kernel_functor_cuda.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_cuda/execute_kernel_functor_cuda.hpp
@@ -79,7 +79,7 @@ namespace gridtools {
                     meta::lazy::id<positional_iterate_domain<iterate_domain_cuda_t>>,
                     meta::lazy::id<iterate_domain_cuda_t>>::type;
 
-            typedef backend_traits_from_id<platform::cuda> backend_traits_t;
+            typedef backend_traits_from_id<target::cuda> backend_traits_t;
             typedef typename iterate_domain_t::strides_cached_t strides_t;
 
             // number of threads

--- a/include/gridtools/stencil-composition/structured_grids/backend_cuda/grid_traits_cuda.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_cuda/grid_traits_cuda.hpp
@@ -42,7 +42,7 @@
 
 namespace gridtools {
     template <class Args>
-    struct kernel_functor_executor<backend_ids<platform::cuda, grid_type::structured, strategy::block>, Args> {
+    struct kernel_functor_executor<backend_ids<target::cuda, grid_type::structured, strategy::block>, Args> {
         using type = strgrid::execute_kernel_functor_cuda<Args>;
     };
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/structured_grids/backend_host/execute_kernel_functor_host.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_host/execute_kernel_functor_host.hpp
@@ -86,7 +86,7 @@ namespace gridtools {
                 meta::lazy::id<positional_iterate_domain<iterate_domain_host_t>>,
                 meta::lazy::id<iterate_domain_host_t>>::type;
 
-            typedef backend_traits_from_id<platform::x86> backend_traits_t;
+            typedef backend_traits_from_id<target::x86> backend_traits_t;
 
             typedef typename iterate_domain_t::strides_cached_t strides_t;
 

--- a/include/gridtools/stencil-composition/structured_grids/backend_host/grid_traits_host.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_host/grid_traits_host.hpp
@@ -42,7 +42,7 @@
 
 namespace gridtools {
     template <class Strategy, class Args>
-    struct kernel_functor_executor<backend_ids<platform::x86, grid_type::structured, Strategy>, Args> {
+    struct kernel_functor_executor<backend_ids<target::x86, grid_type::structured, Strategy>, Args> {
         using type = strgrid::execute_kernel_functor_host<Args>;
     };
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/structured_grids/backend_mic/block.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_mic/block.hpp
@@ -42,11 +42,11 @@
 
 namespace gridtools {
     template <class Grid>
-    uint_t block_i_size(backend_ids<platform::mc, grid_type::structured, strategy::block> const &, Grid const &grid) {
+    uint_t block_i_size(backend_ids<target::mc, grid_type::structured, strategy::block> const &, Grid const &grid) {
         return execinfo_mic{grid}.i_block_size();
     }
     template <class Grid>
-    uint_t block_j_size(backend_ids<platform::mc, grid_type::structured, strategy::block> const &, Grid const &grid) {
+    uint_t block_j_size(backend_ids<target::mc, grid_type::structured, strategy::block> const &, Grid const &grid) {
         return execinfo_mic{grid}.j_block_size();
     }
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/structured_grids/backend_mic/grid_traits_mic.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_mic/grid_traits_mic.hpp
@@ -42,7 +42,7 @@
 
 namespace gridtools {
     template <class Args>
-    struct kernel_functor_executor<backend_ids<platform::mc, grid_type::structured, strategy::block>, Args> {
+    struct kernel_functor_executor<backend_ids<target::mc, grid_type::structured, strategy::block>, Args> {
         using type = strgrid::execute_kernel_functor_mic<Args>;
     };
 } // namespace gridtools

--- a/include/gridtools/stencil-composition/structured_grids/backend_mic/iterate_domain_mic.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_mic/iterate_domain_mic.hpp
@@ -64,7 +64,7 @@ namespace gridtools {
          * @brief Per-thread global value of omp_get_thread_num() / omp_get_max_threads().
          */
         inline float thread_factor() {
-            thread_local static const float value = (float) omp_get_thread_num() / omp_get_max_threads();
+            thread_local static const float value = (float)omp_get_thread_num() / omp_get_max_threads();
             return value;
         }
 
@@ -122,7 +122,7 @@ namespace gridtools {
 
         using iterate_domain_reduction_t = iterate_domain_reduction<IterateDomainArguments>;
         using reduction_type_t = typename iterate_domain_reduction_t::reduction_type_t;
-        using backend_traits_t = backend_traits_from_id<platform::mc>;
+        using backend_traits_t = backend_traits_from_id<target::mc>;
 
         using esf_sequence_t = typename IterateDomainArguments::esf_sequence_t;
         using cache_sequence_t = typename IterateDomainArguments::cache_sequence_t;

--- a/include/gridtools/stencil-composition/structured_grids/backend_mic/tmp_storage.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/backend_mic/tmp_storage.hpp
@@ -42,7 +42,7 @@
 namespace gridtools {
     namespace tmp_storage {
         template <class StorageInfo, class /*MaxExtent*/>
-        uint_t get_i_size(backend_ids<platform::mc, grid_type::structured, strategy::block> const &,
+        uint_t get_i_size(backend_ids<target::mc, grid_type::structured, strategy::block> const &,
             uint_t block_size,
             uint_t /*total_size*/) {
             static constexpr auto halo = StorageInfo::halo_t::template at<0>();
@@ -51,14 +51,14 @@ namespace gridtools {
         }
 
         template <class /*StorageInfo*/, class /*MaxExtent*/>
-        GT_FUNCTION int_t get_i_block_offset(backend_ids<platform::mc, grid_type::structured, strategy::block> const &,
+        GT_FUNCTION int_t get_i_block_offset(backend_ids<target::mc, grid_type::structured, strategy::block> const &,
             uint_t /*block_size*/,
             uint_t /*block_no*/) {
             return false ? 0 : throw "should not be used";
         }
 
         template <class StorageInfo, class /*MaxExtent*/>
-        uint_t get_j_size(backend_ids<platform::mc, grid_type::structured, strategy::block> const &,
+        uint_t get_j_size(backend_ids<target::mc, grid_type::structured, strategy::block> const &,
             uint_t block_size,
             uint_t /*total_size*/) {
             static constexpr auto halo = StorageInfo::halo_t::template at<1>();
@@ -66,7 +66,7 @@ namespace gridtools {
         }
 
         template <class /*StorageInfo*/, class /*MaxExtent*/>
-        GT_FUNCTION int_t get_j_block_offset(backend_ids<platform::mc, grid_type::structured, strategy::block> const &,
+        GT_FUNCTION int_t get_j_block_offset(backend_ids<target::mc, grid_type::structured, strategy::block> const &,
             uint_t /*block_size*/,
             uint_t /*block_no*/) {
             return false ? 0 : throw "should not be used";

--- a/include/gridtools/storage/storage-facility.hpp
+++ b/include/gridtools/storage/storage-facility.hpp
@@ -69,7 +69,7 @@ namespace gridtools {
     /**
      * @brief storage traits used to retrieve the correct storage_info, data_store, and data_store_field types.
      * Additionally to the default types, specialized and custom storage_info types can be retrieved
-     * @tparam T used platform (e.g., Cuda or Host)
+     * @tparam T used target (e.g., Cuda or Host)
      */
     template <class BackendId>
     struct storage_traits : gridtools::storage_traits_from_id<BackendId> {

--- a/include/gridtools/storage/storage_traits_cuda.hpp
+++ b/include/gridtools/storage/storage_traits_cuda.hpp
@@ -55,7 +55,7 @@ namespace gridtools {
 
     /** @brief storage traits for the CUDA backend*/
     template <>
-    struct storage_traits_from_id<platform::cuda> {
+    struct storage_traits_from_id<target::cuda> {
 
         template <typename ValueType>
         struct select_storage {

--- a/include/gridtools/storage/storage_traits_host.hpp
+++ b/include/gridtools/storage/storage_traits_host.hpp
@@ -53,7 +53,7 @@ namespace gridtools {
 
     /** @brief storage traits for the Host backend*/
     template <>
-    struct storage_traits_from_id<platform::x86> {
+    struct storage_traits_from_id<target::x86> {
 
         template <typename ValueType>
         struct select_storage {

--- a/include/gridtools/storage/storage_traits_mic.hpp
+++ b/include/gridtools/storage/storage_traits_mic.hpp
@@ -62,7 +62,7 @@ namespace gridtools {
 
     /** @brief storage traits for the Mic backend*/
     template <>
-    struct storage_traits_from_id<platform::mc> {
+    struct storage_traits_from_id<target::mc> {
 
         template <typename ValueType>
         struct select_storage {

--- a/regression/backend_select.hpp
+++ b/regression/backend_select.hpp
@@ -40,14 +40,14 @@
 
 #ifdef BACKEND_HOST
 #ifdef BACKEND_STRATEGY_NAIVE
-using backend_t = gridtools::backend<gridtools::platform::x86, GRIDBACKEND, gridtools::strategy::naive>;
+using backend_t = gridtools::backend<gridtools::target::x86, GRIDBACKEND, gridtools::strategy::naive>;
 #else
-using backend_t = gridtools::backend<gridtools::platform::x86, GRIDBACKEND, gridtools::strategy::block>;
+using backend_t = gridtools::backend<gridtools::target::x86, GRIDBACKEND, gridtools::strategy::block>;
 #endif
 #elif defined(BACKEND_MIC)
-using backend_t = gridtools::backend<gridtools::platform::mc, GRIDBACKEND, gridtools::strategy::block>;
+using backend_t = gridtools::backend<gridtools::target::mc, GRIDBACKEND, gridtools::strategy::block>;
 #elif defined(BACKEND_CUDA)
-using backend_t = gridtools::backend<gridtools::platform::cuda, GRIDBACKEND, gridtools::strategy::block>;
+using backend_t = gridtools::backend<gridtools::target::cuda, GRIDBACKEND, gridtools::strategy::block>;
 #else
 #error "no backend selected"
 #endif

--- a/regression/extended_4D.hpp
+++ b/regression/extended_4D.hpp
@@ -46,10 +46,10 @@ using namespace gridtools;
 using namespace enumtype;
 using namespace expressions;
 
-using layout_map_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, platform::x86>::value,
+using layout_map_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, target::x86>::value,
     layout_map<3, 4, 5, 0, 1, 2>,
     layout_map<5, 4, 3, 2, 1, 0>>::type;
-using layout_map_quad_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, platform::x86>::value,
+using layout_map_quad_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, target::x86>::value,
     layout_map<1, 2, 3, 0>,
     layout_map<3, 2, 1, 0>>::type;
 

--- a/regression/icosahedral/unstructured_grid.hpp
+++ b/regression/icosahedral/unstructured_grid.hpp
@@ -72,7 +72,7 @@ namespace gridtools {
     };
 
     class unstructured_grid {
-        using backend_t = backend<platform::x86, grid_type::icosahedral, strategy::naive>;
+        using backend_t = backend<target::x86, grid_type::icosahedral, strategy::naive>;
         using grid_topology_t = icosahedral_topology<backend_t>;
 
         static const int ncolors = 2;

--- a/unit_tests/backend_select.hpp
+++ b/unit_tests/backend_select.hpp
@@ -39,17 +39,17 @@
 #include <gridtools/stencil-composition/backend.hpp>
 
 #ifdef BACKEND_HOST
-using ARCH = gridtools::platform::x86;
+using ARCH = gridtools::target::x86;
 #ifdef BACKEND_STRATEGY_NAIVE
 using backend_t = gridtools::backend<ARCH, GRIDBACKEND, gridtools::strategy::naive>;
 #else
 using backend_t = gridtools::backend<ARCH, GRIDBACKEND, gridtools::strategy::block>;
 #endif
 #elif defined(BACKEND_MIC)
-using ARCH = gridtools::platform::mc;
+using ARCH = gridtools::target::mc;
 using backend_t = gridtools::backend<ARCH, GRIDBACKEND, gridtools::strategy::block>;
 #elif defined(BACKEND_CUDA)
-using ARCH = gridtools::platform::cuda;
+using ARCH = gridtools::target::cuda;
 using backend_t = gridtools::backend<ARCH, GRIDBACKEND, gridtools::strategy::block>;
 #else
 #error "no backend selected"

--- a/unit_tests/interface/repository/custom_test_generated_repository.cpp.in
+++ b/unit_tests/interface/repository/custom_test_generated_repository.cpp.in
@@ -42,10 +42,10 @@
 
 using namespace gridtools;
 
-using IJKStorageInfo = typename storage_traits<platform::x86>::storage_info_t<0, 3>;
-using IJKDataStore = typename storage_traits<platform::x86>::data_store_t<float_type, IJKStorageInfo>;
-using IJStorageInfo = typename storage_traits<platform::x86>::storage_info_t<1, 2>;
-using IJDataStore = typename storage_traits<platform::x86>::data_store_t<float_type, IJStorageInfo>;
+using IJKStorageInfo = typename storage_traits<target::x86>::storage_info_t<0, 3>;
+using IJKDataStore = typename storage_traits<target::x86>::data_store_t<float_type, IJKStorageInfo>;
+using IJStorageInfo = typename storage_traits<target::x86>::storage_info_t<1, 2>;
+using IJDataStore = typename storage_traits<target::x86>::data_store_t<float_type, IJStorageInfo>;
 
 // We include a repository file which is generated from preprocessor output
 #include "@GENERATED_REPOSITORY@"

--- a/unit_tests/interface/repository/exported_repository.hpp
+++ b/unit_tests/interface/repository/exported_repository.hpp
@@ -37,17 +37,17 @@
 #include <gridtools/interface/repository/repository.hpp>
 #include <gridtools/storage/storage-facility.hpp>
 
-using IJKStorageInfo = typename gridtools::storage_traits<gridtools::platform::x86>::storage_info_t<0, 3>;
+using IJKStorageInfo = typename gridtools::storage_traits<gridtools::target::x86>::storage_info_t<0, 3>;
 using IJKDataStore =
-    typename gridtools::storage_traits<gridtools::platform::x86>::data_store_t<gridtools::float_type, IJKStorageInfo>;
-using IJStorageInfo = typename gridtools::storage_traits<gridtools::platform::x86>::special_storage_info_t<1,
-    gridtools::selector<1, 1, 0>>;
+    typename gridtools::storage_traits<gridtools::target::x86>::data_store_t<gridtools::float_type, IJKStorageInfo>;
+using IJStorageInfo =
+    typename gridtools::storage_traits<gridtools::target::x86>::special_storage_info_t<1, gridtools::selector<1, 1, 0>>;
 using IJDataStore =
-    typename gridtools::storage_traits<gridtools::platform::x86>::data_store_t<gridtools::float_type, IJStorageInfo>;
-using JKStorageInfo = typename gridtools::storage_traits<gridtools::platform::x86>::special_storage_info_t<2,
-    gridtools::selector<0, 1, 1>>;
+    typename gridtools::storage_traits<gridtools::target::x86>::data_store_t<gridtools::float_type, IJStorageInfo>;
+using JKStorageInfo =
+    typename gridtools::storage_traits<gridtools::target::x86>::special_storage_info_t<2, gridtools::selector<0, 1, 1>>;
 using JKDataStore =
-    typename gridtools::storage_traits<gridtools::platform::x86>::data_store_t<gridtools::float_type, JKStorageInfo>;
+    typename gridtools::storage_traits<gridtools::target::x86>::data_store_t<gridtools::float_type, JKStorageInfo>;
 
 #define MY_FIELDTYPES (IJKDataStore, (0, 1, 2))(IJDataStore, (0, 1, 2))(JKDataStore, (0, 1, 2))
 #define MY_FIELDS (IJKDataStore, ijkfield)(IJDataStore, ijfield)(JKDataStore, jkfield)

--- a/unit_tests/interface/repository/test_repository.cpp
+++ b/unit_tests/interface/repository/test_repository.cpp
@@ -118,13 +118,13 @@ TEST(extended_repo, inherited_functions) {
     ASSERT_EQ(10, repo.u().total_length<0>());
 }
 
-using IJKWStorageInfo = typename gridtools::storage_traits<gridtools::platform::x86>::storage_info_t<2, 3>;
+using IJKWStorageInfo = typename gridtools::storage_traits<gridtools::target::x86>::storage_info_t<2, 3>;
 using IJKWDataStore =
-    typename gridtools::storage_traits<gridtools::platform::x86>::data_store_t<gridtools::float_type, IJKWStorageInfo>;
-using IKStorageInfo = typename gridtools::storage_traits<gridtools::platform::x86>::special_storage_info_t<2,
-    gridtools::selector<1, 0, 1>>;
+    typename gridtools::storage_traits<gridtools::target::x86>::data_store_t<gridtools::float_type, IJKWStorageInfo>;
+using IKStorageInfo =
+    typename gridtools::storage_traits<gridtools::target::x86>::special_storage_info_t<2, gridtools::selector<1, 0, 1>>;
 using IKDataStore =
-    typename gridtools::storage_traits<gridtools::platform::x86>::data_store_t<gridtools::float_type, IKStorageInfo>;
+    typename gridtools::storage_traits<gridtools::target::x86>::data_store_t<gridtools::float_type, IKStorageInfo>;
 
 #define MY_FIELDTYPES \
     (IJKDataStore, (0, 1, 2))(IJDataStore, (0, 1, 2))(IJKWDataStore, (0, 1, 3))(IKDataStore, (0, 0, 2))

--- a/unit_tests/interface/test_fortran_array_adapter.cpp
+++ b/unit_tests/interface/test_fortran_array_adapter.cpp
@@ -40,9 +40,9 @@
 #include <gridtools/interface/fortran_array_adapter.hpp>
 #include <gridtools/storage/storage-facility.hpp>
 
-using IJKStorageInfo = typename gridtools::storage_traits<gridtools::platform::x86>::storage_info_t<0, 3>;
+using IJKStorageInfo = typename gridtools::storage_traits<gridtools::target::x86>::storage_info_t<0, 3>;
 using IJKDataStore =
-    typename gridtools::storage_traits<gridtools::platform::x86>::data_store_t<gridtools::float_type, IJKStorageInfo>;
+    typename gridtools::storage_traits<gridtools::target::x86>::data_store_t<gridtools::float_type, IJKStorageInfo>;
 
 TEST(FortranArrayAdapter, TransformAdapterIntoDataStore) {
     constexpr size_t x_size = 6;

--- a/unit_tests/stencil-composition/caches/test_cache_metafunctions.cpp
+++ b/unit_tests/stencil-composition/caches/test_cache_metafunctions.cpp
@@ -64,8 +64,8 @@ struct functor1 {
     GT_FUNCTION static void Do(Evaluation &eval, x_interval) {}
 };
 
-typedef storage_traits<platform::x86>::storage_info_t<0, 2> storage_info_ij_t;
-typedef storage_traits<platform::x86>::data_store_t<float_type, storage_info_ij_t> storage_type;
+typedef storage_traits<target::x86>::storage_info_t<0, 2> storage_info_ij_t;
+typedef storage_traits<target::x86>::data_store_t<float_type, storage_info_ij_t> storage_type;
 
 typedef arg<0, storage_type> p_in;
 typedef arg<2, storage_type> p_out;
@@ -114,7 +114,7 @@ TEST(cache_metafunctions, extract_ij_extents_for_caches) {
     typedef typename boost::mpl::
         fold<extents_t, extent<0, 0, 0, 0>, enclosing_extent_2<boost::mpl::_1, boost::mpl::_2>>::type max_extent_t;
 
-    typedef iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         local_domain_t,
         esf_sequence_t,
         extents_t,
@@ -142,7 +142,7 @@ TEST(cache_metafunctions, extract_k_extents_for_caches) {
     typedef typename boost::mpl::
         fold<extents_t, extent<0, 0, 0, 0>, enclosing_extent_2<boost::mpl::_1, boost::mpl::_2>>::type max_extent_t;
 
-    typedef iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         local_domain_t,
         esfk_sequence_t,
         extents_t,
@@ -171,7 +171,7 @@ TEST(cache_metafunctions, get_ij_cache_storage_tuple) {
 
     typedef gridtools::interval<level_t<0, -2>, level_t<1, 1>> axis;
 
-    typedef iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         local_domain_t,
         esf_sequence_t,
         extents_t,
@@ -206,7 +206,7 @@ TEST(cache_metafunctions, get_k_cache_storage_tuple) {
     typedef typename boost::mpl::
         fold<extents_t, extent<0, 0, 0, 0>, enclosing_extent_2<boost::mpl::_1, boost::mpl::_2>>::type max_extent_t;
 
-    typedef iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         local_domain_t,
         esfk_sequence_t,
         extents_t,

--- a/unit_tests/stencil-composition/icosahedral_grids/test_make_computation.cpp
+++ b/unit_tests/stencil-composition/icosahedral_grids/test_make_computation.cpp
@@ -57,7 +57,7 @@ namespace make_computation_test {
     using level_t = level<Splitter, Offset, level_offset_limit>;
 
     typedef gridtools::interval<level_t<0, -1>, level_t<1, -1>> axis;
-    using backend_t = backend<platform::x86, grid_type::icosahedral, strategy::block>;
+    using backend_t = backend<target::x86, grid_type::icosahedral, strategy::block>;
     using icosahedral_topology_t = gridtools::icosahedral_topology<backend_t>;
 
     struct test_functor {

--- a/unit_tests/stencil-composition/structured_grids/test_check_grid_against_fields.cpp
+++ b/unit_tests/stencil-composition/structured_grids/test_check_grid_against_fields.cpp
@@ -63,13 +63,13 @@ namespace gridtools {
      */
     bool do_test(uint_t x, uint_t y, uint_t z, uint_t gx, uint_t gy, uint_t gz) {
 
-        using storage_info_t = storage_traits<platform::x86>::storage_info_t<0, 3, halo<2, 2, 0>>;
+        using storage_info_t = storage_traits<target::x86>::storage_info_t<0, 3, halo<2, 2, 0>>;
 
         halo_descriptor di = {0, 0, 0, gx - 1, gx};
         halo_descriptor dj = {0, 0, 0, gy - 1, gy};
 
         auto grid = make_grid(di, dj, gz);
-        auto testee = storage_info_fits_grid<backend_ids<platform::x86, grid_type::structured, strategy::block>>(grid);
+        auto testee = storage_info_fits_grid<backend_ids<target::x86, grid_type::structured, strategy::block>>(grid);
 
         return testee(storage_info_t{x + 3, y, z}) && testee(storage_info_t{x, y + 2, z}) &&
                testee(storage_info_t{x, y, z + 1});

--- a/unit_tests/stencil-composition/structured_grids/test_iterate_domain.cpp
+++ b/unit_tests/stencil-composition/structured_grids/test_iterate_domain.cpp
@@ -103,14 +103,14 @@ namespace gridtools {
 
             auto mss_ = gridtools::make_multistage // mss_descriptor
                 (enumtype::execute<enumtype::forward>(), gridtools::make_stage<dummy_functor>(p_in, p_buff, p_out));
-            auto computation_ = make_computation<gridtools::backend<platform::x86, GRIDBACKEND, strategy::naive>>(
+            auto computation_ = make_computation<gridtools::backend<target::x86, GRIDBACKEND, strategy::naive>>(
                 grid, p_in = in, p_buff = buff, p_out = out, mss_);
             auto local_domain1 = std::get<0>(computation_.local_domains());
 
             using esf_t = decltype(gridtools::make_stage<dummy_functor>(p_in, p_buff, p_out));
 
             using iterate_domain_arguments_t =
-                iterate_domain_arguments<backend_ids<platform::x86, GRIDBACKEND, strategy::naive>,
+                iterate_domain_arguments<backend_ids<target::x86, GRIDBACKEND, strategy::naive>,
                     decltype(local_domain1),
                     boost::mpl::vector1<esf_t>,
                     boost::mpl::vector1<extent<>>,

--- a/unit_tests/stencil-composition/structured_grids/test_iterate_domain.cu
+++ b/unit_tests/stencil-composition/structured_grids/test_iterate_domain.cu
@@ -52,7 +52,7 @@ namespace test_iterate_domain {
     typedef layout_map<0, 1, 2> layout_kji_t;
     typedef layout_map<0, 1> layout_ij_t;
 
-    typedef gridtools::backend<platform::cuda, grid_type::structured, strategy::block> backend_t;
+    typedef gridtools::backend<target::cuda, grid_type::structured, strategy::block> backend_t;
     typedef gridtools::cuda_storage_info<0, layout_ijk_t> meta_ijk_t;
     typedef gridtools::cuda_storage_info<0, layout_kji_t> meta_kji_t;
     typedef gridtools::cuda_storage_info<0, layout_ij_t> meta_ij_t;
@@ -141,7 +141,7 @@ TEST(test_iterate_domain, accessor_metafunctions) {
         p_shared_mem_arg(),
         p_kcache_arg())) esf_t;
 
-    typedef iterate_domain_cuda<iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_cuda<iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         decay_t<decltype(std::get<0>(computation_.local_domains()))>,
         boost::mpl::vector1<esf_t>,
         boost::mpl::vector1<extent<0, 0, 0, 0>>,

--- a/unit_tests/stencil-composition/structured_grids/test_iterate_domain_cache.cu
+++ b/unit_tests/stencil-composition/structured_grids/test_iterate_domain_cache.cu
@@ -56,8 +56,8 @@ using krange1 = axis_t::get_interval<0>;
 using krange2 = axis_t::get_interval<1>::modify<0, -1>;
 using kmaximum = axis_t::full_interval::last_level;
 
-typedef storage_traits<platform::x86>::storage_info_t<0, 2> storage_info_ij_t;
-typedef storage_traits<platform::x86>::data_store_t<float_type, storage_info_ij_t> storage_type;
+typedef storage_traits<target::x86>::storage_info_t<0, 2> storage_info_ij_t;
+typedef storage_traits<target::x86>::data_store_t<float_type, storage_info_ij_t> storage_type;
 
 typedef arg<0, storage_type> p_in1;
 typedef arg<1, storage_type> p_in2;
@@ -120,7 +120,7 @@ TEST(iterate_domain_cache, flush) {
     typedef typename boost::mpl::
         fold<extents_t, extent<0, 0, 0, 0>, enclosing_extent_2<boost::mpl::_1, boost::mpl::_2>>::type max_extent_t;
 
-    typedef iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         local_domain_t,
         esfk_sequence_t,
         extents_t,
@@ -158,7 +158,7 @@ TEST(iterate_domain_cache, fill) {
     typedef typename boost::mpl::
         fold<extents_t, extent<0, 0, 0, 0>, enclosing_extent_2<boost::mpl::_1, boost::mpl::_2>>::type max_extent_t;
 
-    typedef iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         local_domain_t,
         esfk_sequence_t,
         extents_t,
@@ -195,7 +195,7 @@ TEST(iterate_domain_cache, epflush) {
 
     typedef boost::mpl::vector5<cachef1_t, cachef2_t, cachef3_t, cachef4_t, cachef5_t> cachesf_t;
 
-    typedef iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         local_domain_t,
         esfk_sequence_t,
         extents_t,
@@ -237,7 +237,7 @@ TEST(iterate_domain_cache, bpfill) {
     typedef typename boost::mpl::
         fold<extents_t, extent<0, 0, 0, 0>, enclosing_extent_2<boost::mpl::_1, boost::mpl::_2>>::type max_extent_t;
 
-    typedef iterate_domain_arguments<backend_ids<platform::cuda, GRIDBACKEND, strategy::block>,
+    typedef iterate_domain_arguments<backend_ids<target::cuda, GRIDBACKEND, strategy::block>,
         local_domain_t,
         esfk_sequence_t,
         extents_t,

--- a/unit_tests/stencil-composition/structured_grids/test_local_domain.cpp
+++ b/unit_tests/stencil-composition/structured_grids/test_local_domain.cpp
@@ -73,7 +73,7 @@ struct dummy_functor {
     GT_FUNCTION static void Do(Evaluation &eval);
 };
 
-typedef backend<platform::x86, GRIDBACKEND, strategy::naive> backend_t;
+typedef backend<target::x86, GRIDBACKEND, strategy::naive> backend_t;
 typedef layout_map<2, 1, 0> layout_ijk_t;
 typedef layout_map<0, 1, 2> layout_kji_t;
 typedef host_storage_info<0, layout_ijk_t> meta_ijk_t;
@@ -86,7 +86,7 @@ typedef arg<1, storage_buff_t> p_buff;
 typedef arg<2, storage_t> p_out;
 
 typedef intermediate<false,
-    backend<platform::x86, GRIDBACKEND, strategy::naive>,
+    backend<target::x86, GRIDBACKEND, strategy::naive>,
     grid<axis<1>::axis_interval_t>,
     std::tuple<>,
     std::tuple<decltype(make_multistage // mss_descriptor

--- a/unit_tests/stencil-composition/structured_grids/test_stage_with_extents.cpp
+++ b/unit_tests/stencil-composition/structured_grids/test_stage_with_extents.cpp
@@ -68,7 +68,7 @@ namespace test_iterate_domain {
 
 TEST(testdomain, iterate_domain_with_extents) {
     using namespace test_iterate_domain;
-    typedef backend<platform::x86, grid_type::structured, strategy::naive> backend_t;
+    typedef backend<target::x86, grid_type::structured, strategy::naive> backend_t;
 
     typedef storage_traits<backend_t::backend_id_t>::storage_info_t<0, 3> storage_info_t;
     typedef storage_traits<backend_t::backend_id_t>::data_store_t<float_type, storage_info_t> data_store_t;
@@ -83,7 +83,7 @@ TEST(testdomain, iterate_domain_with_extents) {
     {
         auto mss_ = make_multistage(enumtype::execute<enumtype::forward>(),
             make_stage_with_extent<stage1, extent<0, 1, 0, 0>>(p_in(), p_out()));
-        auto computation_ = make_computation<backend<platform::x86, GRIDBACKEND, strategy::naive>>(grid, mss_);
+        auto computation_ = make_computation<backend<target::x86, GRIDBACKEND, strategy::naive>>(grid, mss_);
 
         typedef decltype(computation_) intermediate_t;
         static_assert(
@@ -93,7 +93,7 @@ TEST(testdomain, iterate_domain_with_extents) {
         auto mss_ = make_multistage(enumtype::execute<enumtype::forward>(),
             make_stage_with_extent<stage1, extent<0, 1, 0, 0>>(p_in(), p_out()),
             make_stage_with_extent<stage2, extent<0, 1, -1, 2>>(p_out(), p_in()));
-        auto computation_ = make_computation<backend<platform::x86, GRIDBACKEND, strategy::naive>>(grid, mss_);
+        auto computation_ = make_computation<backend<target::x86, GRIDBACKEND, strategy::naive>>(grid, mss_);
 
         typedef decltype(computation_) intermediate_t;
         static_assert(
@@ -108,7 +108,7 @@ TEST(testdomain, iterate_domain_with_extents) {
             make_stage_with_extent<stage1, extent<-2, 1, 0, 0>>(p_in(), p_out()),
             make_stage_with_extent<stage2, extent<-2, 1, -1, 2>>(p_out(), p_in()));
 
-        auto computation_ = make_computation<backend<platform::x86, GRIDBACKEND, strategy::naive>>(grid, mss1_, mss2_);
+        auto computation_ = make_computation<backend<target::x86, GRIDBACKEND, strategy::naive>>(grid, mss1_, mss2_);
 
         typedef decltype(computation_) intermediate_t;
         static_assert(
@@ -123,7 +123,7 @@ TEST(testdomain, iterate_domain_with_extents) {
             make_stage_with_extent<stage1, extent<-2, 1, 0, 0>>(p_in(), p_out()),
             make_stage_with_extent<stage2, extent<-2, 1, -1, 2>>(p_out(), p_in()));
 
-        auto computation_ = make_computation<backend<platform::x86, GRIDBACKEND, strategy::naive>>(grid, mss1_, mss2_);
+        auto computation_ = make_computation<backend<target::x86, GRIDBACKEND, strategy::naive>>(grid, mss1_, mss2_);
 
         typedef decltype(computation_) intermediate_t;
         static_assert(

--- a/unit_tests/stencil-composition/structured_grids/test_stress_dimensions.cpp
+++ b/unit_tests/stencil-composition/structured_grids/test_stress_dimensions.cpp
@@ -45,14 +45,13 @@ using namespace gridtools;
 using namespace enumtype;
 using namespace expressions;
 
-using layout_map_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, platform::x86>::value,
+using layout_map_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, target::x86>::value,
     layout_map<3, 4, 5, 0, 1, 2>,
     layout_map<5, 4, 3, 2, 1, 0>>::type;
-using layout_map_global_quad_t =
-    typename boost::conditional<std::is_same<backend_t::backend_id_t, platform::x86>::value,
-        layout_map<1, 2, 3, 0>,
-        layout_map<3, 2, 1, 0>>::type;
-using layout_map_local_quad_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, platform::x86>::value,
+using layout_map_global_quad_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, target::x86>::value,
+    layout_map<1, 2, 3, 0>,
+    layout_map<3, 2, 1, 0>>::type;
+using layout_map_local_quad_t = typename boost::conditional<std::is_same<backend_t::backend_id_t, target::x86>::value,
     layout_map<-1, -1, -1, 1, 2, 3, 0>,
     layout_map<-1, -1, -1, 3, 2, 1, 0>>::type;
 

--- a/unit_tests/storage/storage_cuda/test_alignment_inner_region.cu
+++ b/unit_tests/storage/storage_cuda/test_alignment_inner_region.cu
@@ -60,7 +60,7 @@ void run() {
     constexpr gt::uint_t h2 = 4;
     constexpr gt::uint_t h3 = 5;
     using info = gt::cuda_storage_info<0, Layout, gt::halo<h1, h2, h3>, gt::alignment<a>>;
-    using store = gt::storage_traits<gridtools::platform::cuda>::data_store_t<ValueType, info>;
+    using store = gt::storage_traits<gridtools::target::cuda>::data_store_t<ValueType, info>;
 
     info i(23, 34, 12);
     store s(i);

--- a/unit_tests/storage/storage_host/test_alignment_inner_region.cpp
+++ b/unit_tests/storage/storage_host/test_alignment_inner_region.cpp
@@ -52,7 +52,7 @@ void run() {
     constexpr gt::uint_t h2 = 4;
     constexpr gt::uint_t h3 = 5;
     using info = gt::host_storage_info<0, Layout, gt::halo<h1, h2, h3>, gt::alignment<a>>;
-    using store = gt::storage_traits<gridtools::platform::x86>::data_store_t<ValueType, info>;
+    using store = gt::storage_traits<gridtools::target::x86>::data_store_t<ValueType, info>;
 
     info i(12, 34, 12);
     store s(i);
@@ -76,7 +76,7 @@ void run_multi() {
     constexpr gt::uint_t h2 = 4;
     constexpr gt::uint_t h3 = 5;
     using info = gt::host_storage_info<0, Layout, gt::halo<h1, h2, h3>, gt::alignment<a>>;
-    using store = gt::storage_traits<gridtools::platform::x86>::data_store_t<ValueType, info>;
+    using store = gt::storage_traits<gridtools::target::x86>::data_store_t<ValueType, info>;
 
     info i(10, 10, 12);
     store s(i, (ValueType)1, "name");

--- a/unit_tests/storage/test_storage_facility.cpp
+++ b/unit_tests/storage/test_storage_facility.cpp
@@ -54,8 +54,8 @@ struct static_type_tests {
 #ifdef __CUDACC__
 // static type tests for Cuda backend
 template <class GridBackend, class Strategy>
-struct static_type_tests<backend<platform::cuda, GridBackend, Strategy>> {
-    using storage_traits_t = storage_traits<platform::cuda>;
+struct static_type_tests<backend<target::cuda, GridBackend, Strategy>> {
+    using storage_traits_t = storage_traits<target::cuda>;
 
     /*########## STORAGE INFO CHECKS ########## */
     // storage info check
@@ -97,8 +97,8 @@ struct static_type_tests<backend<platform::cuda, GridBackend, Strategy>> {
 
 // static type tests for Mic backend
 template <class GridBackend, class Strategy>
-struct static_type_tests<backend<platform::mc, GridBackend, Strategy>> {
-    using storage_traits_t = storage_traits<platform::mc>;
+struct static_type_tests<backend<target::mc, GridBackend, Strategy>> {
+    using storage_traits_t = storage_traits<target::mc>;
 
     /*########## STORAGE INFO CHECKS ########## */
     // storage info check
@@ -151,8 +151,8 @@ struct static_type_tests<backend<platform::mc, GridBackend, Strategy>> {
 
 // static type tests for Host backend
 template <class GridBackend, class Strategy>
-struct static_type_tests<backend<platform::x86, GridBackend, Strategy>> {
-    using storage_traits_t = storage_traits<platform::x86>;
+struct static_type_tests<backend<target::x86, GridBackend, Strategy>> {
+    using storage_traits_t = storage_traits<target::x86>;
 
     /*########## STORAGE INFO CHECKS ########## */
     // storage info check
@@ -546,23 +546,22 @@ struct static_layout_tests {
 
 #ifdef __CUDACC__
 template <class GridBackend, class Strategy>
-struct static_layout_tests<backend<platform::cuda, GridBackend, Strategy>>
-    : static_layout_tests_decreasing<platform::cuda> {};
+struct static_layout_tests<backend<target::cuda, GridBackend, Strategy>>
+    : static_layout_tests_decreasing<target::cuda> {};
 #endif
 
 #ifdef STRUCTURED_GRIDS
 template <class GridBackend, class Strategy>
-struct static_layout_tests<backend<platform::mc, GridBackend, Strategy>>
-    : static_layout_tests_decreasing_swappedxy<platform::mc> {};
+struct static_layout_tests<backend<target::mc, GridBackend, Strategy>>
+    : static_layout_tests_decreasing_swappedxy<target::mc> {};
 #else
 template <class GridBackend, class Strategy>
-struct static_layout_tests<backend<platform::mc, GridBackend, Strategy>>
-    : static_layout_tests_increasing<platform::mc> {};
+struct static_layout_tests<backend<target::mc, GridBackend, Strategy>> : static_layout_tests_increasing<target::mc> {};
 #endif
 
 template <class GridBackend, class Strategy>
-struct static_layout_tests<backend<platform::x86, GridBackend, Strategy>>
-    : static_layout_tests_increasing<platform::x86> {};
+struct static_layout_tests<backend<target::x86, GridBackend, Strategy>> : static_layout_tests_increasing<target::x86> {
+};
 
 template class static_layout_tests<backend_t>;
 

--- a/unit_tests/storage/test_storage_facility.cu
+++ b/unit_tests/storage/test_storage_facility.cu
@@ -38,11 +38,11 @@
 
 TEST(StorageFacility, TestInCudaFile) {
     // just a small test that instantiates storage_info_t, data_store_t, and data_store_field_t
-    typedef gridtools::storage_traits<gridtools::platform::cuda>::storage_info_t<0, 1> storage_info_ty;
+    typedef gridtools::storage_traits<gridtools::target::cuda>::storage_info_t<0, 1> storage_info_ty;
     storage_info_ty a(3);
-    typedef gridtools::storage_traits<gridtools::platform::cuda>::data_store_t<double, storage_info_ty> data_store_t;
+    typedef gridtools::storage_traits<gridtools::target::cuda>::data_store_t<double, storage_info_ty> data_store_t;
     data_store_t b(a);
-    typedef gridtools::storage_traits<gridtools::platform::cuda>::data_store_field_t<double, storage_info_ty, 2>
+    typedef gridtools::storage_traits<gridtools::target::cuda>::data_store_field_t<double, storage_info_ty, 2>
         data_store_field_t;
     data_store_field_t c(a);
 }


### PR DESCRIPTION
Description: Former `platform` is now called `target`.