### PR TITLE
Set max dynamic shared mem only for >= sm_70

### DIFF
--- a/include/gridtools/stencil_composition/backend_cuda/launch_kernel.hpp
+++ b/include/gridtools/stencil_composition/backend_cuda/launch_kernel.hpp
@@ -137,8 +137,10 @@ namespace gridtools {
             template <class Kernel, class... Args>
             void launch(dim3 blocks, dim3 threads, size_t shared_memory_size, Kernel kernel, Args... args) {
 #ifndef __HIPCC__
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
                 GT_CUDA_CHECK(
                     cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+#endif
 #endif
                 kernel<<<blocks, threads, shared_memory_size>>>(std::move(args)...);
 #ifndef NDEBUG


### PR DESCRIPTION
For some kernel `cudaFuncSetAttribute()` with `cudaFuncAttributeMaxDynamicSharedMemorySize` results in a CUDA error. This attribute is relatively new and documentation of this function is quite poor. Unclear if it should be supported on arch < sm_70.