### PR TITLE
Doc: update lexer with in_accessor/inout_accessor

### DIFF
--- a/docs/manuals/gridtools_lexer.py
+++ b/docs/manuals/gridtools_lexer.py
@@ -4,6 +4,8 @@ from pygments.lexers.c_cpp import CppLexer
 
 gridtools_keywords = ((
         'accessor',
+        'in_accessor',
+        'inout_accessor',
         'aggregator_type',
         'arg',
         'tmp_arg',
@@ -27,8 +29,6 @@ gridtools_keywords = ((
         'grid',
         'icosahedral_topology',
         'IJ',
-        'in',
-        'inout',
         'interval',
         'K',
         'layout_map',


### PR DESCRIPTION
Description: I think highlighting `in` is not a good idea as it is too general. E.g. in the getting started `in` is used for a variable. Instead most user codes will use `in_accessor` and `inout_accessor` anyway.