### PR TITLE
Fix "external constructor" for data store

### DIFF
--- a/include/gridtools/storage/data_store.hpp
+++ b/include/gridtools/storage/data_store.hpp
@@ -145,8 +145,8 @@ namespace gridtools {
             T external_ptr,
             ownership own = ownership::external_cpu,
             std::string const &name = "")
-            : m_shared_storage(info.length() ? new storage_t(info.padded_total_length(), external_ptr, own) : nullptr),
-              m_shared_storage_info(info.length() ? new storage_info_t(info) : nullptr), m_name(name) {}
+            : m_shared_storage(new storage_t(info.padded_total_length(), external_ptr, own)),
+              m_shared_storage_info(new storage_info_t(info)), m_name(name) {}
 
         /**
          * @brief allocate the needed memory. this will instantiate a storage instance.


### PR DESCRIPTION
The "external constructor" gets a pointer (which must be non-zero). So there is no need to make sure that the length of the data is non-zero.

This fix is needed, because the check uses data (halo sizes) which is not needed for the external interface and may be wrongly initialized.

Required for GT4Py