### PR TITLE
Fix for Issue #735 (Argument Type Check of make_multistage)

### DIFF
--- a/include/gridtools/stencil-composition/make_stencils.hpp
+++ b/include/gridtools/stencil-composition/make_stencils.hpp
@@ -86,6 +86,7 @@ namespace gridtools {
      */
     template <typename ExecutionEngine,
         typename... MssParameters,
+        // Check argument types before mss_descriptor is instantiated to get nicer error messages
         bool ArgsOk = _impl::check_make_multistage_args<ExecutionEngine, MssParameters...>::value>
     mss_descriptor<ExecutionEngine,
         GT_META_CALL(extract_mss_esfs, (MssParameters...)),


### PR DESCRIPTION
User-friendly static assertions in make_multistage have never been triggered due to earlier evaluation of internal assertions in the construction of the return type. Fixes #735 