### PR TITLE
CMake test: storage_cuda without CUDA compiler

### DIFF
--- a/cmake/public/gridtools_setup_targets.cmake
+++ b/cmake/public/gridtools_setup_targets.cmake
@@ -215,10 +215,6 @@ macro(_gt_setup_targets _config_mode clang_cuda_mode)
         list(APPEND GT_BACKENDS cuda)
         list(APPEND GT_ICO_BACKENDS cuda)
 
-        _gt_add_library(${_config_mode} storage_cuda)
-        target_link_libraries(${_gt_namespace}storage_cuda INTERFACE ${_gt_namespace}gridtools _gridtools_cuda)
-        list(APPEND GT_STORAGES cuda)
-
         if(MPI_CXX_FOUND)
             _gt_add_library(${_config_mode} gcl_gpu)
             target_link_libraries(${_gt_namespace}gcl_gpu INTERFACE ${_gt_namespace}gridtools _gridtools_cuda MPI::MPI_CXX)
@@ -231,6 +227,13 @@ macro(_gt_setup_targets _config_mode clang_cuda_mode)
         target_link_libraries(${_gt_namespace}layout_transformation_gpu INTERFACE ${_gt_namespace}gridtools _gridtools_cuda)
 
         list(APPEND GT_GCL_ARCHS gpu)
+    endif()
+
+    find_package(CUDAToolkit)
+    if(CUDAToolkit_FOUND)
+        _gt_add_library(${_config_mode} storage_cuda)
+        target_link_libraries(${_gt_namespace}storage_cuda INTERFACE ${_gt_namespace}gridtools CUDA::cudart)
+        list(APPEND GT_STORAGES cuda)
     endif()
 
     if (OpenMP_CXX_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,10 @@ function(gridtools_add_mpi_test arch tgt)
 endfunction()
 
 
-add_subdirectory(cmake)
 add_subdirectory(regression)
 add_subdirectory(unit_tests)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    # Even if the explicitly requests testing, we cannot run these CMake tests as it would result in an infinite recursion.
+    add_subdirectory(cmake)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,5 +102,6 @@ function(gridtools_add_mpi_test arch tgt)
 endfunction()
 
 
+add_subdirectory(cmake)
 add_subdirectory(regression)
 add_subdirectory(unit_tests)

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -11,6 +11,7 @@ function(add_cmake_test name)
     add_test(NAME cmaketest_${name}
         COMMAND /usr/bin/env sh ${test_driver_filename}
     )
+    set_tests_properties(cmaketest_${name} PROPERTIES LABELS cmake)
 endfunction()
 
 if(TARGET _gridtools_cuda)

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(_cmake_test_root_dir ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY})
+
+# This default test driver assumes that the project
+# - is located in a subdirectory called ${name}
+# - generates an executable called 'main' which exits with exit code 0 on success
+function(add_cmake_test name)
+    set(test_build_dir ${_cmake_test_root_dir}/${name})
+    set(test_source_dir ${CMAKE_CURRENT_SOURCE_DIR}/${name})
+    set(test_driver_filename ${_cmake_test_root_dir}/test_driver.${name}.sh)
+    configure_file(test_driver.sh.in ${test_driver_filename} @ONLY)
+    add_test(NAME cmaketest_${name}
+        COMMAND /usr/bin/env sh ${test_driver_filename}
+    )
+endfunction()
+
+if(TARGET _gridtools_cuda)
+    # TODO most likely we have to change the test for HIP
+    add_cmake_test(storage_cuda)
+endif()

--- a/tests/cmake/README.md
+++ b/tests/cmake/README.md
@@ -1,0 +1,4 @@
+# CMake tests
+
+Tests if CMake infrastructure works properly for external projects.
+The tests are standalone CMake projects with GridTools as a dependency.

--- a/tests/cmake/storage_cuda/CMakeLists.txt
+++ b/tests/cmake/storage_cuda/CMakeLists.txt
@@ -1,0 +1,15 @@
+# This test checks that even if the CUDA language is not enabled, we can still use cuda storages,
+# as they don't require a CUDA compiler, but just link to cudart.
+# Note that this test is meaningless with Clang as it is (almost) always a CUDA compiler.
+cmake_minimum_required(VERSION 3.14.5)
+
+project(test_storage_cuda LANGUAGES CXX)
+
+include(FetchContent)
+FetchContent_Declare(
+    gridtools
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../..
+)
+FetchContent_MakeAvailable(gridtools)
+add_executable(main main.cpp)
+target_link_libraries(main GridTools::storage_cuda)

--- a/tests/cmake/storage_cuda/main.cpp
+++ b/tests/cmake/storage_cuda/main.cpp
@@ -1,9 +1,21 @@
+#include <cuda_runtime.h>
 #include <gridtools/storage/builder.hpp>
 #include <gridtools/storage/cuda.hpp>
 
 int main() {
+    int result_value = 42;
+
     auto builder = gridtools::storage::builder<gridtools::storage::cuda>.type<int>().dimensions(2);
     auto my_storage = builder();
-    my_storage->host_view()(0) = 10;
-    my_storage->get_target_ptr();
+
+    my_storage->host_view()(0) = result_value;
+    auto dev_ptr = my_storage->get_target_ptr();
+
+    int host_buffer;
+    cudaMemcpy(&host_buffer, dev_ptr, sizeof(int), cudaMemcpyDeviceToHost);
+
+    if (host_buffer == result_value)
+        exit(0);
+    else
+        exit(1);
 }

--- a/tests/cmake/storage_cuda/main.cpp
+++ b/tests/cmake/storage_cuda/main.cpp
@@ -1,0 +1,9 @@
+#include <gridtools/storage/builder.hpp>
+#include <gridtools/storage/cuda.hpp>
+
+int main() {
+    auto builder = gridtools::storage::builder<gridtools::storage::cuda>.type<int>().dimensions(2);
+    auto my_storage = builder();
+    my_storage->host_view()(0) = 10;
+    my_storage->get_target_ptr();
+}

--- a/tests/cmake/test_driver.sh.in
+++ b/tests/cmake/test_driver.sh.in
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+rm -rf @test_build_dir@
+mkdir -p @test_build_dir@
+@CMAKE_COMMAND@ -S @test_source_dir@ -B @test_build_dir@ && cmake --build @test_build_dir@ && @test_build_dir@/main


### PR DESCRIPTION
Adds infrastructure for testing CMake projects using GridTools:
- Put a CMake project in `test/cmake/<testname>`.
- Add `add_cmake_test(<testname>)`.
- The CMake project should produce an executable called main which exits with exit code 0 on success. Later, this can be refined as needed.
- The configure & build & run will run as part of ctest with lable `cmake`.
