### PR TITLE
Daint: back to CUDA 9.1 in perftests

### DIFF
--- a/pyutils/perftest/config/daint_common.py
+++ b/pyutils/perftest/config/daint_common.py
@@ -6,7 +6,7 @@ import os
 from perftest.config import default
 
 modules = default.modules | {'daint-gpu',
-                             'cudatoolkit/9.2.148_3.19-6.0.7.1_2.1__g3d9acc8',
+                             'cudatoolkit/9.1.85_3.18-6.0.7.0_5.1__g2eb7c52',
                              '/users/jenkins/easybuild/daint/haswell/modules/all/CMake/3.12.4'}
 
 env = dict(default.env,


### PR DESCRIPTION
Description: Back to CUDA 9.1 as horizontal diffusion fused has a huge performance degradation with CUDA 9.2. Tests are still compiled with CUDA 9.2.