### PR TITLE
Performance Unrelated Changes from Sid Strides PR

### DIFF
--- a/include/gridtools/common/array.hpp
+++ b/include/gridtools/common/array.hpp
@@ -16,11 +16,33 @@
 #include <iterator>
 #include <type_traits>
 
+#include "../meta/id.hpp"
+#include "../meta/macros.hpp"
+#include "../meta/repeat.hpp"
 #include "defs.hpp"
+#include "generic_metafunctions/utility.hpp"
 #include "gt_assert.hpp"
 #include "host_device.hpp"
 
 namespace gridtools {
+
+    template <typename T, size_t D>
+    class array;
+
+    namespace array_impl_ {
+        template <class... Ts>
+        struct deduce_array_type : std::common_type<Ts...> {};
+
+        template <>
+        struct deduce_array_type<> {
+            using type = meta::lazy::id<void>;
+        };
+
+        struct from_types_f {
+            template <class... Ts>
+            GT_META_DEFINE_ALIAS(apply, meta::id, (array<typename deduce_array_type<Ts...>::type, sizeof...(Ts)>));
+        };
+    } // namespace array_impl_
 
     /** \defgroup common Common Shared Utilities
         @{
@@ -30,9 +52,6 @@ namespace gridtools {
         @{
     */
 
-    template <typename T>
-    struct is_array;
-
     /** \brief A class equivalent to std::array but enabled for GridTools use
 
         \tparam T Value type of the array
@@ -41,6 +60,30 @@ namespace gridtools {
     template <typename T, size_t D>
     class array {
         using type = array;
+
+        struct getter {
+            template <size_t I>
+            static GT_FUNCTION constexpr T &get(array &arr) noexcept {
+                GT_STATIC_ASSERT(I < D, "index is out of bounds");
+                return arr.m_array[I];
+            }
+
+            template <size_t I>
+            static GT_FUNCTION constexpr const T &get(const array &arr) noexcept {
+                GT_STATIC_ASSERT(I < D, "index is out of bounds");
+                return arr.m_array[I];
+            }
+
+            template <size_t I>
+            static GT_FUNCTION constexpr T &&get(array &&arr) noexcept {
+                GT_STATIC_ASSERT(I < D, "index is out of bounds");
+                return const_expr::move(arr.m_array[I]);
+            }
+        };
+
+        friend GT_META_CALL(meta::repeat_c, (D, T)) tuple_to_types(array const &) { return {}; }
+        friend array_impl_::from_types_f tuple_from_types(array const &) { return {}; }
+        friend getter tuple_getter(array const &) { return {}; }
 
       public:
         // we make the members public to make this class an aggregate

--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -92,11 +92,6 @@ namespace gridtools {
 } // namespace gridtools
 #endif
 
-// macro defining empty copy constructors and assignment operators
-#define GT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
-    TypeName(const TypeName &);               \
-    TypeName &operator=(const TypeName &)
-
 // check boost::optional workaround for CUDA9.2
 #if (defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2)
 #if (not defined(BOOST_OPTIONAL_CONFIG_USE_OLD_IMPLEMENTATION_OF_OPTIONAL) || \

--- a/include/gridtools/common/integral_constant.hpp
+++ b/include/gridtools/common/integral_constant.hpp
@@ -80,7 +80,7 @@ namespace gridtools {
 #undef GT_INTEGRAL_CONSTANT_OPERATOR_RESULT_TYPE
 
     namespace literals {
-        namespace impl_ {
+        namespace literals_impl_ {
 
             using literal_int_t = int;
 
@@ -135,10 +135,11 @@ namespace gridtools {
 
             template <char... Chars>
             struct parser<'0', 'b', Chars...> : digits_parser<2, Chars...> {};
-        } // namespace impl_
+        } // namespace literals_impl_
 
         template <char... Chars>
-        constexpr GT_FUNCTION integral_constant<impl_::literal_int_t, impl_::parser<Chars...>::value> operator"" _c() {
+        constexpr GT_FUNCTION integral_constant<literals_impl_::literal_int_t, literals_impl_::parser<Chars...>::value>
+        operator"" _c() {
             return {};
         }
     } // namespace literals

--- a/include/gridtools/common/pair.hpp
+++ b/include/gridtools/common/pair.hpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "defs.hpp"
+#include "generic_metafunctions/utility.hpp"
 #include "host_device.hpp"
 
 namespace gridtools {
@@ -124,7 +125,7 @@ namespace gridtools {
         using type = T2;
     };
 
-    namespace impl_ {
+    namespace pair_impl_ {
         template <size_t I>
         struct pair_get;
 
@@ -155,19 +156,35 @@ namespace gridtools {
             }
             template <typename T1, typename T2>
             static constexpr GT_FUNCTION T2 &&move_get(pair<T1, T2> &&p) noexcept {
-                return std::move(p.second);
+                return const_expr::move(p.second);
             }
         };
-    } // namespace impl_
+
+        struct getter {
+            template <size_t I, class T1, class T2>
+            static constexpr GT_FUNCTION auto get(pair<T1, T2> &p) noexcept GT_AUTO_RETURN(pair_get<I>::get(p));
+
+            template <size_t I, class T1, class T2>
+            static constexpr GT_FUNCTION auto get(const pair<T1, T2> &p) noexcept GT_AUTO_RETURN(
+                pair_get<I>::const_get(p));
+
+            template <size_t I, class T1, class T2>
+            static constexpr GT_FUNCTION auto get(pair<T1, T2> &&p) noexcept GT_AUTO_RETURN(
+                pair_get<I>::move_get(std::move(p)));
+        };
+    } // namespace pair_impl_
 
     template <size_t I, class T1, class T2>
-    constexpr GT_FUNCTION auto get(pair<T1, T2> &p) noexcept GT_AUTO_RETURN(impl_::pair_get<I>::get(p));
+    constexpr GT_FUNCTION auto get(pair<T1, T2> &p) noexcept GT_AUTO_RETURN(pair_impl_::pair_get<I>::get(p));
 
     template <size_t I, class T1, class T2>
-    constexpr GT_FUNCTION auto get(const pair<T1, T2> &p) noexcept GT_AUTO_RETURN(impl_::pair_get<I>::const_get(p));
+    constexpr GT_FUNCTION auto get(const pair<T1, T2> &p) noexcept GT_AUTO_RETURN(
+        pair_impl_::pair_get<I>::const_get(p));
 
     template <size_t I, class T1, class T2>
     constexpr GT_FUNCTION auto get(pair<T1, T2> &&p) noexcept GT_AUTO_RETURN(
-        impl_::pair_get<I>::move_get(std::move(p)));
+        pair_impl_::pair_get<I>::move_get(std::move(p)));
 
+    template <class T1, class T2>
+    pair_impl_::getter tuple_getter(pair<T1, T2> const &);
 } // namespace gridtools

--- a/include/gridtools/common/tuple_util.hpp
+++ b/include/gridtools/common/tuple_util.hpp
@@ -107,13 +107,11 @@
 #include <utility>
 
 #include "../meta.hpp"
-#include "array.hpp"
 #include "defs.hpp"
 #include "functional.hpp"
 #include "generic_metafunctions/implicit_cast.hpp"
 #include "generic_metafunctions/utility.hpp"
 #include "host_device.hpp"
-#include "pair.hpp"
 
 #define GT_TUPLE_UTIL_FORWARD_CTORS_TO_MEMBER(class_name, member_name)                                              \
     template <class... Args, enable_if_t<std::is_constructible<decltype(member_name), Args &&...>::value, int> = 0> \
@@ -153,13 +151,12 @@ namespace gridtools {
                     using type = meta::lazy::id<void>;
                 };
 
-                /// implementation of the `from_types`  for `std::array` and its gridtools clone
+                /// implementation of the `from_types`  for `std::array`
                 //
-                template <template <class, size_t> class Arr>
                 struct array_from_types {
                     template <class... Ts>
                     GT_META_DEFINE_ALIAS(
-                        apply, meta::id, (Arr<typename deduce_array_type<Ts...>::type, sizeof...(Ts)>));
+                        apply, meta::id, (std::array<typename deduce_array_type<Ts...>::type, sizeof...(Ts)>));
                 };
 
                 /// getter for the standard "tuple like" entities: `std::tuple`, `std::pair` and `std::array`
@@ -168,14 +165,6 @@ namespace gridtools {
                     template <size_t I, class T>
                     GT_FORCE_INLINE static constexpr auto get(T &&obj) noexcept GT_AUTO_RETURN(
                         std::get<I>(const_expr::forward<T>(obj)));
-                };
-
-                /// getter for gridtools clones of the standard "tuple like" entities
-                //
-                struct gt_getter {
-                    template <size_t I, class T>
-                    GT_FUNCTION static constexpr auto get(T &&obj) noexcept GT_AUTO_RETURN(
-                        ::gridtools::get<I>(const_expr::forward<T>(obj)));
                 };
             } // namespace _impl
 
@@ -193,11 +182,6 @@ namespace gridtools {
             GT_META_CALL(meta::repeat_c, (N, T))
             tuple_to_types(std::array<T, N>);
 
-            // the same for the gridtools clone
-            template <class T, size_t N>
-            GT_META_CALL(meta::repeat_c, (N, T))
-            tuple_to_types(::gridtools::array<T, N>);
-
             // from_types
 
             // generic `tuple_from_types` that works for `std::tuple`, `std::pair` and its clones.
@@ -207,9 +191,7 @@ namespace gridtools {
 
             // arrays specialization.
             template <class T, size_t N>
-            _impl::array_from_types<std::array> tuple_from_types(std::array<T, N>);
-            template <class T, size_t N>
-            _impl::array_from_types<::gridtools::array> tuple_from_types(::gridtools::array<T, N>);
+            _impl::array_from_types tuple_from_types(std::array<T, N>);
 
             // getter
 
@@ -220,12 +202,6 @@ namespace gridtools {
             _impl::std_getter tuple_getter(std::pair<T, U>);
             template <class T, size_t N>
             _impl::std_getter tuple_getter(std::array<T, N>);
-
-            // gridtools stuff uses gridtools clone of `std::get`
-            template <class T, class U>
-            _impl::gt_getter tuple_getter(::gridtools::pair<T, U>);
-            template <class T, size_t N>
-            _impl::gt_getter tuple_getter(::gridtools::array<T, N>);
 
             // end of builtin adaptations
 

--- a/include/gridtools/stencil-composition/backend_base.hpp
+++ b/include/gridtools/stencil-composition/backend_base.hpp
@@ -76,7 +76,6 @@ namespace gridtools {
         - - (INTERFACE) execute_traits ?????? this was needed when backend_traits was forcely shared between x86 and
        cuda backends. Now they are separated and this may be simplified.
         - - (INTERNAL) for_each that is used to invoke the different things for different stencils in the MSS
-        - - (INTERNAL) once_per_block
     */
     template <class BackendId, class StrategyId>
     struct backend_base {
@@ -124,8 +123,6 @@ namespace gridtools {
             view(0) = new_val;
             gp.sync();
         }
-
-        using make_view_f = typename backend_traits_t::make_view_f;
 
         using mss_fuse_esfs_strategy = typename backend_traits_t::mss_fuse_esfs_strategy;
 

--- a/include/gridtools/stencil-composition/backend_cuda/backend_traits_cuda.hpp
+++ b/include/gridtools/stencil-composition/backend_cuda/backend_traits_cuda.hpp
@@ -13,7 +13,6 @@
 
 #include "../../common/defs.hpp"
 #include "../../common/timer/timer_traits.hpp"
-#include "../../storage/data_store.hpp"
 
 #include "../backend_traits_fwd.hpp"
 #include "../grid_traits_fwd.hpp"
@@ -27,15 +26,6 @@ namespace gridtools {
     /** @brief traits struct defining the types which are specific to the CUDA backend*/
     template <>
     struct backend_traits_from_id<target::cuda> {
-
-        /** This is the functor used to generate view instances. According to the given storage
-           an appropriate view is returned. When using the CUDA backend we return device view instances.
-        */
-        struct make_view_f {
-            template <typename S, typename SI>
-            auto operator()(data_store<S, SI> const &src) const GT_AUTO_RETURN(make_device_view(src));
-        };
-
         /**
            @brief assigns the two given values using the given thread Id whithin the block
         */

--- a/include/gridtools/stencil-composition/backend_mc/backend_traits_mc.hpp
+++ b/include/gridtools/stencil-composition/backend_mc/backend_traits_mc.hpp
@@ -24,15 +24,6 @@ namespace gridtools {
     /**Traits struct, containing the types which are specific for the mc backend*/
     template <>
     struct backend_traits_from_id<target::mc> {
-
-        /** This is the functor used to generate view instances. According to the given storage an appropriate view is
-         * returned. When using the Host backend we return host view instances.
-         */
-        struct make_view_f {
-            template <typename S, typename SI>
-            auto operator()(data_store<S, SI> const &src) const GT_AUTO_RETURN(make_host_view(src));
-        };
-
         template <uint_t Id>
         struct once_per_block {
             template <typename Left, typename Right>

--- a/include/gridtools/stencil-composition/backend_x86/backend_traits_x86.hpp
+++ b/include/gridtools/stencil-composition/backend_x86/backend_traits_x86.hpp
@@ -23,15 +23,6 @@ namespace gridtools {
     /**Traits struct, containing the types which are specific for the x86 backend*/
     template <>
     struct backend_traits_from_id<target::x86> {
-
-        /** This is the functor used to generate view instances. According to the given storage an appropriate view is
-         * returned. When using the X86 backend we return x86 view instances.
-         */
-        struct make_view_f {
-            template <typename S, typename SI>
-            auto operator()(data_store<S, SI> const &src) const GT_AUTO_RETURN(make_host_view(src));
-        };
-
         template <uint_t Id>
         struct once_per_block {
             template <typename Left, typename Right>

--- a/include/gridtools/stencil-composition/dim.hpp
+++ b/include/gridtools/stencil-composition/dim.hpp
@@ -1,0 +1,17 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2019, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#ifndef GT_ICOSAHEDRAL_GRIDS
+#include "./structured_grids/dim.hpp"
+#else
+#include "./icosahedral_grids/dim.hpp"
+#endif

--- a/include/gridtools/stencil-composition/esf_metafunctions.hpp
+++ b/include/gridtools/stencil-composition/esf_metafunctions.hpp
@@ -41,17 +41,6 @@ namespace gridtools {
     };
 
     /**
-       Given an ESF this metafunction provides the list of placeholders (if Pred derives
-       from false_type), or map between placeholders in this ESF and the extents
-       associated with it (if Pred derives from true_type)
-     */
-    template <typename Esf>
-    struct esf_args {
-        GT_STATIC_ASSERT((is_esf_descriptor<Esf>::value), "Wrong Type");
-        typedef typename Esf::args_t type;
-    };
-
-    /**
        Given an ESF this metafunction provides the placeholder (if Pred derives
        from false_type) at a given index in the list of placeholders, or mpl::pair of
        placeholder and extent (if Pred derives from true_type)

--- a/include/gridtools/stencil-composition/icosahedral_grids/dim.hpp
+++ b/include/gridtools/stencil-composition/icosahedral_grids/dim.hpp
@@ -1,0 +1,22 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2019, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#include "../../common/integral_constant.hpp"
+
+namespace gridtools {
+    namespace dim {
+        using i = integral_constant<int, 0>;
+        using c = integral_constant<int, 1>;
+        using j = integral_constant<int, 2>;
+        using k = integral_constant<int, 3>;
+    } // namespace dim
+} // namespace gridtools

--- a/include/gridtools/stencil-composition/sid/composite.hpp
+++ b/include/gridtools/stencil-composition/sid/composite.hpp
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include <cassert>
+
 #include "../../common/binops.hpp"
 #include "../../common/defs.hpp"
 #include "../../common/generic_metafunctions/for_each.hpp"

--- a/include/gridtools/stencil-composition/sid/concept.hpp
+++ b/include/gridtools/stencil-composition/sid/concept.hpp
@@ -404,8 +404,7 @@ namespace gridtools {
              *  noop `shift` overload
              */
             template <class T, class Stride, class Offset>
-            GT_FUNCTION enable_if_t<!need_shift<T, Stride, Offset>::value> shift(
-                T &, Stride const &stride, Offset const &) {}
+            GT_FUNCTION enable_if_t<!need_shift<T, Stride, Offset>::value> shift(T &, Stride const &, Offset const &) {}
 
             /**
              * `shift` overload that delegates to `sid_shift`
@@ -416,8 +415,7 @@ namespace gridtools {
                 class Stride,
                 class Offset,
                 enable_if_t<need_shift<T, Stride, Offset>::value && !is_default_shiftable<T, Stride>::value, int> = 0>
-            GT_FUNCTION auto shift(
-                T &GT_RESTRICT obj, Stride const &GT_RESTRICT stride, Offset const &GT_RESTRICT offset)
+            GT_FUNCTION auto shift(T &obj, Stride const &GT_RESTRICT stride, Offset const &GT_RESTRICT offset)
                 GT_AUTO_RETURN(sid_shift(obj, stride, offset));
 
             /**
@@ -465,7 +463,7 @@ namespace gridtools {
             template <class T, class Stride, class Offset>
             GT_FUNCTION enable_if_t<need_shift<T, Stride, Offset>::value && is_default_shiftable<T, Stride>::value &&
                                     !is_integral_constant<Stride>::value && is_integral_constant_of<Offset, 1>::value>
-            shift(T &GT_RESTRICT obj, Stride const &GT_RESTRICT stride, Offset const &) {
+            shift(T &obj, Stride const &GT_RESTRICT stride, Offset const &) {
                 obj += stride;
             }
 
@@ -476,7 +474,7 @@ namespace gridtools {
             GT_FUNCTION enable_if_t<need_shift<T, Stride, Offset>::value && is_default_shiftable<T, Stride>::value &&
                                     !is_integral_constant<Stride>::value &&
                                     is_integral_constant_of<Offset, -1>::value && has_dec_assignment<T, Stride>::value>
-            shift(T &GT_RESTRICT obj, Stride const &GT_RESTRICT stride, Offset const &) {
+            shift(T &obj, Stride const &GT_RESTRICT stride, Offset const &) {
                 obj -= stride;
             }
 
@@ -486,7 +484,7 @@ namespace gridtools {
             template <class T, class Stride, class Offset>
             GT_FUNCTION enable_if_t<need_shift<T, Stride, Offset>::value && is_default_shiftable<T, Stride>::value &&
                                     is_integral_constant_of<Stride, 1>::value && !is_integral_constant<Offset>::value>
-            shift(T &GT_RESTRICT obj, Stride const &GT_RESTRICT, Offset const &offset) {
+            shift(T &obj, Stride const &, Offset const &GT_RESTRICT offset) {
                 obj += offset;
             }
 
@@ -497,7 +495,7 @@ namespace gridtools {
             GT_FUNCTION enable_if_t<need_shift<T, Stride, Offset>::value && is_default_shiftable<T, Stride>::value &&
                                     is_integral_constant_of<Stride, -1>::value &&
                                     !is_integral_constant<Offset>::value && has_dec_assignment<T, Stride>::value>
-            shift(T &obj, Stride const &, Offset const &offset) {
+            shift(T &obj, Stride const &, Offset const &GT_RESTRICT offset) {
                 obj -= offset;
             }
 
@@ -511,7 +509,7 @@ namespace gridtools {
                             !(is_integral_constant_of<Stride, 1>::value || is_integral_constant_of<Offset, 1>::value) &&
                             !(has_dec_assignment<T, Stride>::value && (is_integral_constant_of<Stride, -1>::value ||
                                                                           is_integral_constant_of<Offset, -1>::value))>
-                shift(T &GT_RESTRICT obj, Stride const &GT_RESTRICT stride, Offset const &GT_RESTRICT offset) {
+                shift(T &obj, Stride const &GT_RESTRICT stride, Offset const &GT_RESTRICT offset) {
                 obj += stride * offset;
             }
 

--- a/include/gridtools/stencil-composition/structured_grids/dim.hpp
+++ b/include/gridtools/stencil-composition/structured_grids/dim.hpp
@@ -1,0 +1,21 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2019, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#include "../../common/integral_constant.hpp"
+
+namespace gridtools {
+    namespace dim {
+        using i = integral_constant<int, 0>;
+        using j = integral_constant<int, 1>;
+        using k = integral_constant<int, 2>;
+    } // namespace dim
+} // namespace gridtools

--- a/include/gridtools/storage/common/storage_interface.hpp
+++ b/include/gridtools/storage/common/storage_interface.hpp
@@ -85,16 +85,6 @@ namespace gridtools {
         void swap(storage_interface &other) { static_cast<Derived *>(this)->swap_impl(static_cast<Derived &>(other)); }
 
         /*
-         * @brief This method retrieves all pointers that are contained in the storage (in case of host_storage
-         * only one pointer, in case of cuda_storage two pointers).
-         * @return struct that contains the pointer(s)
-         */
-        template <typename T>
-        T get_ptrs() const {
-            return static_cast<Derived const *>(this)->get_ptrs_impl();
-        }
-
-        /*
          * @brief This method returns information about validity of the storage (e.g., no nullptrs, etc.).
          * @return true if the storage is valid, false otherwise
          */

--- a/include/gridtools/storage/data_store.hpp
+++ b/include/gridtools/storage/data_store.hpp
@@ -328,7 +328,7 @@ namespace gridtools {
          * @brief retrieve a pointer to the underlying storage instance.
          * @return shared pointer to the underlying storage instance
          */
-        std::shared_ptr<storage_t> get_storage_ptr() const { return m_shared_storage; }
+        std::shared_ptr<storage_t> const &get_storage_ptr() const { return m_shared_storage; }
 
         /**
          * @brief retrieve a pointer to the underlying storage_info instance.

--- a/include/gridtools/storage/sid.hpp
+++ b/include/gridtools/storage/sid.hpp
@@ -25,7 +25,6 @@
 #include "../meta/make_indices.hpp"
 #include "../meta/transform.hpp"
 #include "data_store.hpp"
-#include "storage-facility.hpp"
 
 namespace gridtools {
     namespace storage_sid_impl_ {
@@ -74,7 +73,6 @@ namespace gridtools {
             template <class Src>
             int_t operator()(Src const &src) {
                 assert(src[I::value] != 0);
-                assert(src[I::value] != 1);
                 return (int_t)src[I::value];
             }
         };
@@ -110,10 +108,12 @@ namespace gridtools {
             static impl_t const &impl();
 
             friend host_device::constant<typename Storage::data_t *> sid_get_origin(host_adapter const &obj) {
-                impl_t const &impl = obj.m_impl;
-                if (impl.host_needs_update())
-                    impl.sync();
-                return {advanced_get_raw_pointer_of(make_host_view(impl))};
+                auto &&storage_ptr = obj.m_impl.get_storage_ptr();
+                assert(storage_ptr);
+                if (storage_ptr->host_needs_update_impl())
+                    storage_ptr->sync();
+                storage_ptr->reactivate_host_write_views();
+                return {storage_ptr->get_cpu_ptr()};
             }
             friend decltype(sid_get_strides(impl())) sid_get_strides(host_adapter const &obj) {
                 return sid_get_strides(obj.m_impl);
@@ -131,9 +131,12 @@ namespace gridtools {
      */
     template <class Storage, class StorageInfo>
     host_device::constant<typename Storage::data_t *> sid_get_origin(data_store<Storage, StorageInfo> const &obj) {
-        if (obj.device_needs_update())
-            obj.sync();
-        return {advanced_get_raw_pointer_of(make_target_view(obj))};
+        auto &&storage_ptr = obj.get_storage_ptr();
+        assert(storage_ptr);
+        if (storage_ptr->device_needs_update_impl())
+            storage_ptr->sync();
+        storage_ptr->reactivate_device_write_views();
+        return {storage_ptr->get_target_ptr()};
     }
 
     template <class Storage, class StorageInfo>

--- a/include/gridtools/storage/storage_cuda/cuda_storage.hpp
+++ b/include/gridtools/storage/storage_cuda/cuda_storage.hpp
@@ -41,7 +41,6 @@ namespace gridtools {
     template <typename DataType>
     struct cuda_storage : storage_interface<cuda_storage<DataType>> {
         typedef DataType data_t;
-        typedef std::array<DataType *, 2> ptrs_t;
         typedef state_machine state_machine_t;
 
       private:
@@ -123,6 +122,11 @@ namespace gridtools {
             return m_gpu_ptr;
         }
 
+        DataType *get_target_ptr() const {
+            GT_ASSERT_OR_THROW(m_gpu_ptr, "This storage has never been initialized.");
+            return m_gpu_ptr;
+        }
+
         /*
          * @brief retrieve the host data pointer.
          * @return host pointer
@@ -183,7 +187,7 @@ namespace gridtools {
          */
         void reactivate_device_write_views_impl() {
             GT_ASSERT_OR_THROW(!m_state.m_dnu, "host views are in write mode");
-            m_state.m_hnu = 1;
+            m_state.m_hnu = true;
         }
 
         /*
@@ -191,18 +195,13 @@ namespace gridtools {
          */
         void reactivate_host_write_views_impl() {
             GT_ASSERT_OR_THROW(!m_state.m_hnu, "device views are in write mode");
-            m_state.m_dnu = 1;
+            m_state.m_dnu = true;
         }
 
         /*
          * @brief get_state_machine_ptr implementation for cuda_storage.
          */
         state_machine *get_state_machine_ptr_impl() { return &m_state; }
-
-        /*
-         * @brief get_ptrs implementation for cuda_storage.
-         */
-        ptrs_t get_ptrs_impl() const { return {m_cpu_ptr, m_gpu_ptr}; }
 
         /*
          * @brief valid implementation for cuda_storage.

--- a/include/gridtools/storage/storage_cuda/data_view_helpers.hpp
+++ b/include/gridtools/storage/storage_cuda/data_view_helpers.hpp
@@ -32,13 +32,14 @@ namespace gridtools {
      */
     template <access_mode AccessMode = access_mode::read_write,
         typename CudaDataStore,
-        typename DecayedCDS = decay_t<CudaDataStore>>
-    enable_if_t<is_cuda_storage<typename DecayedCDS::storage_t>::value &&
-                    is_storage_info<typename DecayedCDS::storage_info_t>::value && is_data_store<DecayedCDS>::value,
-        data_view<DecayedCDS, AccessMode>>
+        typename Res = data_view<CudaDataStore, AccessMode>>
+    enable_if_t<is_cuda_storage<typename CudaDataStore::storage_t>::value &&
+                    is_storage_info<typename CudaDataStore::storage_info_t>::value &&
+                    is_data_store<CudaDataStore>::value,
+        Res>
     make_host_view(CudaDataStore const &ds) {
         if (!ds.valid())
-            return data_view<DecayedCDS, AccessMode>();
+            return {};
 
         if (AccessMode != access_mode::read_only) {
             GT_ASSERT_OR_THROW(!ds.get_storage_ptr()->get_state_machine_ptr()->m_hnu,
@@ -47,10 +48,10 @@ namespace gridtools {
                 "before constructing the view.");
             ds.get_storage_ptr()->get_state_machine_ptr()->m_dnu = true;
         }
-        return data_view<DecayedCDS, AccessMode>(ds.get_storage_ptr()->get_cpu_ptr(),
+        return {ds.get_storage_ptr()->get_cpu_ptr(),
             ds.get_storage_info_ptr().get(),
             ds.get_storage_ptr()->get_state_machine_ptr(),
-            false);
+            false};
     }
 
     /**
@@ -61,13 +62,14 @@ namespace gridtools {
      */
     template <access_mode AccessMode = access_mode::read_write,
         typename CudaDataStore,
-        typename DecayedCDS = decay_t<CudaDataStore>>
-    enable_if_t<is_cuda_storage<typename DecayedCDS::storage_t>::value &&
-                    is_storage_info<typename DecayedCDS::storage_info_t>::value && is_data_store<DecayedCDS>::value,
-        data_view<DecayedCDS, AccessMode>>
+        typename Res = data_view<CudaDataStore, AccessMode>>
+    enable_if_t<is_cuda_storage<typename CudaDataStore::storage_t>::value &&
+                    is_storage_info<typename CudaDataStore::storage_info_t>::value &&
+                    is_data_store<CudaDataStore>::value,
+        Res>
     make_device_view(CudaDataStore const &ds) {
         if (!ds.valid())
-            return data_view<DecayedCDS, AccessMode>();
+            return {};
 
         if (AccessMode != access_mode::read_only) {
             GT_ASSERT_OR_THROW(!ds.get_storage_ptr()->get_state_machine_ptr()->m_dnu,
@@ -76,10 +78,10 @@ namespace gridtools {
                 "before constructing the view.");
             ds.get_storage_ptr()->get_state_machine_ptr()->m_hnu = true;
         }
-        return data_view<DecayedCDS, AccessMode>(ds.get_storage_ptr()->get_gpu_ptr(),
+        return {ds.get_storage_ptr()->get_gpu_ptr(),
             get_gpu_storage_info_ptr(*ds.get_storage_info_ptr()),
             ds.get_storage_ptr()->get_state_machine_ptr(),
-            true);
+            true};
     }
 
     /**
@@ -90,10 +92,11 @@ namespace gridtools {
      */
     template <access_mode AccessMode = access_mode::read_write,
         typename CudaDataStore,
-        typename DecayedCDS = decay_t<CudaDataStore>>
-    enable_if_t<is_cuda_storage<typename DecayedCDS::storage_t>::value &&
-                    is_storage_info<typename DecayedCDS::storage_info_t>::value && is_data_store<DecayedCDS>::value,
-        data_view<DecayedCDS, AccessMode>>
+        typename Res = data_view<CudaDataStore, AccessMode>>
+    enable_if_t<is_cuda_storage<typename CudaDataStore::storage_t>::value &&
+                    is_storage_info<typename CudaDataStore::storage_info_t>::value &&
+                    is_data_store<CudaDataStore>::value,
+        Res>
     make_target_view(CudaDataStore const &ds) {
         return make_device_view<AccessMode>(ds);
     }
@@ -104,34 +107,31 @@ namespace gridtools {
      * @param v data view
      * @return true if the given view is in a valid state and can be used safely.
      */
-    template <typename DataStore,
-        typename DataView,
-        typename DecayedDS = decay_t<DataStore>,
-        typename DecayedDV = decay_t<DataView>>
-    enable_if_t<is_cuda_storage<typename DecayedDS::storage_t>::value &&
-                    is_storage_info<typename DecayedDS::storage_info_t>::value && is_data_store<DecayedDS>::value,
+    template <typename DataStore, typename DataView>
+    enable_if_t<is_cuda_storage<typename DataStore::storage_t>::value &&
+                    is_storage_info<typename DataStore::storage_info_t>::value && is_data_store<DataStore>::value,
         bool>
     check_consistency(DataStore const &d, DataView const &v) {
-        GT_STATIC_ASSERT(is_data_view<DecayedDV>::value, "Passed type is no data_view type");
+        GT_STATIC_ASSERT(is_data_view<DataView>::value, "Passed type is no data_view type");
         // if the storage is not valid return false
         if (!d.valid())
             return false;
         // if ptrs do not match anymore return false
-        if ((advanced::get_raw_pointer_of(v) != d.get_storage_ptr()->get_gpu_ptr()) &&
-            (advanced::get_raw_pointer_of(v) != d.get_storage_ptr()->get_cpu_ptr()))
+        if (advanced::get_raw_pointer_of(v) != d.get_storage_ptr()->get_gpu_ptr() &&
+            advanced::get_raw_pointer_of(v) != d.get_storage_ptr()->get_cpu_ptr())
             return false;
         // check if we have a device view
-        const bool device_view = (advanced::get_raw_pointer_of(v) == d.get_storage_ptr()->get_cpu_ptr()) ? false : true;
+        bool device_view = advanced::get_raw_pointer_of(v) != d.get_storage_ptr()->get_cpu_ptr();
         // read-only? if yes, take early exit
-        if (DecayedDV::mode == access_mode::read_only)
+        if (DataView::mode == access_mode::read_only)
             return device_view ? !d.get_storage_ptr()->get_state_machine_ptr()->m_dnu
                                : !d.get_storage_ptr()->get_state_machine_ptr()->m_hnu;
         else
             // get storage state
-            return device_view ? ((d.get_storage_ptr()->get_state_machine_ptr()->m_hnu) &&
-                                     !(d.get_storage_ptr()->get_state_machine_ptr()->m_dnu))
-                               : (!(d.get_storage_ptr()->get_state_machine_ptr()->m_hnu) &&
-                                     (d.get_storage_ptr()->get_state_machine_ptr()->m_dnu));
+            return device_view ? d.get_storage_ptr()->get_state_machine_ptr()->m_hnu &&
+                                     !d.get_storage_ptr()->get_state_machine_ptr()->m_dnu
+                               : !d.get_storage_ptr()->get_state_machine_ptr()->m_hnu &&
+                                     d.get_storage_ptr()->get_state_machine_ptr()->m_dnu;
     }
 
     /**

--- a/include/gridtools/storage/storage_host/data_view_helpers.hpp
+++ b/include/gridtools/storage/storage_host/data_view_helpers.hpp
@@ -76,7 +76,7 @@ namespace gridtools {
     check_consistency(DataStore const &ds, DataView const &dv) {
         GT_STATIC_ASSERT(is_data_view<DecayedDV>::value, GT_INTERNAL_ERROR_MSG("Passed type is no data_view type"));
         return ds.valid() && advanced::get_raw_pointer_of(dv) == ds.get_storage_ptr()->get_cpu_ptr() &&
-               advanced::storage_info_raw_ptr(dv) && ds.get_storage_info_ptr().get();
+               ds.get_storage_info_ptr().get();
     }
 
     /**

--- a/include/gridtools/storage/storage_host/host_storage.hpp
+++ b/include/gridtools/storage/storage_host/host_storage.hpp
@@ -39,7 +39,6 @@ namespace gridtools {
     template <typename DataType>
     struct host_storage : storage_interface<host_storage<DataType>> {
         typedef DataType data_t;
-        typedef DataType *ptrs_t;
         typedef state_machine state_machine_t;
 
       private:
@@ -103,11 +102,7 @@ namespace gridtools {
          */
         DataType *get_cpu_ptr() const { return m_ptr; }
 
-        /*
-         * @brief get_ptrs implementation for host_storage.
-         */
-        DataType *get_ptrs_impl() const { return m_ptr; }
-
+        DataType *get_target_ptr() const { return m_ptr; }
         /*
          * @brief valid implementation for host_storage.
          */

--- a/include/gridtools/storage/storage_mc/data_view_helpers.hpp
+++ b/include/gridtools/storage/storage_mc/data_view_helpers.hpp
@@ -73,6 +73,6 @@ namespace gridtools {
     check_consistency(DataStore const &ds, DataView const &dv) {
         GT_STATIC_ASSERT(is_data_view<DecayedDV>::value, GT_INTERNAL_ERROR_MSG("Passed type is no data_view type"));
         return ds.valid() && advanced::get_raw_pointer_of(dv) == ds.get_storage_ptr()->get_cpu_ptr() &&
-               advanced::storage_info_raw_ptr(dv) && ds.get_storage_info_ptr();
+               ds.get_storage_info_ptr();
     }
 } // namespace gridtools

--- a/include/gridtools/storage/storage_mc/mc_storage.hpp
+++ b/include/gridtools/storage/storage_mc/mc_storage.hpp
@@ -34,7 +34,6 @@ namespace gridtools {
     template <typename DataType>
     struct mc_storage : storage_interface<mc_storage<DataType>> {
         typedef DataType data_t;
-        typedef DataType *ptrs_t;
         typedef state_machine state_machine_t;
 
       private:
@@ -115,11 +114,7 @@ namespace gridtools {
          */
         DataType *get_cpu_ptr() const { return m_ptr; }
 
-        /*
-         * @brief get_ptrs implementation for mc_storage.
-         */
-        DataType *get_ptrs_impl() const { return m_ptr; }
-
+        DataType *get_target_ptr() const { return m_ptr; }
         /*
          * @brief valid implementation for mc_storage.
          */

--- a/unit_tests/common/test_integral_constant.cpp
+++ b/unit_tests/common/test_integral_constant.cpp
@@ -24,7 +24,7 @@ namespace gridtools {
         static_assert(0100_c == 0100, "");
         static_assert(0xDEAD_c == 0xDEAD, "");
 
-        static_assert(impl_::parser<'1', '\'', '2'>::value == 12, "");
+        static_assert(literals_impl_::parser<'1', '\'', '2'>::value == 12, "");
 
         static_assert(2_c + 3_c == 5_c, "");
 

--- a/unit_tests/common/test_tuple_util.cpp
+++ b/unit_tests/common/test_tuple_util.cpp
@@ -20,6 +20,7 @@
 #include <gridtools/common/array.hpp>
 #include <gridtools/common/defs.hpp>
 #include <gridtools/common/host_device.hpp>
+#include <gridtools/common/pair.hpp>
 #include <gridtools/meta.hpp>
 
 namespace custom {

--- a/unit_tests/storage/storage_cuda/test_storage.cu
+++ b/unit_tests/storage/storage_cuda/test_storage.cu
@@ -69,11 +69,6 @@ TEST(StorageHostTest, Simple) {
     EXPECT_EQ(s2.get_cpu_ptr()[1], 400);
     EXPECT_EQ(s2.get_cpu_ptr()[0], 300);
 
-    // ptr ref should be equal to the cpu ptr
-    EXPECT_EQ(s1.get_cpu_ptr(), s1.get_ptrs<gridtools::cuda_storage<int>::ptrs_t>()[0]);
-    EXPECT_EQ(s2.get_cpu_ptr(), s2.get_ptrs<gridtools::cuda_storage<int>::ptrs_t>()[0]);
-    EXPECT_EQ(s1.get_gpu_ptr(), s1.get_ptrs<gridtools::cuda_storage<int>::ptrs_t>()[1]);
-    EXPECT_EQ(s2.get_gpu_ptr(), s2.get_ptrs<gridtools::cuda_storage<int>::ptrs_t>()[1]);
     // swap the storages
     s1.swap(s2);
     // check if changes are there

--- a/unit_tests/storage/storage_host/test_storage.cpp
+++ b/unit_tests/storage/storage_host/test_storage.cpp
@@ -30,9 +30,6 @@ TEST(StorageHostTest, Simple) {
     EXPECT_EQ(s1.get_cpu_ptr()[0], 10);
     EXPECT_EQ(s2.get_cpu_ptr()[1], 200);
     EXPECT_EQ(s2.get_cpu_ptr()[0], 100);
-    // ptr ref should be equal to the cpu ptr
-    EXPECT_EQ(s1.get_cpu_ptr(), s1.get_ptrs<typename gridtools::host_storage<int>::ptrs_t>());
-    EXPECT_EQ(s2.get_cpu_ptr(), s2.get_ptrs<typename gridtools::host_storage<int>::ptrs_t>());
     // swap storages
     s1.swap(s2);
     // check if changes are there

--- a/unit_tests/storage/test_storage_sid.cpp
+++ b/unit_tests/storage/test_storage_sid.cpp
@@ -57,6 +57,18 @@ namespace gridtools {
             EXPECT_EQ(expected_strides[3], get<3>(strides));
         }
 
+        TEST(storage_sid, regression_strides_of_small_storage) {
+            data_store_t testee = {{1, 1, 1, 1}, 0};
+
+            auto strides = sid::get_strides(testee);
+            auto expected_strides = testee.strides();
+
+            EXPECT_EQ(expected_strides[0], get<0>(strides));
+            EXPECT_EQ(expected_strides[1], get<1>(strides));
+            EXPECT_EQ(expected_strides[2], get<2>(strides));
+            EXPECT_EQ(expected_strides[3], get<3>(strides));
+        }
+
         TEST(storage_sid, as_host) {
             data_store_t data = {{10, 10, 10, 10}, 42};
             auto testee = as_host(data);


### PR DESCRIPTION
- `gridtools::array` and `gridtools::pair` now model `tuple_like` concept via `adl`
- unused `GT_DISALLOW_COPY_AND_ASSIGN` is removed
- `literals::impl_` renamed to `literals::literals_impl_` to avoid conflicts while doing `using namespace literals`
- unused `make_view_f` is removed
- `dim.hpp` file is introduced with SID tags to of dimensions. Not used yet.
- unused `esf_args` metafunction is removed
- `GT_RESTRICT` usage is refined in SID
- unused code in `accessor_mixed` is removed
- `get_taget_ptr` is added to the storages
- SID adaptation to `data_store` is redone to avoid using `data_view` (because it leaks for cuda)     