### PR TITLE
New versioning scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12.4)
 
 cmake_policy(SET CMP0048 NEW)
-project(GridTools VERSION "0.1.8.2" LANGUAGES CXX)
+project(GridTools VERSION 0.19.0 LANGUAGES CXX)
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 

--- a/cmake/export.cmake
+++ b/cmake/export.cmake
@@ -13,7 +13,7 @@ configure_package_config_file(cmake/GridToolsConfig.cmake.in
   INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
 write_basic_package_version_file(
   ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/install/GridToolsConfigVersion.cmake
-  COMPATIBILITY SameMajorVersion )
+  COMPATIBILITY SameMinorVersion )
 # for build tree
 set(GRIDTOOLS_MODULE_PATH ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/build-install/lib/cmake)
 set(GRIDTOOLS_SOURCES_PATH ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/build-install/src)
@@ -24,7 +24,7 @@ configure_package_config_file(cmake/GridToolsConfig.cmake.in
   INSTALL_DESTINATION ${PROJECT_BINARY_DIR})
 write_basic_package_version_file(
   ${PROJECT_BINARY_DIR}/GridToolsConfigVersion.cmake
-  COMPATIBILITY SameMajorVersion )
+  COMPATIBILITY SameMinorVersion )
 
 install(TARGETS gridtools EXPORT GridToolsTargets
   LIBRARY DESTINATION lib
@@ -87,8 +87,8 @@ if(COMPONENT_C_BINDINGS)
     install(FILES ${CMAKE_SOURCES} DESTINATION "lib/cmake")
     install(FILES ${CBINDINGS_SOURCES} DESTINATION "src/c_bindings")
 
-    install(FILES ${CMAKE_SOURCES} DESTINATION "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/build-install/lib/cmake")
-    install(FILES ${CBINDINGS_SOURCES} DESTINATION "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/build-install/src/c_bindings")
+    file(COPY ${CMAKE_SOURCES} DESTINATION "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/build-install/lib/cmake")
+    file(COPY ${CBINDINGS_SOURCES} DESTINATION "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/build-install/src/c_bindings")
 endif()
 
 if ( GT_INSTALL_EXAMPLES )


### PR DESCRIPTION
The following will be our new release and versioning scheme:
Version number: X.Y.Z
- X: Major version will be 0 until the public release, then it will be 1, probably until a new major feature, e.g. complete icgrid.
- Y: Minor version will be increased after every API change and new smaller features, probably very often.
- Z: Patch version will be increased for bug fixes.

After each minor release we will make a release branch. The master will then point to the next minor release. In the release branch we can still cherry-pick bugfixes from the master and make a patch release.

The CMake version matching is changed in this release to `COMPATIBILITY SameMinorVersion` which means the following: Let's say the user requires `find_package(GridTools 0.18.2)`. Then `0.18.3` (a newer patch release) will be compatible; `0.18.1` (an older than requested release) and `0.19.0` (a newer minor release) will be rejected.