### PR TITLE
`storage_info` has to be `GT_FUNCTION`

### DIFF
--- a/include/gridtools/storage/data_view.hpp
+++ b/include/gridtools/storage/data_view.hpp
@@ -83,7 +83,7 @@ namespace gridtools {
             GT_ASSERT_OR_THROW(info_ptr, "Cannot create data_view with invalid storage info pointer");
         }
 
-        storage_info_t const &storage_info() const {
+        GT_FUNCTION storage_info_t const &storage_info() const {
             GT_CHECK_MEMORY_SPACE(m_device_view);
             return *m_storage_info;
         }


### PR DESCRIPTION
`storage_info` is sometimes called within a `GT_FUNCTION` (in the boundary conditions, the user gets a `data_view` which we might want to query).

Thus, also this function has to be `GT_FUNCTION`.