### PR TITLE
PyUtils: Workaround for Slow SLURM

### DIFF
--- a/jenkins/setup.sh
+++ b/jenkins/setup.sh
@@ -16,7 +16,7 @@ if [[ $label != "kesch" ]]; then
 fi
 
 # possibly delete old log files and create new log file
-find /tmp -maxdepth 1 -mtime +5 -name 'gridtools-jenkins-*.log' -execdir rm -f {} +
+find /tmp -maxdepth 1 -mtime +5 -name 'gridtools-jenkins-*.log' -execdir rm -f {} + 2>/dev/null
 logfile=$(mktemp -p /tmp gridtools-jenkins-XXXXX.log)
 chmod +r $logfile
 

--- a/pyutils/driver.py
+++ b/pyutils/driver.py
@@ -77,12 +77,12 @@ if buildinfo:
             label = 'perftests_*'
         else:
             label = '(unittest_*|regression_*)'
-            
+
         if run_mpi_tests:
             mpi_label = 'mpitest_*'
         else:
             mpi_label = None
-            
+
         test.run(label, mpi_label, verbose_ctest)
         if build_examples:
             test.compile_examples(examples_build_dir)

--- a/pyutils/perftest/stencils/structured.py
+++ b/pyutils/perftest/stencils/structured.py
@@ -43,6 +43,7 @@ class LayoutTransformation(Stencil):
     gridtools_path = path('layout_transformation')
     halo = 2
 
+
 class BoundaryConditions(Stencil):
     gridtools_path = path('boundary_conditions')
     halo = 3

--- a/pyutils/pyutils/runtools.py
+++ b/pyutils/pyutils/runtools.py
@@ -178,12 +178,14 @@ def _retreive_outputs(rundir, commands, task_id):
 
     with open(_stderr_file(rundir), 'r') as outfile:
         stderr = outfile.read()
+        log.debug('Raw job stderr', stderr)
         stderr = stderr.split('%RETURNCODE%\n')[:-1]
         stderr, exitcodes = zip(*(o.split('%PYUTILS%') for o in stderr))
         exitcodes = [int(exitcode) for exitcode in exitcodes]
 
     with open(_stdout_file(rundir), 'r') as outfile:
         stdout = outfile.read()
+        log.debug('Raw job stdout', stdout)
         stdout = stdout.split('%PYUTILS%\n')[:-1]
 
     return list(zip(exitcodes, stdout, stderr))

--- a/pyutils/pyutils/runtools.py
+++ b/pyutils/pyutils/runtools.py
@@ -208,6 +208,7 @@ def _emulate_sbatch(commands, cwd):
 def _sbatch(commands, cwd=None, use_srun=True, use_mpi_config=False):
     if env.use_slurm():
         with tempfile.TemporaryDirectory(dir='.') as rundir:
+            rundir = os.path.abspath(rundir)
             task = _run_sbatch(rundir, commands, cwd, use_srun, use_mpi_config)
             return _retreive_outputs(rundir, commands, task)
     else:


### PR DESCRIPTION
This introduces scheduling of a single SLURM job with sequential test execution instead of an array job that overloaded SLURM on Daint (we seem to have a scheduler that’s too overstrained to schedule).