### PR TITLE
fix the bug with delegating optional concept functions

### DIFF
--- a/include/gridtools/sid/as_const.hpp
+++ b/include/gridtools/sid/as_const.hpp
@@ -25,22 +25,22 @@ namespace gridtools {
             template <class Sid>
             struct const_adapter : delegate<Sid> {
                 struct const_ptr_holder {
-                    sid::ptr_holder_type<Sid> m_impl;
+                    ptr_holder_type<Sid> m_impl;
 
                     GT_CONSTEXPR GT_FUNCTION std::add_const_t<sid::element_type<Sid>> *operator()() const {
                         return m_impl();
                     }
 
                     friend GT_CONSTEXPR GT_FUNCTION const_ptr_holder operator+(
-                        const_ptr_holder const &obj, sid::ptr_diff_type<Sid> offset) {
+                        const_ptr_holder const &obj, ptr_diff_type<Sid> offset) {
                         return {obj.m_impl + offset};
                     }
                 };
 
                 friend const_ptr_holder sid_get_origin(const_adapter const &obj) {
-                    return {sid::get_origin(const_cast<Sid &>(obj.impl()))};
+                    return {get_origin(const_cast<Sid &>(obj.m_impl))};
                 }
-                using sid::delegate<Sid>::delegate;
+                using delegate<Sid>::delegate;
             };
         } // namespace as_const_impl_
 
@@ -51,11 +51,9 @@ namespace gridtools {
          *   TODO(anstaf): at a moment the generated ptr holder always has `host_device` `operator()`
          *                 probably might we need the `host` and `device` variations as well
          */
-        template <class SrcRef,
-            class Src = std::decay_t<SrcRef>,
-            std::enable_if_t<std::is_pointer<sid::ptr_type<Src>>::value, int> = 0>
-        as_const_impl_::const_adapter<Src> as_const(SrcRef &&src) {
-            return as_const_impl_::const_adapter<Src>{std::forward<SrcRef>(src)};
+        template <class Src, std::enable_if_t<std::is_pointer<sid::ptr_type<std::decay_t<Src>>>::value, int> = 0>
+        as_const_impl_::const_adapter<Src> as_const(Src &&src) {
+            return {std::forward<Src>(src)};
         }
 
         template <class Src>
@@ -63,20 +61,18 @@ namespace gridtools {
             return std::forward<Src>(src);
         }
 
-        template <class SrcRef,
-            class Src = std::decay_t<SrcRef>,
-            class Ptr = sid::ptr_type<Src>,
+        template <class Src,
+            class Ptr = sid::ptr_type<std::decay_t<Src>>,
             std::enable_if_t<std::is_pointer<Ptr>::value && !std::is_const<std::remove_pointer_t<Ptr>>::value, int> = 0>
-        auto add_const(std::true_type, SrcRef &&src) {
-            return as_const(std::forward<SrcRef>(src));
+        auto add_const(std::true_type, Src &&src) {
+            return as_const(std::forward<Src>(src));
         }
 
-        template <class SrcRef,
-            class Src = std::decay_t<SrcRef>,
-            class Ptr = sid::ptr_type<Src>,
+        template <class Src,
+            class Ptr = sid::ptr_type<std::decay_t<Src>>,
             std::enable_if_t<!std::is_pointer<Ptr>::value || std::is_const<std::remove_pointer_t<Ptr>>::value, int> = 0>
-        auto add_const(std::true_type, SrcRef &&src) {
-            return std::forward<SrcRef>(src);
+        auto add_const(std::true_type, Src &&src) {
+            return std::forward<Src>(src);
         }
 
     } // namespace sid

--- a/include/gridtools/sid/block.hpp
+++ b/include/gridtools/sid/block.hpp
@@ -117,7 +117,7 @@ namespace gridtools {
                     : delegate<Sid>(std::forward<SidT>(impl)), m_block_map(std::forward<BlockMapT>(block_map)) {}
 
                 friend strides_t sid_get_strides(blocked_sid const &obj) {
-                    return tuple_util::generate<generators_t, strides_t>(get_strides(obj.impl()), obj.m_block_map);
+                    return tuple_util::generate<generators_t, strides_t>(get_strides(obj.m_impl), obj.m_block_map);
                 }
             };
 

--- a/include/gridtools/sid/delegate.hpp
+++ b/include/gridtools/sid/delegate.hpp
@@ -91,5 +91,22 @@ namespace gridtools {
         decltype(sid_get_upper_bounds(std::declval<Sid const &>())) sid_get_upper_bounds(delegate<Sid> const &obj) {
             return sid_get_upper_bounds(obj.m_impl);
         }
+
+        template <class Arr, std::enable_if_t<std::is_array<Arr>::value, int> = 0>
+        auto sid_get_origin(delegate<Arr &> &obj) {
+            return sid::get_origin(obj.m_impl);
+        }
+        template <class Arr, std::enable_if_t<std::is_array<Arr>::value, int> = 0>
+        auto sid_get_strides(delegate<Arr &> const &obj) {
+            return get_strides(obj.m_impl);
+        }
+        template <class Arr, std::enable_if_t<std::is_array<Arr>::value, int> = 0>
+        auto sid_get_lower_bounds(delegate<Arr &> const &obj) {
+            return get_lower_bounds(obj.m_impl);
+        }
+        template <class Arr, std::enable_if_t<std::is_array<Arr>::value, int> = 0>
+        auto sid_get_upper_bounds(delegate<Arr &> const &obj) {
+            return get_upper_bounds(obj.m_impl);
+        }
     } // namespace sid
 } // namespace gridtools

--- a/include/gridtools/sid/delegate.hpp
+++ b/include/gridtools/sid/delegate.hpp
@@ -32,16 +32,6 @@ namespace gridtools {
 
             friend ptr_holder_type<Sid> sid_get_origin(delegate &obj) { return get_origin(obj.m_impl); }
             friend strides_type<Sid> sid_get_strides(delegate const &obj) { return get_strides(obj.m_impl); }
-            friend lower_bounds_type<Sid> sid_get_lower_bounds(delegate const &obj) {
-                return get_lower_bounds(obj.m_impl);
-            }
-            friend upper_bounds_type<Sid> sid_get_upper_bounds(delegate const &obj) {
-                return get_upper_bounds(obj.m_impl);
-            }
-
-          protected:
-            Sid const &impl() const { return m_impl; }
-            Sid &impl() { return m_impl; }
 
           public:
             template <class Arg>
@@ -49,6 +39,9 @@ namespace gridtools {
 
             template <class Arg>
             explicit delegate(Arg &&arg) noexcept : m_impl(std::forward<Arg>(arg)) {}
+
+            Sid const &impl() const { return m_impl; }
+            Sid &impl() { return m_impl; }
         };
 
         template <class Sid>
@@ -56,5 +49,14 @@ namespace gridtools {
 
         template <class Sid>
         strides_kind<Sid> sid_get_strides_kind(delegate<Sid> const &);
+
+        template <class Sid>
+        decltype(get_lower_bounds(std::declval<Sid const &>())) sid_get_lower_bounds(delegate<Sid> const &obj) {
+            return get_lower_bounds(obj.impl());
+        }
+        template <class Sid>
+        decltype(get_upper_bounds(std::declval<Sid const &>())) sid_get_upper_bounds(delegate<Sid> const &obj) {
+            return get_upper_bounds(obj.impl());
+        }
     } // namespace sid
 } // namespace gridtools

--- a/include/gridtools/sid/delegate.hpp
+++ b/include/gridtools/sid/delegate.hpp
@@ -31,7 +31,6 @@ namespace gridtools {
             static_assert(is_sid<Sid>::value, GT_INTERNAL_ERROR);
 
             friend ptr_holder_type<Sid> sid_get_origin(delegate &obj) { return get_origin(obj.m_impl); }
-            friend strides_type<Sid> sid_get_strides(delegate const &obj) { return get_strides(obj.m_impl); }
 
           public:
             template <class Arg>
@@ -45,18 +44,22 @@ namespace gridtools {
         };
 
         template <class Sid>
-        ptr_diff_type<Sid> sid_get_ptr_diff(delegate<Sid> const &);
+        decltype(sid_get_ptr_diff(std::declval<Sid const &>())) sid_get_ptr_diff(delegate<Sid> const &);
 
         template <class Sid>
-        strides_kind<Sid> sid_get_strides_kind(delegate<Sid> const &);
+        decltype(sid_get_strides_kind(std::declval<Sid const &>())) sid_get_strides_kind(delegate<Sid> const &);
 
         template <class Sid>
-        decltype(get_lower_bounds(std::declval<Sid const &>())) sid_get_lower_bounds(delegate<Sid> const &obj) {
-            return get_lower_bounds(obj.impl());
+        decltype(sid_get_strides(std::declval<Sid const &>())) sid_get_strides(delegate<Sid> const &obj) {
+            return sid_get_strides(obj.impl());
         }
         template <class Sid>
-        decltype(get_upper_bounds(std::declval<Sid const &>())) sid_get_upper_bounds(delegate<Sid> const &obj) {
-            return get_upper_bounds(obj.impl());
+        decltype(sid_get_lower_bounds(std::declval<Sid const &>())) sid_get_lower_bounds(delegate<Sid> const &obj) {
+            return sid_get_lower_bounds(obj.impl());
+        }
+        template <class Sid>
+        decltype(sid_get_upper_bounds(std::declval<Sid const &>())) sid_get_upper_bounds(delegate<Sid> const &obj) {
+            return sid_get_upper_bounds(obj.impl());
         }
     } // namespace sid
 } // namespace gridtools

--- a/include/gridtools/sid/delegate.hpp
+++ b/include/gridtools/sid/delegate.hpp
@@ -23,6 +23,34 @@ namespace gridtools {
          *  Typically the user template class should inherit from `delegate`
          *  For example please look into `test_sid_delegate.cpp`
          *
+         *  The typical usage looks like:
+         *
+         *  namespace foo_impl_ {
+         *    template <class Sid>
+         *    struct foo : delegate<Sid> { using delegate<Sid>::delegate; };
+         *
+         *    // some SID concept overloads for `foo` here
+         *
+         *    template <class Sid> foo<Sid> make_foo(Sid&& sid) { return {std::forward<Sid>(sid)}; }
+         *  }
+         *  using foo_impl_::make_foo;
+         *
+         *  Please be aware that in this example `delegate` could is instantiated with the reference if the L-value is
+         *  passed to the `make_foo`. If R-value is passed, delegate is instantiated with the non-reference type.
+         *  This affects the ownership semantic of the `foo` proxy. Example:
+         *
+         *  my_sid_t a = make_my_sid();
+         *  auto foo_a = make_foo(a);  // `foo_a` contains the reference on `a`.
+         *
+         *  auto foo_b = make_foo(make_my_sid()); // `foo_b` contains the object of `my_sid`
+         *
+         *  Note also that the ctor of `delegate` is propagated to `foo` with C++11 `using` syntax.
+         *  Please don't propagate `delagate` ctor using perfect forwarding like:
+         *  template <class T> foo(T&& obj) : delegate<Sid>(std::forward<T>(obj)) {}
+         *  It's a well known trap -- copy/move `foo` constructor could be shadowed that way.
+         *  Although it is fine to do perfect forwarding with non unaray constructors. Like:
+         *  template <class T> foo(T&& obj, int arg) : delegate<Sid>(std::forward<T>(obj)) { use_arg(arg); }
+         *
          * @tparam Sid a object that models `SID` concept.
          */
         template <class Sid>
@@ -36,6 +64,9 @@ namespace gridtools {
             template <bool IsRef = std::is_reference<Sid>::value, std::enable_if_t<IsRef, int> = 0>
             delegate(Sid impl) : m_impl(impl) {}
         };
+
+        // Here and below SFINAE principal is used to ensure that the concept functions for the `delegate<Sid>` are
+        // defined only if the corespondent functions are defined for `Sid`.
 
         template <class Sid>
         decltype(sid_get_origin(std::declval<Sid &>())) sid_get_origin(delegate<Sid> &obj) {

--- a/include/gridtools/sid/rename_dimension.hpp
+++ b/include/gridtools/sid/rename_dimension.hpp
@@ -27,8 +27,7 @@ namespace gridtools {
 
             template <class OldKey, class NewKey, class Sid>
             struct renamed_sid : delegate<Sid> {
-                template <class T>
-                renamed_sid(T &&obj) : delegate<Sid>(std::forward<T>(obj)) {}
+                using delegate<Sid>::delegate;
             };
 
             template <class...>
@@ -41,19 +40,19 @@ namespace gridtools {
             template <class OldKey, class NewKey, class Sid>
             decltype(remap<OldKey, NewKey>(sid_get_strides(std::declval<Sid const &>()))) sid_get_strides(
                 renamed_sid<OldKey, NewKey, Sid> const &obj) {
-                return remap<OldKey, NewKey>(sid_get_strides(obj.impl()));
+                return remap<OldKey, NewKey>(sid_get_strides(obj.m_impl));
             }
 
             template <class OldKey, class NewKey, class Sid>
             decltype(remap<OldKey, NewKey>(sid_get_lower_bounds(std::declval<Sid const &>()))) sid_get_lower_bounds(
                 renamed_sid<OldKey, NewKey, Sid> const &obj) {
-                return remap<OldKey, NewKey>(sid_get_lower_bounds(obj.impl()));
+                return remap<OldKey, NewKey>(sid_get_lower_bounds(obj.m_impl));
             }
 
             template <class OldKey, class NewKey, class Sid>
             decltype(remap<OldKey, NewKey>(sid_get_upper_bounds(std::declval<Sid const &>()))) sid_get_upper_bounds(
                 renamed_sid<OldKey, NewKey, Sid> const &obj) {
-                return remap<OldKey, NewKey>(sid_get_upper_bounds(obj.impl()));
+                return remap<OldKey, NewKey>(sid_get_upper_bounds(obj.m_impl));
             }
 
             template <class OldKey, class NewKey, class Sid>

--- a/include/gridtools/sid/rename_dimension.hpp
+++ b/include/gridtools/sid/rename_dimension.hpp
@@ -36,12 +36,6 @@ namespace gridtools {
                 friend remapped_t<strides_type<Sid>> sid_get_strides(renamed_sid const &obj) {
                     return remap<OldKey, NewKey>(sid_get_strides(obj.impl()));
                 }
-                friend remapped_t<lower_bounds_type<Sid>> sid_get_lower_bounds(renamed_sid const &obj) {
-                    return remap<OldKey, NewKey>(sid_get_lower_bounds(obj.impl()));
-                }
-                friend remapped_t<upper_bounds_type<Sid>> sid_get_upper_bounds(renamed_sid const &obj) {
-                    return remap<OldKey, NewKey>(sid_get_upper_bounds(obj.impl()));
-                }
             };
 
             template <class...>
@@ -54,6 +48,18 @@ namespace gridtools {
             template <class OldKey, class NewKey, class Sid>
             renamed_sid<OldKey, NewKey, Sid> rename_dimension(Sid &&sid) {
                 return renamed_sid<OldKey, NewKey, Sid>{std::forward<Sid>(sid)};
+            }
+
+            template <class OldKey, class NewKey, class Sid>
+            decltype(remap<OldKey, NewKey>(sid_get_lower_bounds(std::declval<Sid const &>()))) sid_get_lower_bounds(
+                renamed_sid<OldKey, NewKey, Sid> const &obj) {
+                return remap<OldKey, NewKey>(sid_get_lower_bounds(obj.impl()));
+            }
+
+            template <class OldKey, class NewKey, class Sid>
+            decltype(remap<OldKey, NewKey>(sid_get_upper_bounds(std::declval<Sid const &>()))) sid_get_upper_bounds(
+                renamed_sid<OldKey, NewKey, Sid> const &obj) {
+                return remap<OldKey, NewKey>(sid_get_upper_bounds(obj.impl()));
             }
         } // namespace rename_dimension_impl_
         using rename_dimension_impl_::rename_dimension;

--- a/include/gridtools/sid/rename_dimension.hpp
+++ b/include/gridtools/sid/rename_dimension.hpp
@@ -27,27 +27,21 @@ namespace gridtools {
 
             template <class OldKey, class NewKey, class Sid>
             struct renamed_sid : delegate<Sid> {
-                template <class Map>
-                using remapped_t = decltype(remap<OldKey, NewKey>(std::declval<Map>()));
-
                 template <class T>
                 renamed_sid(T &&obj) : delegate<Sid>(std::forward<T>(obj)) {}
-
-                friend remapped_t<strides_type<Sid>> sid_get_strides(renamed_sid const &obj) {
-                    return remap<OldKey, NewKey>(sid_get_strides(obj.impl()));
-                }
             };
 
             template <class...>
             struct stride_kind_wrapper {};
 
             template <class OldKey, class NewKey, class Sid>
-            stride_kind_wrapper<OldKey, NewKey, strides_kind<Sid>> sid_get_strides_kind(
-                renamed_sid<OldKey, NewKey, Sid> const &);
+            stride_kind_wrapper<OldKey, NewKey, decltype(sid_get_strides_kind(std::declval<Sid const &>()))>
+            sid_get_strides_kind(renamed_sid<OldKey, NewKey, Sid> const &);
 
             template <class OldKey, class NewKey, class Sid>
-            renamed_sid<OldKey, NewKey, Sid> rename_dimension(Sid &&sid) {
-                return renamed_sid<OldKey, NewKey, Sid>{std::forward<Sid>(sid)};
+            decltype(remap<OldKey, NewKey>(sid_get_strides(std::declval<Sid const &>()))) sid_get_strides(
+                renamed_sid<OldKey, NewKey, Sid> const &obj) {
+                return remap<OldKey, NewKey>(sid_get_strides(obj.impl()));
             }
 
             template <class OldKey, class NewKey, class Sid>
@@ -60,6 +54,11 @@ namespace gridtools {
             decltype(remap<OldKey, NewKey>(sid_get_upper_bounds(std::declval<Sid const &>()))) sid_get_upper_bounds(
                 renamed_sid<OldKey, NewKey, Sid> const &obj) {
                 return remap<OldKey, NewKey>(sid_get_upper_bounds(obj.impl()));
+            }
+
+            template <class OldKey, class NewKey, class Sid>
+            renamed_sid<OldKey, NewKey, Sid> rename_dimension(Sid &&sid) {
+                return renamed_sid<OldKey, NewKey, Sid>{std::forward<Sid>(sid)};
             }
         } // namespace rename_dimension_impl_
         using rename_dimension_impl_::rename_dimension;

--- a/include/gridtools/sid/rename_dimension.hpp
+++ b/include/gridtools/sid/rename_dimension.hpp
@@ -55,6 +55,21 @@ namespace gridtools {
                 return remap<OldKey, NewKey>(sid_get_upper_bounds(obj.m_impl));
             }
 
+            template <class OldKey, class NewKey, class Arr, std::enable_if_t<std::is_array<Arr>::value, int> = 0>
+            auto sid_get_strides(renamed_sid<OldKey, NewKey, Arr &> const &obj) {
+                return remap<OldKey, NewKey>(get_strides(obj.m_impl));
+            }
+
+            template <class OldKey, class NewKey, class Arr, std::enable_if_t<std::is_array<Arr>::value, int> = 0>
+            auto sid_get_lower_bounds(renamed_sid<OldKey, NewKey, Arr &> const &obj) {
+                return remap<OldKey, NewKey>(get_lower_bounds(obj.m_impl));
+            }
+
+            template <class OldKey, class NewKey, class Arr, std::enable_if_t<std::is_array<Arr>::value, int> = 0>
+            auto sid_get_upper_bounds(renamed_sid<OldKey, NewKey, Arr &> const &obj) {
+                return remap<OldKey, NewKey>(get_upper_bounds(obj.m_impl));
+            }
+
             template <class OldKey, class NewKey, class Sid>
             renamed_sid<OldKey, NewKey, Sid> rename_dimension(Sid &&sid) {
                 return renamed_sid<OldKey, NewKey, Sid>{std::forward<Sid>(sid)};

--- a/include/gridtools/sid/sid_shift_origin.hpp
+++ b/include/gridtools/sid/sid_shift_origin.hpp
@@ -41,11 +41,11 @@ namespace gridtools {
 
             template <class Sid, class LowerBounds, class UpperBounds>
             class shifted_sid : public delegate<Sid> {
-                sid::ptr_holder_type<Sid> m_origin;
+                ptr_holder_type<Sid> m_origin;
                 LowerBounds m_lower_bounds;
                 UpperBounds m_upper_bounds;
 
-                friend sid::ptr_holder_type<Sid> sid_get_origin(shifted_sid &obj) { return obj.m_origin; }
+                friend ptr_holder_type<Sid> sid_get_origin(shifted_sid &obj) { return obj.m_origin; }
                 friend LowerBounds const &sid_get_lower_bounds(shifted_sid const &obj) { return obj.m_lower_bounds; }
                 friend UpperBounds const &sid_get_upper_bounds(shifted_sid const &obj) { return obj.m_upper_bounds; }
 
@@ -53,19 +53,19 @@ namespace gridtools {
                 template <class Arg, class Offsets>
                 shifted_sid(Arg &&original_sid, Offsets &&offsets) noexcept
                     : delegate<Sid>(std::forward<Arg>(original_sid)), m_origin{[this, &offsets]() {
-                          auto &&strides = sid::get_strides(this->impl());
-                          sid::ptr_diff_type<Sid> ptr_offset{};
+                          auto &&strides = get_strides(this->m_impl);
+                          ptr_diff_type<Sid> ptr_offset{};
                           multi_shift(ptr_offset, strides, offsets);
-                          return sid::get_origin(this->impl()) + ptr_offset;
+                          return get_origin(this->m_impl) + ptr_offset;
                       }()},
-                      m_lower_bounds(add_offsets(sid::get_lower_bounds(this->impl()), offsets)),
-                      m_upper_bounds(add_offsets(sid::get_upper_bounds(this->impl()), offsets)) {}
+                      m_lower_bounds(add_offsets(get_lower_bounds(this->m_impl), offsets)),
+                      m_upper_bounds(add_offsets(get_upper_bounds(this->m_impl), offsets)) {}
             };
 
             template <class Sid, class Offsets>
             using shifted_sid_type = shifted_sid<Sid,
-                decltype(add_offsets(sid::get_lower_bounds(std::declval<Sid const &>()), std::declval<Offsets>())),
-                decltype(add_offsets(sid::get_upper_bounds(std::declval<Sid const &>()), std::declval<Offsets>()))>;
+                decltype(add_offsets(get_lower_bounds(std::declval<Sid const &>()), std::declval<Offsets>())),
+                decltype(add_offsets(get_upper_bounds(std::declval<Sid const &>()), std::declval<Offsets>()))>;
         } // namespace shift_sid_origin_impl_
 
         template <class Sid, class Offset>

--- a/tests/unit_tests/sid/test_sid_delegate.cpp
+++ b/tests/unit_tests/sid/test_sid_delegate.cpp
@@ -16,7 +16,6 @@
 
 #include <gridtools/common/integral_constant.hpp>
 #include <gridtools/common/tuple_util.hpp>
-#include <gridtools/meta.hpp>
 #include <gridtools/sid/concept.hpp>
 #include <gridtools/sid/simple_ptr_holder.hpp>
 #include <gridtools/sid/synthetic.hpp>
@@ -26,27 +25,19 @@ namespace gridtools {
         using namespace literals;
 
         template <class Sid>
-        class i_shifted : public sid::delegate<Sid> {
+        struct i_shifted : sid::delegate<Sid> {
             friend sid::ptr_holder_type<Sid> sid_get_origin(i_shifted &obj) {
-                auto &&impl = obj.impl();
+                auto &&impl = obj.m_impl;
                 sid::ptr_diff_type<Sid> offset{};
                 sid::shift(offset, sid::get_stride<integral_constant<int, 0>>(sid::get_strides(impl)), 1_c);
                 return sid::get_origin(impl) + offset;
             }
-
-          public:
-            template <class Arg>
-            i_shifted(Arg &&arg) : sid::delegate<Sid>(std::forward<Arg>(arg)) {}
+            using sid::delegate<Sid>::delegate;
         };
 
         template <class Sid>
-        i_shifted<Sid> i_shift(Sid const &sid) {
-            return {sid};
-        }
-
-        template <class Sid>
-        i_shifted<Sid &> i_shift(std::reference_wrapper<Sid> sid) {
-            return {sid.get()};
+        i_shifted<Sid> i_shift(Sid &&sid) {
+            return {std::forward<Sid>(sid)};
         }
 
         using sid::property;
@@ -57,17 +48,18 @@ namespace gridtools {
             auto src = sid::synthetic()
                            .set<property::origin>(sid::host_device::make_simple_ptr_holder(&data[0][0]))
                            .set<property::strides>(tu::make<tuple>(5_c, 1_c));
-            auto testee = i_shift(src);
+            EXPECT_EQ(&data[0][0], sid::get_origin(src)());
+
+            auto testee = i_shift(std::move(src));
 
             static_assert(is_sid<decltype(testee)>(), "");
 
-            EXPECT_EQ(&data[0][0], sid::get_origin(src)());
             EXPECT_EQ(&data[1][0], sid::get_origin(testee)());
         }
 
         TEST(delegate, array) {
             double src[3][5];
-            auto testee = i_shift(std::ref(src));
+            auto testee = i_shift(src);
 
             static_assert(is_sid<decltype(testee)>(), "");
 
@@ -75,13 +67,8 @@ namespace gridtools {
         }
 
         template <class Sid>
-        struct delegate_everything : sid::delegate<Sid> {
-            using sid::delegate<Sid>::delegate;
-        };
-
-        template <class Sid>
-        delegate_everything<Sid> just_delegate(Sid const &s) {
-            return delegate_everything<Sid>(s);
+        sid::delegate<Sid> just_delegate(Sid &&s) {
+            return {std::forward<Sid>(s)};
         }
 
         TEST(delegate, do_nothing) {

--- a/tests/unit_tests/sid/test_sid_delegate.cpp
+++ b/tests/unit_tests/sid/test_sid_delegate.cpp
@@ -64,6 +64,9 @@ namespace gridtools {
             static_assert(is_sid<decltype(testee)>(), "");
 
             EXPECT_EQ(&src[1][0], sid::get_origin(testee)());
+            auto strides = sid::get_strides(testee);
+            EXPECT_EQ(tu::get<0>(strides), 5);
+            EXPECT_EQ(tu::get<1>(strides), 1);
         }
 
         template <class Sid>

--- a/tests/unit_tests/sid/test_sid_rename_dimension.cpp
+++ b/tests/unit_tests/sid/test_sid_rename_dimension.cpp
@@ -15,6 +15,7 @@
 #include <gridtools/common/hymap.hpp>
 #include <gridtools/common/integral_constant.hpp>
 #include <gridtools/common/tuple_util.hpp>
+#include <gridtools/sid/composite.hpp>
 #include <gridtools/sid/simple_ptr_holder.hpp>
 #include <gridtools/sid/synthetic.hpp>
 
@@ -28,7 +29,6 @@ namespace gridtools {
         struct b {};
         struct c {};
         struct d {};
-
         TEST(rename_dimensions, smoke) {
             double data[3][5][7];
 
@@ -51,6 +51,18 @@ namespace gridtools {
             auto u_bound = sid::get_upper_bounds(testee);
             EXPECT_EQ(3, at_key<a>(u_bound));
             EXPECT_EQ(5, at_key<d>(u_bound));
+        }
+
+        TEST(rename_dimensions, rename_twice_and_make_composite) {
+            double data[3][5][7];
+            auto src = sid::synthetic()
+                           .set<property::origin>(sid::make_simple_ptr_holder(&data[0][0][0]))
+                           .set<property::strides>(tu::make<hymap::keys<a, b, c>::values>(5_c * 7_c, 7_c, 1_c))
+                           .set<property::upper_bounds>(tu::make<hymap::keys<a, b>::values>(3, 5));
+            auto testee = sid::rename_dimension<a, c>(sid::rename_dimension<b, d>(src));
+            static_assert(sid::is_sid<decltype(testee)>(), "");
+            auto composite = tu::make<gridtools::sid::composite::keys<void>::values>(testee);
+            static_assert(sid::is_sid<decltype(composite)>(), "");
         }
     } // namespace
 } // namespace gridtools

--- a/tests/unit_tests/sid/test_sid_rename_dimension.cpp
+++ b/tests/unit_tests/sid/test_sid_rename_dimension.cpp
@@ -29,6 +29,7 @@ namespace gridtools {
         struct b {};
         struct c {};
         struct d {};
+
         TEST(rename_dimensions, smoke) {
             double data[3][5][7];
 

--- a/tests/unit_tests/sid/test_sid_rename_dimension.cpp
+++ b/tests/unit_tests/sid/test_sid_rename_dimension.cpp
@@ -62,8 +62,9 @@ namespace gridtools {
                            .set<property::upper_bounds>(tu::make<hymap::keys<a, b>::values>(3, 5));
             auto testee = sid::rename_dimension<a, c>(sid::rename_dimension<b, d>(src));
             static_assert(sid::is_sid<decltype(testee)>(), "");
-            auto composite = tu::make<gridtools::sid::composite::keys<void>::values>(testee);
+            auto composite = tu::make<sid::composite::keys<void>::values>(testee);
             static_assert(sid::is_sid<decltype(composite)>(), "");
+            sid::get_origin(composite);
         }
     } // namespace
 } // namespace gridtools

--- a/tests/unit_tests/sid/test_sid_rename_dimension.cpp
+++ b/tests/unit_tests/sid/test_sid_rename_dimension.cpp
@@ -54,6 +54,27 @@ namespace gridtools {
             EXPECT_EQ(5, at_key<d>(u_bound));
         }
 
+        TEST(rename_dimensions, c_array) {
+            double data[3][5][7];
+
+            auto testee = sid::rename_dimension<integral_constant<int, 1>, d>(data);
+            using testee_t = decltype(testee);
+
+            auto strides = sid::get_strides(testee);
+            EXPECT_EQ(35, (sid::get_stride<integral_constant<int, 0>>(strides)));
+            EXPECT_EQ(0, (sid::get_stride<integral_constant<int, 1>>(strides)));
+            EXPECT_EQ(1, (sid::get_stride<integral_constant<int, 2>>(strides)));
+            EXPECT_EQ(7, sid::get_stride<d>(strides));
+
+            auto l_bound = sid::get_lower_bounds(testee);
+            EXPECT_EQ(0, (at_key<integral_constant<int, 0>>(l_bound)));
+            EXPECT_EQ(0, at_key<d>(l_bound));
+
+            auto u_bound = sid::get_upper_bounds(testee);
+            EXPECT_EQ(3, (at_key<integral_constant<int, 0>>(u_bound)));
+            EXPECT_EQ(5, at_key<d>(u_bound));
+        }
+
         TEST(rename_dimensions, rename_twice_and_make_composite) {
             double data[3][5][7];
             auto src = sid::synthetic()


### PR DESCRIPTION
`delegate` helper was redesigned. Now it implements only those concept functions that are defined in the source SID. In the previous design all concept functions were defined (including those that are fall back to default for the source SID). As a result it was a lot of hard to debug compilation errors.  