### PR TITLE
Fix documentation of access restriction

### DIFF
--- a/docs_src/manuals/user_manual/execution_model.hrst
+++ b/docs_src/manuals/user_manual/execution_model.hrst
@@ -54,7 +54,7 @@ The execution model imposes restrictions on how accessors can be evaluated. The 
  1. Accessors can be read at any offset at any time, if the fields bound to the accessor are read-only within
     a whole *multistage*
     
-2. A stage may write to a field through an accessor, if its new value is independent of a read of the same through the same accessor.
+2. A stage may write to a field through an accessor, if its new value is independent of a read of the same accessor.
 
 3. A stage may write to a field through an accessor, where the new value depends on a read of the same accesor, if all reads (before or after) have zero offset (including later stages and multistages), except k-offsets in case of
     non-parallel policy. For example, you must not access such a field with ``eval(field(-1, -1, -1))``.

--- a/docs_src/manuals/user_manual/execution_model.hrst
+++ b/docs_src/manuals/user_manual/execution_model.hrst
@@ -53,7 +53,8 @@ The execution model imposes restrictions on how accessors can be evaluated. The 
 
  1. Accessors can be read at any offset at any time, if the fields bound to the accessor are read-only within
     a whole *multistage*
+    
+2. A stage may write to a field through an accessor, if its new value is independent of a read of the same through the same accessor.
 
- 2. A stage may write to a field through an accessor. In this stage and in all later stages in the same multistage,
-    this field must not be read anymore with any non-zero offsets, except with k-offsets in case of
+3. A stage may write to a field through an accessor, where the new value depends on a read of the same accesor, if all reads (before or after) have zero offset (including later stages and multistages), except k-offsets in case of
     non-parallel policy. For example, you must not access such a field with ``eval(field(-1, -1, -1))``.

--- a/docs_src/manuals/user_manual/execution_model.hrst
+++ b/docs_src/manuals/user_manual/execution_model.hrst
@@ -53,8 +53,8 @@ The execution model imposes restrictions on how accessors can be evaluated. The 
 
  1. Accessors can be read at any offset at any time, if the fields bound to the accessor are read-only within
     a whole *multistage*
-    
-2. A stage may write to a field through an accessor, if its new value is independent of a read of the same accessor.
 
-3. A stage may write to a field through an accessor, where the new value depends on a read of the same accesor, if all reads (before or after) have zero offset (including later stages and multistages), except k-offsets in case of
-    non-parallel policy. For example, you must not access such a field with ``eval(field(-1, -1, -1))``.
+ 2. A stage may write to a field through an accessor, if there is no read of the same accessor in the same multi-stage.
+
+ 3. A stage may write to a field through an accessor in the same multistage where this accessor is read, if all reads of this accessor (before or after) have zero offset in the horizontal (including other stages and multistages). They may have k-offsets in case of
+    non-parallel policy.


### PR DESCRIPTION
The restriction on read-before-write has to be more strict than was stated in the documentation. The important point is, that for any write-after-read of the same accessor, the compute must not be extended. See #1204.