### PR TITLE
Uniform Block-Sizes API

### DIFF
--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -64,13 +64,17 @@ namespace gridtools {
     } // namespace naive
 
     namespace cuda {
-        template <class IBlockSize = integral_constant<int_t, 64>, class JBlockSize = integral_constant<int_t, 8>>
+        template <class IBlockSize = integral_constant<int_t, 64>,
+            class JBlockSize = integral_constant<int_t, 8>,
+            class KBlockSize = integral_constant<int_t, 1>>
         struct backend {
             using i_block_size_t = IBlockSize;
             using j_block_size_t = JBlockSize;
+            using k_block_size_t = KBlockSize;
 
             static constexpr i_block_size_t i_block_size() { return {}; }
             static constexpr j_block_size_t j_block_size() { return {}; }
+            static constexpr k_block_size_t k_block_size() { return {}; }
         };
     } // namespace cuda
 

--- a/include/gridtools/stencil_composition/backend_cuda/entry_point.hpp
+++ b/include/gridtools/stencil_composition/backend_cuda/entry_point.hpp
@@ -125,7 +125,7 @@ namespace gridtools {
             using apply = typename meta::mp_find<PlhMap, Key, dummy_info>::extent_t;
         };
 
-        template <class MaxExtent, class PlhMap, uint_t BlockSize, class... Funs>
+        template <class MaxExtent, class PlhMap, class... Funs>
         struct kernel {
             tuple<Funs...> m_funs;
             size_t m_shared_memory_size;
@@ -134,7 +134,7 @@ namespace gridtools {
             Kernel launch_or_fuse(Backend, Grid const &grid, Kernel kernel) && {
                 launch_kernel<MaxExtent, Backend::i_block_size_t::value, Backend::j_block_size_t::value>(grid.i_size(),
                     grid.j_size(),
-                    blocks_required_z<BlockSize>(grid.k_size()),
+                    blocks_required_z<Backend::k_block_size_t::value>(grid.k_size()),
                     make_multi_kernel(std::move(m_funs)),
                     m_shared_memory_size);
                 return kernel;
@@ -151,8 +151,8 @@ namespace gridtools {
                 std::enable_if_t<Extent::iminus::value == 0 && Extent::iplus::value == 0 &&
                                      Extent::jminus::value == 0 && Extent::jplus::value == 0,
                     int> = 0>
-            kernel<MaxExtent, stage_matrix::merge_plh_maps<PlhMap, OtherPlhMap>, BlockSize, Funs..., Fun>
-            launch_or_fuse(Backend, Grid const &grid, kernel<MaxExtent, OtherPlhMap, BlockSize, Fun> kernel) && {
+            kernel<MaxExtent, stage_matrix::merge_plh_maps<PlhMap, OtherPlhMap>, Funs..., Fun> launch_or_fuse(
+                Backend, Grid const &grid, kernel<MaxExtent, OtherPlhMap, Fun> kernel) && {
                 return {tuple_util::push_back(std::move(m_funs), tuple_util::get<0>(std::move(kernel.m_funs))),
                     std::max(m_shared_memory_size, kernel.m_shared_memory_size)};
             }
@@ -192,12 +192,10 @@ namespace gridtools {
                 meta::transform<stage_matrix::get_caches, plh_map_t>(),
                 plh_map_t()));
 
-            auto kernel_fun = make_kernel_fun<Deref, Mss>(grid, composite);
+            auto kernel_fun = make_kernel_fun<Deref, Mss, Backend::k_block_size()>(grid, composite);
 
-            return kernel<typename Mss::extent_t,
-                typename Mss::plh_map_t,
-                execute::block_size<typename Mss::execution_t>::value,
-                decltype(kernel_fun)>{std::move(kernel_fun), shared_alloc.size()};
+            return kernel<typename Mss::extent_t, typename Mss::plh_map_t, decltype(kernel_fun)>{
+                std::move(kernel_fun), shared_alloc.size()};
         }
 
         template <class Deref,

--- a/include/gridtools/stencil_composition/backend_cuda/entry_point.hpp
+++ b/include/gridtools/stencil_composition/backend_cuda/entry_point.hpp
@@ -192,12 +192,13 @@ namespace gridtools {
                 meta::transform<stage_matrix::get_caches, plh_map_t>(),
                 plh_map_t()));
 
-            auto kernel_fun = make_kernel_fun<Deref, Mss, Backend::k_block_size()>(grid, composite);
+            constexpr int_t k_block_size =
+                execute::is_parallel<typename Mss::execution_t>{} ? Backend::k_block_size() : 0;
 
-            return kernel<typename Mss::extent_t,
-                typename Mss::plh_map_t,
-                (execute::is_parallel<typename Mss::execution_t>{} ? Backend::k_block_size() : 0),
-                decltype(kernel_fun)>{std::move(kernel_fun), shared_alloc.size()};
+            auto kernel_fun = make_kernel_fun<Deref, Mss, k_block_size>(grid, composite);
+
+            return kernel<typename Mss::extent_t, typename Mss::plh_map_t, k_block_size, decltype(kernel_fun)>{
+                std::move(kernel_fun), shared_alloc.size()};
         }
 
         template <class Deref,

--- a/include/gridtools/stencil_composition/backend_cuda/entry_point.hpp
+++ b/include/gridtools/stencil_composition/backend_cuda/entry_point.hpp
@@ -194,9 +194,10 @@ namespace gridtools {
 
             auto kernel_fun = make_kernel_fun<Deref, Mss, Backend::k_block_size()>(grid, composite);
 
-            return kernel < typename Mss::extent_t, typename Mss::plh_map_t,
-                   execute::is_parallel<typename Mss::execution_t>{} ? Backend::k_block_size() : 0,
-                   decltype(kernel_fun) > {std::move(kernel_fun), shared_alloc.size()};
+            return kernel<typename Mss::extent_t,
+                typename Mss::plh_map_t,
+                (execute::is_parallel<typename Mss::execution_t>{} ? Backend::k_block_size() : 0),
+                decltype(kernel_fun)>{std::move(kernel_fun), shared_alloc.size()};
         }
 
         template <class Deref,

--- a/include/gridtools/stencil_composition/backend_cuda/fused_mss_loop_cuda.hpp
+++ b/include/gridtools/stencil_composition/backend_cuda/fused_mss_loop_cuda.hpp
@@ -39,16 +39,11 @@ namespace gridtools {
                 });
             }
 
-            template <class Deref,
-                class Mss,
-                class Sizes,
-                int_t BlockSize,
-                class = typename has_k_caches<Mss>::type,
-                class = typename Mss::execution_t>
+            template <class Deref, class Mss, class Sizes, int_t BlockSize, class = typename has_k_caches<Mss>::type>
             struct k_loop_f;
 
-            template <class Deref, class Mss, class Sizes, int_t BlockSize, class Execution>
-            struct k_loop_f<Deref, Mss, Sizes, BlockSize, std::true_type, Execution> {
+            template <class Deref, class Mss, class Sizes>
+            struct k_loop_f<Deref, Mss, Sizes, 0, std::true_type> {
                 Sizes m_sizes;
 
                 template <class Ptr, class Strides, class Validator>
@@ -75,8 +70,8 @@ namespace gridtools {
                 }
             };
 
-            template <class Deref, class Mss, class Sizes, int_t BlockSize, class Execution>
-            struct k_loop_f<Deref, Mss, Sizes, BlockSize, std::false_type, Execution> {
+            template <class Deref, class Mss, class Sizes>
+            struct k_loop_f<Deref, Mss, Sizes, 0, std::false_type> {
                 Sizes m_sizes;
 
                 template <class Ptr, class Strides, class Validator>
@@ -101,7 +96,7 @@ namespace gridtools {
             };
 
             template <class Deref, class Mss, class Sizes, int_t BlockSize>
-            struct k_loop_f<Deref, Mss, Sizes, BlockSize, std::false_type, execute::parallel> {
+            struct k_loop_f<Deref, Mss, Sizes, BlockSize, std::false_type> {
                 Sizes m_sizes;
 
                 template <class Ptr, class Strides, class Validator>

--- a/include/gridtools/stencil_composition/execution_types.hpp
+++ b/include/gridtools/stencil_composition/execution_types.hpp
@@ -15,25 +15,17 @@
 #include "../common/host_device.hpp"
 #include "../common/integral_constant.hpp"
 
-#ifndef GT_DEFAULT_VERTICAL_BLOCK_SIZE
-#define GT_DEFAULT_VERTICAL_BLOCK_SIZE 1
-#endif
-
 namespace gridtools {
     namespace execute {
-        template <int_t BlockSize>
-        struct parallel_block {
-            static constexpr int_t block_size = BlockSize;
-        };
-        using parallel = parallel_block<GT_DEFAULT_VERTICAL_BLOCK_SIZE>;
+        struct parallel {};
         struct forward {};
         struct backward {};
 
         template <typename T>
         struct is_parallel : std::false_type {};
 
-        template <int_t BlockSize>
-        struct is_parallel<parallel_block<BlockSize>> : std::true_type {};
+        template <>
+        struct is_parallel<parallel> : std::true_type {};
 
         template <typename T>
         struct is_forward : std::false_type {};
@@ -49,19 +41,13 @@ namespace gridtools {
 
         template <typename T>
         constexpr integral_constant<int_t, is_backward<T>::value ? -1 : 1> step = {};
-
-        template <typename T>
-        struct block_size : integral_constant<int_t, 0> {};
-
-        template <int_t BlockSize>
-        struct block_size<parallel_block<BlockSize>> : integral_constant<int_t, BlockSize> {};
     } // namespace execute
 
     template <typename T>
     struct is_execution_engine : std::false_type {};
 
-    template <int_t BlockSize>
-    struct is_execution_engine<execute::parallel_block<BlockSize>> : std::true_type {};
+    template <>
+    struct is_execution_engine<execute::parallel> : std::true_type {};
 
     template <>
     struct is_execution_engine<execute::forward> : std::true_type {};


### PR DESCRIPTION
Move the k-block-size parameter into the CUDA backend for consistency with i- and j-block-sizes.