### PR TITLE
Remove short_t and ushort_t

### DIFF
--- a/include/gridtools/common/boollist.hpp
+++ b/include/gridtools/common/boollist.hpp
@@ -37,9 +37,9 @@ namespace gridtools {
        \endcode
        See \link Concepts \endlink, \link proc_grid_2D_concept \endlink, \link proc_grid_3D_concept \endlink
      */
-    template <ushort_t I>
+    template <uint_t I>
     struct boollist {
-        static const ushort_t m_size = I;
+        static const uint_t m_size = I;
 
       private:
         // const
@@ -47,10 +47,10 @@ namespace gridtools {
 
       public:
         GT_FUNCTION
-        constexpr ushort_t const &size() const { return m_size; }
+        constexpr uint_t const &size() const { return m_size; }
 
         GT_FUNCTION
-        constexpr bool const &value(ushort_t const &id) const { return m_value[id]; }
+        constexpr bool const &value(uint_t const &id) const { return m_value[id]; }
         GT_FUNCTION
         constexpr array<bool, I> const &value() const { return m_value; }
 
@@ -68,7 +68,7 @@ namespace gridtools {
 
         GT_FUNCTION
         void copy_out(bool *arr) const {
-            for (ushort_t i = 0; i < I; ++i)
+            for (uint_t i = 0; i < I; ++i)
                 arr[i] = m_value[i];
         }
 

--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -147,33 +147,12 @@ namespace gridtools {
 
     //################ Type aliases for GridTools ################
 
-    /**
-       @section typedefs Gridtools types definitions
-       @{
-       @note the integer types are all signed,
-       also the ones which should be logically unsigned (uint_t). This is due
-       to a GCC (4.8.2) bug which is preventing vectorization of nested loops
-       with an unsigned iteration index.
-       https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48052
-    */
-
     using int_t = int;
-    using short_t = int;
     using uint_t = unsigned int;
-    using ushort_t = unsigned int;
     template <int_t N>
     using static_int = std::integral_constant<int_t, N>;
     template <uint_t N>
     using static_uint = std::integral_constant<uint_t, N>;
-    template <short_t N>
-    using static_short = std::integral_constant<short_t, N>;
-    template <ushort_t N>
-    using static_ushort = std::integral_constant<ushort_t, N>;
-
-    template <size_t N>
-    using static_size_t = std::integral_constant<size_t, N>;
-    template <bool B>
-    using static_bool = std::integral_constant<bool, B>;
 
     /** @} */
 

--- a/include/gridtools/common/dimension.hpp
+++ b/include/gridtools/common/dimension.hpp
@@ -26,7 +26,7 @@ namespace gridtools {
        It contains a direction (compile time constant, specifying the ID of the component),
        and a value (runtime value, which is storing the offset in the given direction).
     */
-    template <ushort_t Coordinate>
+    template <uint_t Coordinate>
     struct dimension {
         GT_STATIC_ASSERT(Coordinate != 0, "The coordinate values passed to the accessor start from 1");
 
@@ -37,14 +37,14 @@ namespace gridtools {
 
         dimension(dimension const &) = default;
 
-        static constexpr ushort_t index = Coordinate;
+        static constexpr uint_t index = Coordinate;
         int_t value;
     };
 
     template <typename T>
     struct is_dimension : std::false_type {};
 
-    template <ushort_t Id>
+    template <uint_t Id>
     struct is_dimension<dimension<Id>> : std::true_type {};
 
     /** @} */

--- a/include/gridtools/common/generic_metafunctions/repeat_template.hpp
+++ b/include/gridtools/common/generic_metafunctions/repeat_template.hpp
@@ -24,10 +24,10 @@
 namespace gridtools {
 
     namespace _impl {
-        template <template <ushort_t...> class Lambda, class Args>
+        template <template <uint_t...> class Lambda, class Args>
         struct apply_lambda;
 
-        template <template <ushort_t...> class Lambda, template <class...> class L, class... Ts>
+        template <template <uint_t...> class Lambda, template <class...> class L, class... Ts>
         struct apply_lambda<Lambda, L<Ts...>> {
             using type = Lambda<Ts::value...>;
         };
@@ -43,11 +43,11 @@ namespace gridtools {
        \endverbatim
        Optionally a set of initial values to start filling the template class can be passed
     */
-    template <ushort_t Constant, ushort_t Length, template <ushort_t... T> class Lambda, ushort_t... InitialValues>
+    template <uint_t Constant, uint_t Length, template <uint_t... T> class Lambda, uint_t... InitialValues>
     struct repeat_template_c {
-        using repeated_args_t = GT_META_CALL(meta::repeat_c, (Length, std::integral_constant<ushort_t, Constant>));
+        using repeated_args_t = GT_META_CALL(meta::repeat_c, (Length, std::integral_constant<uint_t, Constant>));
         using all_args_t = GT_META_CALL(
-            meta::push_front, (repeated_args_t, std::integral_constant<ushort_t, InitialValues>...));
+            meta::push_front, (repeated_args_t, std::integral_constant<uint_t, InitialValues>...));
         using type = typename _impl::apply_lambda<Lambda, all_args_t>::type;
     };
 

--- a/include/gridtools/common/generic_metafunctions/variadic_typedef.hpp
+++ b/include/gridtools/common/generic_metafunctions/variadic_typedef.hpp
@@ -33,7 +33,7 @@ namespace gridtools {
 
     namespace impl_ {
 
-        template <ushort_t Idx, typename First, typename... Args>
+        template <uint_t Idx, typename First, typename... Args>
         struct get_elem {
             GT_STATIC_ASSERT((Idx <= sizeof...(Args)), "Out of bound access in variadic pack");
             typedef typename ::gridtools::variadic_typedef<Args...>::template get_elem<Idx - 1>::type type;
@@ -50,18 +50,18 @@ namespace gridtools {
     struct variadic_typedef<First, Args...> {
 
         // metafunction that returns a type of a variadic pack by index
-        template <ushort_t Idx>
+        template <uint_t Idx>
         struct get_elem {
             GT_STATIC_ASSERT((Idx <= sizeof...(Args)), "Out of bound access in variadic pack");
             typedef typename impl_::template get_elem<Idx, First, Args...>::type type;
         };
 
         template <typename Elem>
-        static constexpr int_t find(const ushort_t pos = 0) {
+        static constexpr int_t find(const uint_t pos = 0) {
             return std::is_same<First, Elem>::value ? pos : variadic_typedef<Args...>::template find<Elem>(pos + 1);
         }
 
-        static constexpr ushort_t length = sizeof...(Args) + 1;
+        static constexpr uint_t length = sizeof...(Args) + 1;
     };
 
     /// \private
@@ -69,15 +69,15 @@ namespace gridtools {
     struct variadic_typedef<> {
 
         // metafunction that returns a type of a variadic pack by index
-        template <ushort_t Idx>
+        template <uint_t Idx>
         struct get_elem {};
 
         template <typename Elem>
-        static constexpr int_t find(const ushort_t = 0) {
+        static constexpr int_t find(const uint_t = 0) {
             return -1;
         }
 
-        static constexpr ushort_t length = 0;
+        static constexpr uint_t length = 0;
     };
     /** @} */
     /** @} */

--- a/include/gridtools/common/halo_descriptor.hpp
+++ b/include/gridtools/common/halo_descriptor.hpp
@@ -94,7 +94,7 @@ namespace gridtools {
            \param[in] I relative coordinate of the neighbor (the \f$eta\f$ parameter in \link MULTI_DIM_ACCESS \endlink)
         */
         GT_FUNCTION int_t loop_low_bound_outside(
-            short_t I) const { // inside is the fact that the halos are ones outside the begin-end region
+            int_t I) const { // inside is the fact that the halos are ones outside the begin-end region
             switch (I) {
             case 0:
                 return m_begin;
@@ -113,7 +113,7 @@ namespace gridtools {
            \param[in] I relative coordinate of the neighbor (the \f$eta\f$ parameter in \link MULTI_DIM_ACCESS \endlink)
          */
         GT_FUNCTION int_t loop_high_bound_outside(
-            short_t I) const { // inside is the fact that the halos are ones outside the begin-end region
+            int_t I) const { // inside is the fact that the halos are ones outside the begin-end region
             switch (I) {
             case 0:
                 return m_end;
@@ -132,7 +132,7 @@ namespace gridtools {
            \param[in] I relative coordinate of the neighbor (the \f$eta\f$ parameter in \link MULTI_DIM_ACCESS \endlink)
          */
         GT_FUNCTION int_t loop_low_bound_inside(
-            short_t I) const { // inside is the fact that the halos are ones outside the begin-end region
+            int_t I) const { // inside is the fact that the halos are ones outside the begin-end region
 
             switch (I) {
             case 0:
@@ -152,7 +152,7 @@ namespace gridtools {
            \param[in] I relative coordinate of the neighbor (the \f$eta\f$ parameter in \link MULTI_DIM_ACCESS \endlink)
          */
         GT_FUNCTION int_t loop_high_bound_inside(
-            short_t I) const { // inside is the fact that the halos are ones outside the begin-end region
+            int_t I) const { // inside is the fact that the halos are ones outside the begin-end region
             switch (I) {
             case 0:
                 return m_end;
@@ -172,7 +172,7 @@ namespace gridtools {
            \param[in] I relative coordinate of the neighbor (the \f$eta\f$ parameter in \link MULTI_DIM_ACCESS
            \endlink)
         */
-        GT_FUNCTION uint_t r_length(short_t I) const {
+        GT_FUNCTION uint_t r_length(int_t I) const {
             switch (I) {
             case 0:
                 return (m_end - m_begin + 1);
@@ -192,7 +192,7 @@ namespace gridtools {
            \param[in] I relative coordinate of the neighbor (the \f$eta\f$ parameter in \link MULTI_DIM_ACCESS
            \endlink)
         */
-        GT_FUNCTION uint_t s_length(short_t I) const {
+        GT_FUNCTION uint_t s_length(int_t I) const {
             switch (I) {
             case 0:
                 return (m_end - m_begin + 1);

--- a/include/gridtools/common/layout_map_metafunctions.hpp
+++ b/include/gridtools/common/layout_map_metafunctions.hpp
@@ -37,7 +37,7 @@ namespace gridtools {
     struct reverse_map;
 
     /// \private
-    template <short_t... Is>
+    template <int_t... Is>
     struct reverse_map<layout_map<Is...>> {
         static constexpr int max = layout_map<Is...>::max();
         using type = layout_map<(Is < 0 ? Is : max - Is)...>;
@@ -46,25 +46,25 @@ namespace gridtools {
     template <typename DATALO, typename PROCLO>
     struct layout_transform;
 
-    template <short_t I1, short_t I2, short_t P1, short_t P2>
+    template <int_t I1, int_t I2, int_t P1, int_t P2>
     struct layout_transform<layout_map<I1, I2>, layout_map<P1, P2>> {
         typedef layout_map<I1, I2> L1;
         typedef layout_map<P1, P2> L2;
 
-        static constexpr short_t N1 = L1::template at<P1>();
-        static constexpr short_t N2 = L1::template at<P2>();
+        static constexpr int_t N1 = L1::template at<P1>();
+        static constexpr int_t N2 = L1::template at<P2>();
 
         typedef layout_map<N1, N2> type;
     };
 
-    template <short_t I1, short_t I2, short_t I3, short_t P1, short_t P2, short_t P3>
+    template <int_t I1, int_t I2, int_t I3, int_t P1, int_t P2, int_t P3>
     struct layout_transform<layout_map<I1, I2, I3>, layout_map<P1, P2, P3>> {
         typedef layout_map<I1, I2, I3> L1;
         typedef layout_map<P1, P2, P3> L2;
 
-        static constexpr short_t N1 = L1::template at<P1>();
-        static constexpr short_t N2 = L1::template at<P2>();
-        static constexpr short_t N3 = L1::template at<P3>();
+        static constexpr int_t N1 = L1::template at<P1>();
+        static constexpr int_t N2 = L1::template at<P2>();
+        static constexpr int_t N3 = L1::template at<P3>();
 
         typedef layout_map<N1, N2, N3> type;
     };
@@ -139,7 +139,7 @@ namespace gridtools {
     };
 
     namespace impl {
-        template <int_t Val, short_t NExtraDim>
+        template <int_t Val, int_t NExtraDim>
         struct inc_ {
             static const int_t value = Val == -1 ? -1 : Val + NExtraDim;
         };
@@ -147,7 +147,7 @@ namespace gridtools {
 
     enum class InsertLocation { pre, post };
 
-    template <typename LayoutMap, ushort_t NExtraDim, InsertLocation Location = InsertLocation::post>
+    template <typename LayoutMap, uint_t NExtraDim, InsertLocation Location = InsertLocation::post>
     struct extend_layout_map;
 
     /*
@@ -156,7 +156,7 @@ namespace gridtools {
      * a) extend_layout_map< layout_map<0, 1, 3, 2>, 3> == layout_map<3, 4, 6, 5, 0, 1, 2>
      * b) extend_layout_map< layout_map<0, 1, 3, 2>, 3, InsertLocation::pre> == layout_map<0, 1, 2, 3, 4, 6, 5>
      */
-    template <ushort_t NExtraDim, int_t... Args, InsertLocation Location>
+    template <uint_t NExtraDim, int_t... Args, InsertLocation Location>
     struct extend_layout_map<layout_map<Args...>, NExtraDim, Location> {
 
         template <InsertLocation Loc, typename T, int_t... InitialInts>
@@ -177,12 +177,12 @@ namespace gridtools {
         typedef typename build_ext_layout<Location, seq, impl::inc_<Args, NExtraDim>::value...>::type type;
     };
 
-    template <short_t D>
+    template <int_t D>
     struct default_layout_map {
         using type = typename extend_layout_map<layout_map<>, D, InsertLocation::pre>::type;
     };
 
-    template <short_t D>
+    template <int_t D>
     using default_layout_map_t = typename default_layout_map<D>::type;
 
     /** @} */

--- a/include/gridtools/communication/low_level/proc_grids_3D.hpp
+++ b/include/gridtools/communication/low_level/proc_grids_3D.hpp
@@ -52,7 +52,7 @@ namespace gridtools {
 
             MPI_Comm_dup(other.m_communicator, &m_communicator);
 
-            for (ushort_t i = 0; i < ndims; ++i) {
+            for (uint_t i = 0; i < ndims; ++i) {
                 m_dimensions[i] = other.m_dimensions[i];
                 m_coordinates[i] = other.m_coordinates[i];
             }
@@ -130,7 +130,7 @@ namespace gridtools {
         */
         uint_t size() const {
             uint_t ret = m_dimensions[0];
-            for (ushort_t i = 1; i < ndims; ++i)
+            for (uint_t i = 1; i < ndims; ++i)
                 ret *= m_dimensions[i];
             return ret;
         }
@@ -243,8 +243,8 @@ namespace gridtools {
 
         period_type const &cyclic() const { return m_cyclic; }
 
-        int const &coordinates(ushort_t const &i) const { return m_coordinates[i]; }
-        int const &dimensions(ushort_t const &i) const { return m_dimensions[i]; }
+        int const &coordinates(uint_t const &i) const { return m_coordinates[i]; }
+        int const &dimensions(uint_t const &i) const { return m_dimensions[i]; }
     };
 
 #endif

--- a/include/gridtools/stencil_composition/accessor_base.hpp
+++ b/include/gridtools/stencil_composition/accessor_base.hpp
@@ -19,33 +19,33 @@
 
 namespace gridtools {
     namespace accessor_base_impl_ {
-        template <ushort_t I>
+        template <uint_t I>
         struct get_dimension_value_f {
-            template <ushort_t J>
+            template <uint_t J>
             GT_FUNCTION constexpr int_t operator()(dimension<J>) const {
                 return 0;
             }
             GT_FUNCTION constexpr int_t operator()(dimension<I> src) const { return src.value; }
         };
 
-        template <ushort_t I>
+        template <uint_t I>
         GT_FUNCTION constexpr int_t sum_dimensions() {
             return 0;
         }
 
-        template <ushort_t I, class T, class... Ts>
+        template <uint_t I, class T, class... Ts>
         GT_FUNCTION constexpr int_t sum_dimensions(T src, Ts... srcs) {
             return get_dimension_value_f<I>{}(src) + sum_dimensions<I>(srcs...);
         }
 
-        template <ushort_t Dim, ushort_t... Is, class... Ts>
-        GT_FUNCTION constexpr array<int_t, Dim> make_offsets_impl(meta::integer_sequence<ushort_t, Is...>, Ts... srcs) {
+        template <uint_t Dim, uint_t... Is, class... Ts>
+        GT_FUNCTION constexpr array<int_t, Dim> make_offsets_impl(meta::integer_sequence<uint_t, Is...>, Ts... srcs) {
             return {sum_dimensions<Is + 1>(srcs...)...};
         }
 
-        template <ushort_t Dim, class... Ts>
+        template <uint_t Dim, class... Ts>
         GT_FUNCTION constexpr array<int_t, Dim> make_offsets(Ts... srcs) {
-            return make_offsets_impl<Dim>(meta::make_integer_sequence<ushort_t, Dim>{}, srcs...);
+            return make_offsets_impl<Dim>(meta::make_integer_sequence<uint_t, Dim>{}, srcs...);
         }
     } // namespace accessor_base_impl_
 
@@ -86,7 +86,7 @@ namespace gridtools {
 
         GT_FUNCTION constexpr explicit accessor_base(base_t const &src) : base_t{src} {}
 
-        template <ushort_t I, ushort_t... Is>
+        template <uint_t I, uint_t... Is>
         GT_FUNCTION constexpr explicit accessor_base(dimension<I> d, dimension<Is>... ds)
             : base_t{accessor_base_impl_::make_offsets<Dim>(d, ds...)} {
             GT_STATIC_ASSERT((meta::is_set_fast<meta::list<dimension<I>, dimension<Is>...>>::value),
@@ -106,7 +106,7 @@ namespace gridtools {
         GT_FORCE_INLINE constexpr accessor_base(int_t data0 = {}, int_t data1 = {}, int_t data2 = {})
             : data0(data0), data1(data1), data2(data2) {}
 
-        template <ushort_t I, ushort_t... Is>
+        template <uint_t I, uint_t... Is>
         GT_FORCE_INLINE constexpr explicit accessor_base(dimension<I> d, dimension<Is>... ds)
             : accessor_base{accessor_base_impl_::make_offsets<3>(d, ds...)} {
             GT_STATIC_ASSERT((meta::is_set_fast<meta::list<dimension<I>, dimension<Is>...>>::value),

--- a/include/gridtools/stencil_composition/arg.hpp
+++ b/include/gridtools/stencil_composition/arg.hpp
@@ -130,7 +130,7 @@ namespace gridtools {
 
         template <typename Location>
         struct tmp_storage_info_id;
-        template <int_t I, ushort_t NColors>
+        template <int_t I, uint_t NColors>
         struct tmp_storage_info_id<location_type<I, NColors>> : std::integral_constant<unsigned, -NColors> {};
 
         template <uint_t>

--- a/include/gridtools/stencil_composition/expressions/expressions.hpp
+++ b/include/gridtools/stencil_composition/expressions/expressions.hpp
@@ -44,7 +44,7 @@ namespace gridtools {
            \param d1 Coordinate id
            \param offset: the offset to be applied in the Coordinate direction
         */
-        template <ushort_t Coordinate>
+        template <uint_t Coordinate>
         GT_FUNCTION constexpr dimension<Coordinate> operator+(dimension<Coordinate>, int const &offset) {
             return dimension<Coordinate>(offset);
         }
@@ -55,7 +55,7 @@ namespace gridtools {
            \param d1 Coordinate id
            \param offset: the offset to be applied in the Coordinate direction
         */
-        template <ushort_t Coordinate>
+        template <uint_t Coordinate>
         GT_FUNCTION constexpr dimension<Coordinate> operator-(dimension<Coordinate>, int const &offset) {
             return dimension<Coordinate>(-offset);
         }

--- a/include/gridtools/stencil_composition/icosahedral_grids/accessor.hpp
+++ b/include/gridtools/stencil_composition/icosahedral_grids/accessor.hpp
@@ -24,7 +24,7 @@ namespace gridtools {
     /**
      * This is the type of the accessors accessed by a stencil functor.
      */
-    template <uint_t ID, intent Intent, typename LocationType, typename Extent = extent<>, ushort_t FieldDimensions = 4>
+    template <uint_t ID, intent Intent, typename LocationType, typename Extent = extent<>, uint_t FieldDimensions = 4>
     struct accessor : accessor_base<FieldDimensions> {
         GT_STATIC_ASSERT(is_location_type<LocationType>::value, GT_INTERNAL_ERROR);
         using index_t = static_uint<ID>;
@@ -37,16 +37,16 @@ namespace gridtools {
         using accessor_base<FieldDimensions>::accessor_base;
     };
 
-    template <uint_t ID, typename LocationType, typename Extent = extent<>, ushort_t FieldDimensions = 4>
+    template <uint_t ID, typename LocationType, typename Extent = extent<>, uint_t FieldDimensions = 4>
     meta::always<accessor<ID, intent::in, LocationType, Extent, FieldDimensions>> tuple_from_types(
         accessor<ID, intent::in, LocationType, Extent, FieldDimensions> const &);
 
-    template <uint_t ID, typename LocationType, typename Extent = extent<>, ushort_t FieldDimensions = 4>
+    template <uint_t ID, typename LocationType, typename Extent = extent<>, uint_t FieldDimensions = 4>
     using in_accessor = accessor<ID, intent::in, LocationType, Extent, FieldDimensions>;
 
-    template <uint_t ID, typename LocationType, ushort_t FieldDimensions = 4>
+    template <uint_t ID, typename LocationType, uint_t FieldDimensions = 4>
     using inout_accessor = accessor<ID, intent::inout, LocationType, extent<>, FieldDimensions>;
 
-    template <uint_t ID, intent Intent, typename LocationType, typename Extent, ushort_t FieldDimensions>
+    template <uint_t ID, intent Intent, typename LocationType, typename Extent, uint_t FieldDimensions>
     struct is_accessor<accessor<ID, Intent, LocationType, Extent, FieldDimensions>> : std::true_type {};
 } // namespace gridtools

--- a/include/gridtools/stencil_composition/icosahedral_grids/icosahedral_topology_metafunctions.hpp
+++ b/include/gridtools/stencil_composition/icosahedral_grids/icosahedral_topology_metafunctions.hpp
@@ -48,7 +48,7 @@ namespace gridtools {
 
         template <int_t LocationTypeIndex, bool... B>
         struct compute_uuid<LocationTypeIndex, selector<B...>> {
-            static constexpr ushort_t value =
+            static constexpr uint_t value =
                 metastorage_library_indices_limit + LocationTypeIndex + compute_uuid_selector<2>(0, B...);
         };
     } // namespace impl

--- a/include/gridtools/stencil_composition/location_type.hpp
+++ b/include/gridtools/stencil_composition/location_type.hpp
@@ -14,16 +14,16 @@
 #include "../common/defs.hpp"
 
 namespace gridtools {
-    template <int_t I, ushort_t NColors>
+    template <int_t I, uint_t NColors>
     struct location_type {
         static const int_t value = I;
-        typedef static_ushort<NColors> n_colors; //! <- is the number of locations of this type
+        typedef static_uint<NColors> n_colors; //! <- is the number of locations of this type
     };
 
     template <typename T>
     struct is_location_type : std::false_type {};
 
-    template <int I, ushort_t NColors>
+    template <int I, uint_t NColors>
     struct is_location_type<location_type<I, NColors>> : std::true_type {};
 
     namespace enumtype {

--- a/include/gridtools/stencil_composition/structured_grids/accessor_mixed.hpp
+++ b/include/gridtools/stencil_composition/structured_grids/accessor_mixed.hpp
@@ -18,7 +18,7 @@
 
 namespace gridtools {
 
-    template <ushort_t, int_t>
+    template <uint_t, int_t>
     struct pair_;
 
     /**@brief same as accessor but mixing run-time offsets with compile-time ones
@@ -33,7 +33,7 @@ namespace gridtools {
     template <class Base, class... Pairs>
     struct accessor_mixed;
 
-    template <class Base, ushort_t... Inxs, int_t... Vals>
+    template <class Base, uint_t... Inxs, int_t... Vals>
     struct accessor_mixed<Base, pair_<Inxs, Vals>...> : Base {
         template <class... Ts>
         GT_FUNCTION explicit constexpr accessor_mixed(Ts... args) : Base(dimension<Inxs>(Vals)..., args...) {}
@@ -60,7 +60,7 @@ the dimension is chosen
     template <typename AccessorType, typename... Known>
     struct alias;
 
-    template <typename AccessorType, ushort_t... Inxs>
+    template <typename AccessorType, uint_t... Inxs>
     struct alias<AccessorType, dimension<Inxs>...> {
         GT_STATIC_ASSERT(is_accessor<AccessorType>::value,
             "wrong type. If you want to generalize the alias "

--- a/include/gridtools/stencil_composition/tmp_storage.hpp
+++ b/include/gridtools/stencil_composition/tmp_storage.hpp
@@ -76,7 +76,7 @@ namespace gridtools {
         }
     } // namespace tmp_storage
 
-    template <class MaxExtent, class ArgTag, class DataStore, int_t I, ushort_t NColors, class Backend, class Grid>
+    template <class MaxExtent, class ArgTag, class DataStore, int_t I, uint_t NColors, class Backend, class Grid>
     DataStore make_tmp_data_store(
         Backend const &, plh<ArgTag, DataStore, location_type<I, NColors>, true> const &, Grid const &grid) {
         GT_STATIC_ASSERT(is_grid<Grid>::value, GT_INTERNAL_ERROR);

--- a/regression/copy_stencil_parallel.hpp
+++ b/regression/copy_stencil_parallel.hpp
@@ -99,7 +99,7 @@ namespace copy_stencil {
         typedef arg<0, storage_t> p_in;
         typedef arg<1, storage_t> p_out;
 
-        array<ushort_t, 2> halo{1, 1};
+        array<uint_t, 2> halo{1, 1};
 
         if (PROCS == 1) // serial execution
             halo[0] = halo[1] = 0;

--- a/regression/extended_4D.cpp
+++ b/regression/extended_4D.cpp
@@ -75,10 +75,10 @@ struct integration {
         // projection of f on a (e.g.) P1 FE space:
         // loop on quadrature nodes, and on nodes of the P1 element (i,j,k) with i,j,k\in {0,1}
         // computational complexity in the order of  {(I) x (J) x (K) x (i) x (j) x (k) x (nq)}
-        for (short_t I = 0; I < 2; ++I)
-            for (short_t J = 0; J < 2; ++J)
-                for (short_t K = 0; K < 2; ++K) {
-                    for (short_t q = 0; q < 2; ++q) {
+        for (int_t I = 0; I < 2; ++I)
+            for (int_t J = 0; J < 2; ++J)
+                for (int_t K = 0; K < 2; ++K) {
+                    for (int_t q = 0; q < 2; ++q) {
                         eval(result(di + I, dj + J, dk + K)) +=
                             eval(phi(I, J, K, q) * psi(0, 0, 0, q) * jac{i, j, k, qp + q} * f{i, j, k, di, dj, dk} +
                                  phi(I, J, K, q) * psi(0, 0, 0, q) * jac{i, j, k, qp + q} * f{i, j, k, di + 1, dj, dk} +

--- a/regression/icosahedral/stencil_manual_fold.cpp
+++ b/regression/icosahedral/stencil_manual_fold.cpp
@@ -44,7 +44,7 @@ struct test_on_edges_functor {
 
         // retrieve the array of neighbor offsets. This is an array with length 3 (number of neighbors).
         constexpr auto neighbors_offsets = connectivity<enumtype::cells, enumtype::cells, Color>::offsets();
-        ushort_t e = 0;
+        uint_t e = 0;
         // loop over all neighbours. Each iterator (neighbor_offset) is a position offset, i.e. an array with length 4
         for (auto neighbor_offset : neighbors_offsets) {
             eval(weight_edges(edge + e)) = eval(cell_area(neighbor_offset)) / eval(cell_area());

--- a/regression/shallow_water_enhanced.hpp
+++ b/regression/shallow_water_enhanced.hpp
@@ -277,7 +277,7 @@ namespace shallow_water {
         c_grid.dims(di, dj, dk);
         assert(dk == 1);
 
-        array<ushort_t, 3> halo{1, 1, 0};
+        array<uint_t, 3> halo{1, 1, 0};
 
         //! [storage]
         storage_info_t storage_info(d1 + 2 * halo[0], d2 + 2 * halo[1], d3);

--- a/unit_tests/common/test_repeat_template.cpp
+++ b/unit_tests/common/test_repeat_template.cpp
@@ -17,7 +17,7 @@
 
 using namespace gridtools;
 
-template <ushort_t...>
+template <uint_t...>
 struct halo;
 
 static_assert(std::is_same<typename repeat_template_c<5, 3, halo>::type, halo<5, 5, 5>>{}, "");

--- a/unit_tests/stencil_composition/structured_grids/test_stress_dimensions.cpp
+++ b/unit_tests/stencil_composition/structured_grids/test_stress_dimensions.cpp
@@ -129,12 +129,12 @@ bool do_verification(uint_t d1, uint_t d2, uint_t d3, Storage const &result_, Gr
     for (int_t i = 1; i < d1 - 2; ++i)
         for (int_t j = 1; j < d2 - 2; ++j)
             for (int_t k = 0; k < d3 - 1; ++k)
-                for (short_t I = 0; I < 2; ++I)
-                    for (short_t J = 0; J < 2; ++J)
-                        for (short_t K = 0; K < 2; ++K) {
+                for (int_t I = 0; I < 2; ++I)
+                    for (int_t J = 0; J < 2; ++J)
+                        for (int_t K = 0; K < 2; ++K) {
                             // check the initialization to 0
                             assert(referencev(i, j, k, I, J, K) == 0.);
-                            for (short_t q = 0; q < 2; ++q) {
+                            for (int_t q = 0; q < 2; ++q) {
                                 referencev(i, j, k, I, J, K) +=
                                     (phiv(1, 1, 1, I, J, K, q) * psiv(1, 1, 1, 0, 0, 0, q) * jacv(i, j, k, q) *
                                             fv(i, j, k, 0, 0, 0) +
@@ -188,12 +188,12 @@ namespace assembly {
             // projection of f on a (e.g.) P1 FE space:
             // loop on quadrature nodes, and on nodes of the P1 element (i,j,k) with i,j,k\in {0,1}
             // computational complexity in the order of  {(I) x (J) x (K) x (i) x (j) x (k) x (nq)}
-            for (short_t I = 0; I < 2; ++I)
-                for (short_t J = 0; J < 2; ++J)
-                    for (short_t K = 0; K < 2; ++K) {
+            for (int_t I = 0; I < 2; ++I)
+                for (int_t J = 0; J < 2; ++J)
+                    for (int_t K = 0; K < 2; ++K) {
                         // check the initialization to 0
                         assert(eval(result{i, j, k, di + I, dj + J, dk + K}) == 0.);
-                        for (short_t q = 0; q < 2; ++q) {
+                        for (int_t q = 0; q < 2; ++q) {
                             eval(result{di + I, dj + J, dk + K}) +=
                                 eval(phi{i + I, j + J, k + K, qp + q} * psi{i, j, k, qp + q} * jac{i, j, k, di + q} *
                                          f{i, j, k, di, dj, dk} +


### PR DESCRIPTION
This removes confusing `short_t` and `ushort_t` aliases for `int` and `unsigned int` respectively.