### PR TITLE
Jenkins: Make running MPI optional

### DIFF
--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -4,4 +4,4 @@ source $(dirname "$0")/setup.sh
 
 ./pyutils/driver.py -v -l $logfile build -b $build_type -p $real_type -g $grid_type -e $envfile -o build -i install -t install || { echo 'Build failed'; rm -rf $tmpdir; exit 1; }
 
-./build/pyutils/driver.py -v -l $logfile test -m -b || { echo 'Tests failed'; rm -rf $tmpdir; exit 2; }
+./build/pyutils/driver.py -v -l $logfile test $mpi_flag -b || { echo 'Tests failed'; rm -rf $tmpdir; exit 2; }

--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -4,4 +4,8 @@ source $(dirname "$0")/setup.sh
 
 ./pyutils/driver.py -v -l $logfile build -b $build_type -p $real_type -g $grid_type -e $envfile -o build -i install -t install || { echo 'Build failed'; rm -rf $tmpdir; exit 1; }
 
+if [[ -z "${no_mpi}" ]]; then
+    mpi_flag="-m"
+fi
+
 ./build/pyutils/driver.py -v -l $logfile test $mpi_flag -b || { echo 'Tests failed'; rm -rf $tmpdir; exit 2; }


### PR DESCRIPTION
Since MPI tests need 4 nodes we have a long queuing time. Additionally communication parts are changed rarely. Therefore we introduce a new plan to run tests with MPI (`launch mpistrgrid`), while the standard plans `strgrid` and `icgrid` test without MPI communication.