### PR TITLE
Added missing cmake_policy in workaround_mpi.cmake

### DIFF
--- a/cmake/workaround_mpi.cmake
+++ b/cmake/workaround_mpi.cmake
@@ -3,6 +3,8 @@
 # to pass them using -Xcompiler
 
 function(_fix_mpi_flags)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0057 NEW) # Allow "IN_LIST" inside if() statement
     get_property(_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
     if("CUDA" IN_LIST _languages)
         foreach (_LANG IN ITEMS C CXX Fortran)
@@ -22,5 +24,6 @@ function(_fix_mpi_flags)
             endif()
         endforeach()
     endif()
+    cmake_policy(POP)
 endfunction()
 


### PR DESCRIPTION
When doing find_package( GridTools ) and it so happens that the CMake policy `CMP0057` is not set to ON (default = OFF), then the `IN_LIST` keyword is not recognized.
This commit sets the policy, just within the function scope.