### PR TITLE
Remove Version in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12.4)
 
 cmake_policy(SET CMP0048 NEW)
-project(GridTools VERSION 0.0.0 LANGUAGES CXX)
+project(GridTools VERSION 1.0.0 LANGUAGES CXX)
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 


### PR DESCRIPTION
Setting the version should be part of the release procedure. Otherwise, the master is always considered to be compatible with the most recently released version, which of course is not the case.

Currently, a problem arises when installing master and "version 0.1.8.2" (the latest release), because the dycore will look for version 0.1.8.2 and considers master as a viable match.