### PR TITLE
Use Multiple Threads in Storage Initialization

### DIFF
--- a/include/gridtools/storage/data_store.hpp
+++ b/include/gridtools/storage/data_store.hpp
@@ -45,8 +45,8 @@ namespace gridtools {
          * @param args pack that contains the current index for each dimension
          */
         template <typename Lambda, typename StorageInfo, typename DataType, typename... Args>
-        enable_if_t<(sizeof...(Args) == decay_t<StorageInfo>::layout_t::masked_length - 1), void> lambda_initializer(
-            Lambda &&init, StorageInfo &&si, DataType *ptr, Args... args) {
+        enable_if_t<(sizeof...(Args) == StorageInfo::layout_t::masked_length - 1), void> lambda_initializer(
+            Lambda init, StorageInfo const &si, DataType *ptr, Args... args) {
 #pragma ivdep
 #ifdef _OPENMP
 #pragma omp parallel for simd
@@ -71,14 +71,14 @@ namespace gridtools {
          * @param args pack that contains the current index for each dimension
          */
         template <typename Lambda, typename StorageInfo, typename DataType, typename... Args>
-        enable_if_t<(sizeof...(Args) < decay_t<StorageInfo>::layout_t::masked_length - 1), void> lambda_initializer(
-            Lambda &&init, StorageInfo &&si, DataType *ptr, Args... args) {
+        enable_if_t<(sizeof...(Args) < StorageInfo::layout_t::masked_length - 1), void> lambda_initializer(
+            Lambda init, StorageInfo const &si, DataType *ptr, Args... args) {
 #pragma ivdep
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
             for (int i = 0; i < si.template total_length<sizeof...(Args)>(); ++i) {
-                lambda_initializer(std::forward<Lambda>(init), std::forward<StorageInfo>(si), ptr, args..., i);
+                lambda_initializer(init, si, ptr, args..., i);
             }
         }
     } // namespace

--- a/include/gridtools/storage/data_store.hpp
+++ b/include/gridtools/storage/data_store.hpp
@@ -77,6 +77,10 @@ namespace gridtools {
         template <typename Lambda, typename StorageInfo, typename DataType, typename... Args>
         enable_if_t<(sizeof...(Args) == StorageInfo::layout_t::masked_length - 1), void> lambda_initializer(
             Lambda init, StorageInfo si, DataType *ptr, Args... args) {
+#pragma ivdep
+#ifdef _OPENMP
+#pragma omp parallel for simd
+#endif
             for (int i = 0; i < si.template total_length<sizeof...(Args)>(); ++i) {
                 ptr[si.index(args..., i)] = init(args..., i);
             }
@@ -99,6 +103,10 @@ namespace gridtools {
         template <typename Lambda, typename StorageInfo, typename DataType, typename... Args>
         enable_if_t<(sizeof...(Args) < StorageInfo::layout_t::masked_length - 1), void> lambda_initializer(
             Lambda init, StorageInfo si, DataType *ptr, Args... args) {
+#pragma ivdep
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
             for (int i = 0; i < si.template total_length<sizeof...(Args)>(); ++i) {
                 lambda_initializer(init, si, ptr, args..., i);
             }

--- a/include/gridtools/storage/storage_cuda/cuda_storage.hpp
+++ b/include/gridtools/storage/storage_cuda/cuda_storage.hpp
@@ -95,6 +95,10 @@ namespace gridtools {
         template <typename Fun, uint_t Align = 1>
         cuda_storage(uint_t size, Fun &&initializer, uint_t offset_to_align = 0u, alignment<Align> a = alignment<1u>{})
             : cuda_storage(size, offset_to_align, a) {
+#pragma ivdep
+#ifdef _OPENMP
+#pragma omp parallel for simd
+#endif
             for (uint_t i = 0; i < size; ++i)
                 m_cpu_ptr[i] = initializer(i);
             this->clone_to_device();

--- a/include/gridtools/storage/storage_host/host_storage.hpp
+++ b/include/gridtools/storage/storage_host/host_storage.hpp
@@ -82,6 +82,10 @@ namespace gridtools {
         template <typename Fun, uint_t Align = 1>
         host_storage(uint_t size, Fun &&initializer, uint_t offset_to_align = 0u, alignment<Align> a = alignment<1u>{})
             : host_storage(size, offset_to_align, a) {
+#pragma ivdep
+#ifdef _OPENMP
+#pragma omp parallel for simd
+#endif
             for (uint_t i = 0; i < size; ++i)
                 m_ptr[i] = initializer(i);
         }

--- a/include/gridtools/storage/storage_mc/mc_storage.hpp
+++ b/include/gridtools/storage/storage_mc/mc_storage.hpp
@@ -78,6 +78,10 @@ namespace gridtools {
         template <typename Fun, uint_t Align = 1>
         mc_storage(uint_t size, Fun &&initializer, uint_t offset_to_align = 0u, alignment<Align> a = alignment<1u>{})
             : mc_storage(size, offset_to_align, a) {
+#pragma ivdep
+#ifdef _OPENMP
+#pragma omp parallel for simd
+#endif
             for (uint_t i = 0; i < size; ++i)
                 m_ptr[i] = initializer(i);
         }


### PR DESCRIPTION
Parallel storage initialization if OpenMP is enabled. Parallelization gives huge speedups on manycore processors, e.g. about factor 10 in total run time for performance tests on KNL.