### PR TITLE
Fix Tave Environment

### DIFF
--- a/jenkins/envs/tave_icc.sh
+++ b/jenkins/envs/tave_icc.sh
@@ -3,7 +3,8 @@
 source $(dirname "$BASH_SOURCE")/tave.sh
 
 module load PrgEnv-intel
-module load gcc
+module swap intel/18.0.2.199
+module load gcc/7.3.0
 
 export CXX=$(which icpc)
 export CC=$(which icc)


### PR DESCRIPTION
Revert GCC and Intel compiler versions to default versions before maintenance.