### PR TITLE
Workaround /tmp blocking issue on daint

### DIFF
--- a/jenkins/setup.sh
+++ b/jenkins/setup.sh
@@ -19,9 +19,11 @@ if [[ ! -v build_examples ]] && [[ $env == "clang_nvcc" ]]; then
     build_examples=false
 fi
 
+logdir=/tmp/gridtools/ # log to subfolder to workaround https://webrt.cscs.ch/Ticket/Display.html?id=38406
+mkdir -p $logdir
 # possibly delete old log files and create new log file
-find /tmp -maxdepth 1 -mtime +5 -name 'gridtools-jenkins-*.log' -execdir rm -f {} + 2>/dev/null
-logfile=$(mktemp -p /tmp gridtools-jenkins-XXXXX.log)
+find $logdir -maxdepth 1 -mtime +5 -name 'gridtools-jenkins-*.log' -execdir rm -f {} + 2>/dev/null
+logfile=$(mktemp -p $logdir gridtools-jenkins-XXXXX.log)
 chmod +r $logfile
 
 # create directory for temporaries


### PR DESCRIPTION
There is a bug on daint where file handles might be broken in /tmp. When trying to access these files, the command will be stuck forever. This happened very often in the last couple of days. The problem is in the `find ...` command. Putting logfiles in a subfolder should workaround  this issue.