### PR TITLE
Fix Missing Include in expr_base.hpp

### DIFF
--- a/include/gridtools/stencil_composition/expressions/expr_base.hpp
+++ b/include/gridtools/stencil_composition/expressions/expr_base.hpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 
 #include "../../common/defs.hpp"
+#include "../../common/generic_metafunctions/utility.hpp"
 #include "../../common/host_device.hpp"
 #include "../../meta/type_traits.hpp"
 #include "../is_accessor.hpp"


### PR DESCRIPTION
Fixes a missing include that might trigger an error in user code if `gridtools/stencil_composition/expressions/expressions.hpp` is the first included GridTools header.