### PR TITLE
Fix for Issue #747 (Error on Missing Backend in make_computation)

### DIFF
--- a/include/gridtools/stencil-composition/make_computation.hpp
+++ b/include/gridtools/stencil-composition/make_computation.hpp
@@ -43,6 +43,7 @@
 #include "../meta/defs.hpp"
 #include "../meta/transform.hpp"
 #include "../meta/type_traits.hpp"
+#include "computation.hpp"
 #include "expandable_parameters/expand_factor.hpp"
 #include "expandable_parameters/intermediate_expand.hpp"
 #include "grid.hpp"


### PR DESCRIPTION
When no backend is specified in a call to make_computation, the following message is displayed:
`GRIDTOOLS ERROR=> No backend was specified on a call to make_computation`
Fixes #747 