### PR TITLE
Fix performance for CUDA >= 9.2 (GT v1.0-branch)

### DIFF
--- a/include/gridtools/common/array.hpp
+++ b/include/gridtools/common/array.hpp
@@ -124,7 +124,7 @@ namespace gridtools {
             }
 
             template <size_t I, typename T, size_t D>
-            static GT_FUNCTION GT_CONSTEXPR T &&get(array<T, D> &&arr) noexcept {
+            static GT_FUNCTION GT_CONSTEXPR T get(array<T, D> &&arr) noexcept {
                 GT_STATIC_ASSERT(I < D, "index is out of bounds");
                 return wstd::move(arr.m_array[I]);
             }
@@ -195,7 +195,7 @@ namespace gridtools {
     }
 
     template <size_t I, typename T, size_t D>
-    GT_FUNCTION GT_CONSTEXPR T &&get(array<T, D> &&arr) noexcept {
+    GT_FUNCTION GT_CONSTEXPR T get(array<T, D> &&arr) noexcept {
         GT_STATIC_ASSERT(I < D, "index is out of bounds");
         return wstd::move(get<I>(arr));
     }

--- a/include/gridtools/common/array.hpp
+++ b/include/gridtools/common/array.hpp
@@ -20,6 +20,7 @@
 #include "../meta/macros.hpp"
 #include "../meta/repeat.hpp"
 #include "defs.hpp"
+#include "generic_metafunctions/const_ref.hpp"
 #include "generic_metafunctions/utility.hpp"
 #include "gt_assert.hpp"
 #include "host_device.hpp"
@@ -117,7 +118,7 @@ namespace gridtools {
             }
 
             template <size_t I, typename T, size_t D>
-            static GT_FUNCTION GT_CONSTEXPR const T &get(const array<T, D> &arr) noexcept {
+            static GT_FUNCTION GT_CONSTEXPR GT_META_CALL(const_ref, T) get(const array<T, D> &arr) noexcept {
                 GT_STATIC_ASSERT(I < D, "index is out of bounds");
                 return arr.m_array[I];
             }
@@ -188,7 +189,7 @@ namespace gridtools {
     }
 
     template <size_t I, typename T, size_t D>
-    GT_FUNCTION GT_CONSTEXPR const T &get(const array<T, D> &arr) noexcept {
+    GT_FUNCTION GT_CONSTEXPR GT_META_CALL(const_ref, T) get(const array<T, D> &arr) noexcept {
         GT_STATIC_ASSERT(I < D, "index is out of bounds");
         return arr.m_array[I];
     }

--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -41,7 +41,7 @@
 #endif
 
 #ifdef __CUDA_ARCH__
-#define GT_CONSTEXPR
+#define GT_CONSTEXPR constexpr
 #else
 #define GT_CONSTEXPR constexpr
 #endif

--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -40,11 +40,7 @@
 #endif
 #endif
 
-#ifdef __CUDA_ARCH__
 #define GT_CONSTEXPR constexpr
-#else
-#define GT_CONSTEXPR constexpr
-#endif
 
 /**
  * Macro to allow make functions constexpr in c++14 (in case they are not only a return statement)

--- a/include/gridtools/common/generic_metafunctions/const_ref.hpp
+++ b/include/gridtools/common/generic_metafunctions/const_ref.hpp
@@ -16,7 +16,7 @@
 #include "../../meta/type_traits.hpp"
 
 namespace gridtools {
-    namespace lazy {
+    GT_META_LAZY_NAMESPACE {
         template <class T, class = void>
         struct const_ref : std::add_lvalue_reference<add_const_t<T>> {};
 
@@ -24,8 +24,10 @@ namespace gridtools {
         struct const_ref<T,
             enable_if_t<!std::is_reference<T>::value && std::is_trivially_copy_constructible<T>::value &&
                         sizeof(T) <= sizeof(add_pointer_t<T>)>> : std::add_const<T> {};
-    } // namespace lazy
+    }
 
+#if !GT_BROKEN_TEMPLATE_ALIASES
     template <class T>
-    GT_META_DEFINE_ALIAS(const_ref, lazy::const_ref, T);
+    using const_ref = typename lazy::const_ref<T>::type;
+#endif
 } // namespace gridtools

--- a/include/gridtools/common/generic_metafunctions/const_ref.hpp
+++ b/include/gridtools/common/generic_metafunctions/const_ref.hpp
@@ -22,8 +22,8 @@ namespace gridtools {
 
         template <class T>
         struct const_ref<T,
-            std::enable_if_t<!std::is_reference<T>::value && std::is_trivially_copy_constructible<T>::value &&
-                             sizeof(T) <= sizeof(add_pointer_t<T>)>> : std::add_const<T> {};
+            enable_if_t<!std::is_reference<T>::value && std::is_trivially_copy_constructible<T>::value &&
+                        sizeof(T) <= sizeof(add_pointer_t<T>)>> : std::add_const<T> {};
     } // namespace lazy
 
     template <class T>

--- a/include/gridtools/common/generic_metafunctions/const_ref.hpp
+++ b/include/gridtools/common/generic_metafunctions/const_ref.hpp
@@ -27,5 +27,5 @@ namespace gridtools {
     } // namespace lazy
 
     template <class T>
-    using const_ref = typename lazy::const_ref<T>::type;
+    GT_META_DEFINE_ALIAS(const_ref, lazy::const_ref, T);
 } // namespace gridtools

--- a/include/gridtools/common/generic_metafunctions/const_ref.hpp
+++ b/include/gridtools/common/generic_metafunctions/const_ref.hpp
@@ -1,11 +1,11 @@
 /*
- *  GridTools
+ * GridTools
  *
- *  Copyright (c) 2014-2019, ETH Zurich
- *  All rights reserved.
+ * Copyright (c) 2014-2019, ETH Zurich
+ * All rights reserved.
  *
- *  Please, refer to the LICENSE file in the root directory.
- *  SPDX-License-Identifier: BSD-3-Clause
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once
@@ -16,14 +16,16 @@
 #include "../../meta/type_traits.hpp"
 
 namespace gridtools {
-    GT_META_LAZY_NAMESPACE {
+    namespace lazy {
         template <class T, class = void>
         struct const_ref : std::add_lvalue_reference<add_const_t<T>> {};
 
         template <class T>
         struct const_ref<T,
-            enable_if_t<!std::is_reference<T>::value && std::is_trivially_copy_constructible<T>::value &&
-                        sizeof(T) <= sizeof(add_pointer_t<T>)>> : std::remove_const<T> {};
-    }
-    GT_META_DELEGATE_TO_LAZY(const_ref, class T, T);
+            std::enable_if_t<!std::is_reference<T>::value && std::is_trivially_copy_constructible<T>::value &&
+                             sizeof(T) <= sizeof(add_pointer_t<T>)>> : std::add_const<T> {};
+    } // namespace lazy
+
+    template <class T>
+    using const_ref = typename lazy::const_ref<T>::type;
 } // namespace gridtools

--- a/include/gridtools/common/generic_metafunctions/const_ref.hpp
+++ b/include/gridtools/common/generic_metafunctions/const_ref.hpp
@@ -1,0 +1,29 @@
+/*
+ *  * GridTools
+ *   *
+ *    * Copyright (c) 2014-2019, ETH Zurich
+ *     * All rights reserved.
+ *      *
+ *       * Please, refer to the LICENSE file in the root directory.
+ *        * SPDX-License-Identifier: BSD-3-Clause
+ *         */
+
+#pragma once
+
+#include <type_traits>
+
+#include "../../meta/macros.hpp"
+#include "../../meta/type_traits.hpp"
+
+namespace gridtools {
+    GT_META_LAZY_NAMESPACE {
+        template <class T, class = void>
+        struct const_ref : std::add_lvalue_reference<add_const_t<T>> {};
+
+        template <class T>
+        struct const_ref<T,
+            enable_if_t<!std::is_reference<T>::value && std::is_trivially_copy_constructible<T>::value &&
+                        sizeof(T) <= sizeof(add_pointer_t<T>)>> : std::remove_const<T> {};
+    }
+    GT_META_DELEGATE_TO_LAZY(const_ref, class T, T);
+} // namespace gridtools

--- a/include/gridtools/common/gt_assert.hpp
+++ b/include/gridtools/common/gt_assert.hpp
@@ -30,6 +30,9 @@
 
 #ifdef __CUDA_ARCH__
 #if __CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2
+// we define this macro to an empty string for CUDA 9.2 because in certain cases, CUDA 9.2 tries to compile device
+// instantiations of certain constexpr function templates, which can lead to compile-time errors like "cannot use an
+// entity undefined in device code".
 #define __PRETTY_FUNCTION__ ""
 #endif
 #define GT_ASSERT_OR_THROW(cond, msg) assert(cond)

--- a/include/gridtools/common/gt_assert.hpp
+++ b/include/gridtools/common/gt_assert.hpp
@@ -29,6 +29,9 @@
 #endif
 
 #ifdef __CUDA_ARCH__
+#if __CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ == 2
+#define __PRETTY_FUNCTION__ ""
+#endif
 #define GT_ASSERT_OR_THROW(cond, msg) assert(cond)
 #else
 #define GT_ASSERT_OR_THROW(cond, msg) \

--- a/include/gridtools/common/pair.hpp
+++ b/include/gridtools/common/pair.hpp
@@ -133,7 +133,7 @@ namespace gridtools {
         template <>
         struct pair_get<0> {
             template <typename T1, typename T2>
-            static GT_CONSTEXPR GT_FUNCTION const T1 &const_get(const pair<T1, T2> &p) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION GT_META_CALL(const_ref, T1) const_get(const pair<T1, T2> &p) noexcept {
                 return p.first;
             }
             template <typename T1, typename T2>
@@ -141,14 +141,14 @@ namespace gridtools {
                 return p.first;
             }
             template <typename T1, typename T2>
-            static GT_CONSTEXPR GT_FUNCTION T1 &&move_get(pair<T1, T2> &&p) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION T1 move_get(pair<T1, T2> &&p) noexcept {
                 return wstd::move(p.first);
             }
         };
         template <>
         struct pair_get<1> {
             template <typename T1, typename T2>
-            static GT_CONSTEXPR GT_FUNCTION const T2 &const_get(const pair<T1, T2> &p) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION GT_META_CALL(const_ref, T2) const_get(const pair<T1, T2> &p) noexcept {
                 return p.second;
             }
             template <typename T1, typename T2>
@@ -156,7 +156,7 @@ namespace gridtools {
                 return p.second;
             }
             template <typename T1, typename T2>
-            static GT_CONSTEXPR GT_FUNCTION T2 &&move_get(pair<T1, T2> &&p) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION T2 move_get(pair<T1, T2> &&p) noexcept {
                 return wstd::move(p.second);
             }
         };

--- a/include/gridtools/common/pair.hpp
+++ b/include/gridtools/common/pair.hpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "defs.hpp"
+#include "generic_metafunctions/const_ref.hpp"
 #include "generic_metafunctions/utility.hpp"
 #include "host_device.hpp"
 

--- a/include/gridtools/common/tuple.hpp
+++ b/include/gridtools/common/tuple.hpp
@@ -62,7 +62,7 @@ namespace gridtools {
             }
 
             template <size_t I, class T>
-            static GT_CONSTEXPR GT_FUNCTION T &&get(tuple_leaf<I, T, false> &&obj) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION T get(tuple_leaf<I, T, false> &&obj) noexcept {
                 return static_cast<T &&>(get<I>(obj));
             }
 
@@ -77,7 +77,7 @@ namespace gridtools {
             }
 
             template <size_t I, class T>
-            static GT_CONSTEXPR GT_FUNCTION T &&get(tuple_leaf<I, T, true> &&obj) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION T get(tuple_leaf<I, T, true> &&obj) noexcept {
                 return static_cast<T &&>(obj);
             }
         };
@@ -210,7 +210,7 @@ namespace gridtools {
             }
 
             template <size_t I, enable_if_t<I == 0, int> = 0>
-            static GT_CONSTEXPR GT_FUNCTION T &&get(tuple &&obj) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION T get(tuple &&obj) noexcept {
                 return static_cast<T &&>(obj.m_value);
             }
         };

--- a/include/gridtools/common/tuple.hpp
+++ b/include/gridtools/common/tuple.hpp
@@ -15,6 +15,7 @@
 #include "../meta/type_traits.hpp"
 #include "../meta/utility.hpp"
 #include "defs.hpp"
+#include "generic_metafunctions/const_ref.hpp"
 #include "generic_metafunctions/utility.hpp"
 #include "host_device.hpp"
 
@@ -50,7 +51,8 @@ namespace gridtools {
 
         struct tuple_leaf_getter {
             template <size_t I, class T>
-            static GT_CONSTEXPR GT_FUNCTION T const &get(tuple_leaf<I, T, false> const &obj) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION GT_META_CALL(const_ref, T)
+                get(tuple_leaf<I, T, false> const &obj) noexcept {
                 return obj.m_value;
             }
 
@@ -65,7 +67,7 @@ namespace gridtools {
             }
 
             template <size_t I, class T>
-            static GT_CONSTEXPR GT_FUNCTION T const &get(tuple_leaf<I, T, true> const &obj) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION GT_META_CALL(const_ref, T) get(tuple_leaf<I, T, true> const &obj) noexcept {
                 return obj;
             }
 
@@ -168,7 +170,7 @@ namespace gridtools {
         tuple &operator=(tuple const &) = default;
         tuple &operator=(tuple &&) = default;
 
-        GT_CONSTEXPR GT_FUNCTION tuple(Ts const &... args) noexcept : m_impl(args...) {}
+        GT_CONSTEXPR GT_FUNCTION tuple(GT_META_CALL(const_ref, Ts)... args) noexcept : m_impl(args...) {}
 
         template <class... Args,
             enable_if_t<sizeof...(Ts) == sizeof...(Args) && conjunction<std::is_constructible<Ts, Args &&>...>::value,
@@ -198,7 +200,7 @@ namespace gridtools {
         T m_value;
         struct getter {
             template <size_t I, enable_if_t<I == 0, int> = 0>
-            static GT_CONSTEXPR GT_FUNCTION T const &get(tuple const &obj) noexcept {
+            static GT_CONSTEXPR GT_FUNCTION GT_META_CALL(const_ref, T) get(tuple const &obj) noexcept {
                 return obj.m_value;
             }
 
@@ -225,7 +227,7 @@ namespace gridtools {
         tuple &operator=(tuple const &) = default;
         tuple &operator=(tuple &&) = default;
 
-        GT_CONSTEXPR GT_FUNCTION tuple(T const &arg) noexcept : m_value(arg) {}
+        GT_CONSTEXPR GT_FUNCTION tuple(GT_META_CALL(const_ref, T) arg) noexcept : m_value(arg) {}
 
         template <class Arg, enable_if_t<std::is_constructible<T, Arg &&>::value, int> = 0>
         GT_CONSTEXPR GT_FUNCTION tuple(Arg &&arg) noexcept : m_value(wstd::forward<Arg>(arg)) {}

--- a/include/gridtools/stencil_composition/expressions/expr_base.hpp
+++ b/include/gridtools/stencil_composition/expressions/expr_base.hpp
@@ -64,7 +64,7 @@ namespace gridtools {
             }
 
             template <class Eval, class Arg, enable_if_t<!std::is_arithmetic<Arg>::value, int> = 0>
-            GT_FUNCTION GT_CONSTEXPR auto apply_eval(Eval &eval, Arg arg) GT_AUTO_RETURN(eval(std::move(arg)));
+            GT_FUNCTION GT_CONSTEXPR auto apply_eval(Eval &eval, Arg arg) GT_AUTO_RETURN(eval(wstd::move(arg)));
 
             template <class Eval, class Op, class Arg>
             GT_FUNCTION GT_CONSTEXPR auto value(Eval &eval, expr<Op, Arg> const &arg)

--- a/include/gridtools/stencil_composition/expressions/expr_base.hpp
+++ b/include/gridtools/stencil_composition/expressions/expr_base.hpp
@@ -66,9 +66,17 @@ namespace gridtools {
             template <class Eval, class Arg, enable_if_t<!std::is_arithmetic<Arg>::value, int> = 0>
             GT_FUNCTION GT_CONSTEXPR auto apply_eval(Eval &eval, Arg arg) GT_AUTO_RETURN(eval(wstd::move(arg)));
 
+            // intel compiler 18.0 segfaults if this is a value. On the other hand, nvcc performs much worse in the
+            // dycore if it is a lvalue reference
+#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER <= 1800)
             template <class Eval, class Op, class Arg>
             GT_FUNCTION GT_CONSTEXPR auto value(Eval &eval, expr<Op, Arg> const &arg)
                 GT_AUTO_RETURN(Op{}(eval(arg.m_arg)));
+#else
+            template <class Eval, class Op, class Arg>
+            GT_FUNCTION GT_CONSTEXPR auto value(Eval &eval, expr<Op, Arg> arg)
+                GT_AUTO_RETURN(Op{}(eval(std::move(arg.m_arg))));
+#endif
 
             template <class Eval, class Op, class Lhs, class Rhs>
             GT_FUNCTION GT_CONSTEXPR auto value(Eval &eval, expr<Op, Lhs, Rhs> const &arg)

--- a/include/gridtools/stencil_composition/expressions/expr_base.hpp
+++ b/include/gridtools/stencil_composition/expressions/expr_base.hpp
@@ -63,20 +63,19 @@ namespace gridtools {
                 return arg;
             }
 
-            template <class Eval, class Arg, enable_if_t<!std::is_arithmetic<Arg>::value, int> = 0>
-            GT_FUNCTION GT_CONSTEXPR auto apply_eval(Eval &eval, Arg arg) GT_AUTO_RETURN(eval(wstd::move(arg)));
-
             // intel compiler 18.0 segfaults if this is a value. On the other hand, nvcc performs much worse in the
             // dycore if it is a lvalue reference
 #if defined(__INTEL_COMPILER) && (__INTEL_COMPILER <= 1800)
+            template <class Eval, class Arg, enable_if_t<!std::is_arithmetic<Arg>::value, int> = 0>
+            GT_FUNCTION GT_CONSTEXPR auto apply_eval(Eval &eval, Arg const &arg) GT_AUTO_RETURN(eval(arg));
+#else
+            template <class Eval, class Arg, enable_if_t<!std::is_arithmetic<Arg>::value, int> = 0>
+            GT_FUNCTION GT_CONSTEXPR auto apply_eval(Eval &eval, Arg arg) GT_AUTO_RETURN(eval(wstd::move(arg)));
+#endif
+
             template <class Eval, class Op, class Arg>
             GT_FUNCTION GT_CONSTEXPR auto value(Eval &eval, expr<Op, Arg> const &arg)
                 GT_AUTO_RETURN(Op{}(eval(arg.m_arg)));
-#else
-            template <class Eval, class Op, class Arg>
-            GT_FUNCTION GT_CONSTEXPR auto value(Eval &eval, expr<Op, Arg> arg)
-                GT_AUTO_RETURN(Op{}(eval(std::move(arg.m_arg))));
-#endif
 
             template <class Eval, class Op, class Lhs, class Rhs>
             GT_FUNCTION GT_CONSTEXPR auto value(Eval &eval, expr<Op, Lhs, Rhs> const &arg)

--- a/include/gridtools/stencil_composition/expressions/expr_base.hpp
+++ b/include/gridtools/stencil_composition/expressions/expr_base.hpp
@@ -64,7 +64,7 @@ namespace gridtools {
             }
 
             template <class Eval, class Arg, enable_if_t<!std::is_arithmetic<Arg>::value, int> = 0>
-            GT_FUNCTION GT_CONSTEXPR auto apply_eval(Eval &eval, Arg const &arg) GT_AUTO_RETURN(eval(arg));
+            GT_FUNCTION GT_CONSTEXPR auto apply_eval(Eval &eval, Arg arg) GT_AUTO_RETURN(eval(std::move(arg)));
 
             template <class Eval, class Op, class Arg>
             GT_FUNCTION GT_CONSTEXPR auto value(Eval &eval, expr<Op, Arg> const &arg)

--- a/include/gridtools/stencil_composition/sid/composite.hpp
+++ b/include/gridtools/stencil_composition/sid/composite.hpp
@@ -95,7 +95,8 @@ namespace gridtools {
                     using type = item_generator;
 
                     template <class Args, class Res = GT_META_CALL(tuple_util::element, (PrimaryIndex::value, Args))>
-                    Res const &operator()(Args const &args) const noexcept {
+                    GT_META_CALL(const_ref, Res)
+                    operator()(Args const &args) const noexcept {
                         GT_STATIC_ASSERT(
                             (conjunction<
                                 std::is_same<GT_META_CALL(tuple_util::element, (SecondaryIndices::value, Args)),

--- a/include/gridtools/stencil_composition/stencil_functions.hpp
+++ b/include/gridtools/stencil_composition/stencil_functions.hpp
@@ -136,7 +136,7 @@ namespace gridtools {
 
             template <class Accessor>
             GT_FUNCTION auto operator()(Accessor acc) const GT_AUTO_RETURN(
-                tuple_util::host_device::get<decay_t<Accessor>::index_t::value>(m_transforms)(m_eval, std::move(acc)));
+                tuple_util::host_device::get<decay_t<Accessor>::index_t::value>(m_transforms)(m_eval, wstd::move(acc)));
 
             template <class Op, class... Ts>
             GT_FUNCTION auto operator()(expr<Op, Ts...> const &arg) const
@@ -231,7 +231,7 @@ namespace gridtools {
         GT_FUNCTION static Res with(Eval &eval, Args... args) {
             Res res;
             call_interfaces_impl_::evaluate_bound_functor<Functor, Region, OffI, OffJ, OffK>(
-                eval, tuple_util::host_device::insert<out_param_index>(res, tuple<Args &&...>{std::move(args)...}));
+                eval, tuple_util::host_device::insert<out_param_index>(res, tuple<Args &&...>{wstd::move(args)...}));
             return res;
         }
     };

--- a/include/gridtools/stencil_composition/stencil_functions.hpp
+++ b/include/gridtools/stencil_composition/stencil_functions.hpp
@@ -135,9 +135,8 @@ namespace gridtools {
             Transforms m_transforms;
 
             template <class Accessor>
-            GT_FUNCTION auto operator()(Accessor &&acc) const
-                GT_AUTO_RETURN(tuple_util::host_device::get<decay_t<Accessor>::index_t::value>(m_transforms)(
-                    m_eval, std::forward<Accessor>(acc)));
+            GT_FUNCTION auto operator()(Accessor acc) const GT_AUTO_RETURN(
+                tuple_util::host_device::get<decay_t<Accessor>::index_t::value>(m_transforms)(m_eval, std::move(acc)));
 
             template <class Op, class... Ts>
             GT_FUNCTION auto operator()(expr<Op, Ts...> const &arg) const
@@ -227,12 +226,12 @@ namespace gridtools {
          */
         template <class Eval,
             class... Args,
-            class Res = typename call_interfaces_impl_::get_result_type<Eval, ReturnType, decay_t<Args>...>::type,
+            class Res = typename call_interfaces_impl_::get_result_type<Eval, ReturnType, Args...>::type,
             enable_if_t<sizeof...(Args) + 1 == meta::length<params_t>::value, int> = 0>
-        GT_FUNCTION static Res with(Eval &eval, Args &&... args) {
+        GT_FUNCTION static Res with(Eval &eval, Args... args) {
             Res res;
-            call_interfaces_impl_::evaluate_bound_functor<Functor, Region, OffI, OffJ, OffK>(eval,
-                tuple_util::host_device::insert<out_param_index>(res, tuple<Args &&...>{std::forward<Args>(args)...}));
+            call_interfaces_impl_::evaluate_bound_functor<Functor, Region, OffI, OffJ, OffK>(
+                eval, tuple_util::host_device::insert<out_param_index>(res, tuple<Args &&...>{std::move(args)...}));
             return res;
         }
     };

--- a/jenkins/envs/kesch.sh
+++ b/jenkins/envs/kesch.sh
@@ -6,7 +6,7 @@ module load craype-network-infiniband
 module load craype-haswell
 module load craype-accel-nvidia35
 module load cray-libsci
-module load cudatoolkit/8.0.61
+module swap cudatoolkit/8.0.61
 module load mvapich2gdr_gnu/2.2_cuda_8.0
 module load gcc/5.4.0-2.26
 module load /users/jenkins/easybuild/kesch/modules/all/cmake/3.12.4

--- a/jenkins/envs/kesch.sh
+++ b/jenkins/envs/kesch.sh
@@ -2,6 +2,9 @@
 
 source $(dirname "$BASH_SOURCE")/base.sh
 
+module load PE/17.06
+module load python/3.6.2-gmvolf-17.02
+
 module load craype-network-infiniband
 module load craype-haswell
 module load craype-accel-nvidia35

--- a/unit_tests/common/test_pair.cpp
+++ b/unit_tests/common/test_pair.cpp
@@ -26,8 +26,6 @@ TEST(pair, get_rval_ref) {
     size_t val0 = 1;
     size_t val1 = 2;
 
-    static_assert(
-        !std::is_reference<decltype(gridtools::get<0>(gridtools::pair<size_t, size_t>{val0, val1}))>::value, "");
     EXPECT_EQ(val0, gridtools::get<0>(gridtools::pair<size_t, size_t>{val0, val1}));
     EXPECT_EQ(val1, gridtools::get<1>(gridtools::pair<size_t, size_t>{val0, val1}));
 }

--- a/unit_tests/common/test_pair.cpp
+++ b/unit_tests/common/test_pair.cpp
@@ -26,8 +26,8 @@ TEST(pair, get_rval_ref) {
     size_t val0 = 1;
     size_t val1 = 2;
 
-    EXPECT_TRUE(
-        std::is_rvalue_reference<decltype(gridtools::get<0>(gridtools::pair<size_t, size_t>{val0, val1}))>::value);
+    static_assert(
+        !std::is_reference<decltype(gridtools::get<0>(gridtools::pair<size_t, size_t>{val0, val1}))>::value, "");
     EXPECT_EQ(val0, gridtools::get<0>(gridtools::pair<size_t, size_t>{val0, val1}));
     EXPECT_EQ(val1, gridtools::get<1>(gridtools::pair<size_t, size_t>{val0, val1}));
 }

--- a/unit_tests/common/test_tuple.cu
+++ b/unit_tests/common/test_tuple.cu
@@ -45,7 +45,8 @@ namespace gridtools {
     __device__ tuple<int, double> tuple_conversion_ctor(tuple<char, char> const &src) { return src; }
 
     TEST(tuple, tuple_conversion_ctor) {
-        tuple<int, double> testee = on_device::exec(GT_MAKE_CONSTANT(tuple_conversion_ctor), tuple<char, char>{'a', 'b'});
+        tuple<int, double> testee =
+            on_device::exec(GT_MAKE_CONSTANT(tuple_conversion_ctor), tuple<char, char>{'a', 'b'});
         EXPECT_EQ('a', tuple_util::host::get<0>(testee));
         EXPECT_EQ('b', tuple_util::host::get<1>(testee));
     }


### PR DESCRIPTION
- sets `GT_CONSTEXPR` to `constexpr` for nvcc
- introduces `const_ref` to fix performance for CUDA >= 9.2 (`T` for small data types, `T const&` for large data types)

Backport to GridTools 1.0. See also #1326 and 9bb2d6402569e1d4bd95239999213a647504dc9c