### PR TITLE
Fix Compilation and Warnings for -Wpedantic

### DIFF
--- a/include/gridtools/common/atomic_functions.hpp
+++ b/include/gridtools/common/atomic_functions.hpp
@@ -65,11 +65,11 @@ namespace gridtools {
 #endif
 #endif
 
-    GT_DECLARE_ATOMIC(add);
-    GT_DECLARE_ATOMIC(sub);
-    GT_DECLARE_ATOMIC(exch);
-    GT_DECLARE_ATOMIC(min);
-    GT_DECLARE_ATOMIC(max);
+    GT_DECLARE_ATOMIC(add)
+    GT_DECLARE_ATOMIC(sub)
+    GT_DECLARE_ATOMIC(exch)
+    GT_DECLARE_ATOMIC(min)
+    GT_DECLARE_ATOMIC(max)
 
 #undef GT_DECLARE_ATOMIC
 

--- a/include/gridtools/common/generic_metafunctions/for_each.hpp
+++ b/include/gridtools/common/generic_metafunctions/for_each.hpp
@@ -28,6 +28,12 @@ namespace gridtools {
             template <class List>
             struct for_each_impl;
 
+            template <template <class...> class L>
+            struct for_each_impl<L<>> {
+                template <class Fun>
+                GT_TARGET GT_FORCE_INLINE static void exec(Fun const &) {}
+            };
+
             template <template <class...> class L, class... Ts>
             struct for_each_impl<L<Ts...>> {
                 template <class Fun>
@@ -38,6 +44,12 @@ namespace gridtools {
 
             template <class List>
             struct for_each_type_impl;
+
+            template <template <class...> class L>
+            struct for_each_type_impl<L<>> {
+                template <class Fun>
+                GT_TARGET GT_FORCE_INLINE static void exec(Fun const &) {}
+            };
 
             template <template <class...> class L, class... Ts>
             struct for_each_type_impl<L<Ts...>> {

--- a/include/gridtools/common/generic_metafunctions/for_each.hpp
+++ b/include/gridtools/common/generic_metafunctions/for_each.hpp
@@ -38,7 +38,8 @@ namespace gridtools {
             struct for_each_impl<L<Ts...>> {
                 template <class Fun>
                 GT_TARGET GT_FORCE_INLINE static void exec(Fun const &fun) {
-                    (void)(int[]){((void)fun(Ts{}), 0)...};
+                    using array_t = int[sizeof...(Ts)];
+                    (void)array_t{((void)fun(Ts{}), 0)...};
                 }
             };
 
@@ -55,7 +56,8 @@ namespace gridtools {
             struct for_each_type_impl<L<Ts...>> {
                 template <class Fun>
                 GT_TARGET GT_FORCE_INLINE static void exec(Fun const &fun) {
-                    (void)(int[]){((void)fun.template operator()<Ts>(), 0)...};
+                    using array_t = int[sizeof...(Ts)];
+                    (void)array_t{((void)fun.template operator()<Ts>(), 0)...};
                 }
             };
         } // namespace for_each_detail

--- a/include/gridtools/common/generic_metafunctions/for_each.hpp
+++ b/include/gridtools/common/generic_metafunctions/for_each.hpp
@@ -71,7 +71,7 @@ namespace gridtools {
         template <class List, class Fun>
         GT_TARGET GT_FORCE_INLINE void for_each(Fun const &fun) {
             for_each_detail::for_each_impl<List>::exec(fun);
-        };
+        }
 
         ///  Calls fun.template operator<T>() for each element of the type list List.
         ///
@@ -84,7 +84,7 @@ namespace gridtools {
         template <class List, class Fun>
         GT_TARGET GT_FORCE_INLINE void for_each_type(Fun const &fun) {
             for_each_detail::for_each_type_impl<List>::exec(fun);
-        };
+        }
 
         /** @} */
         /** @} */

--- a/include/gridtools/common/tuple.hpp
+++ b/include/gridtools/common/tuple.hpp
@@ -102,7 +102,8 @@ namespace gridtools {
 
             GT_FORCE_INLINE void swap(tuple_impl &other) noexcept {
                 using std::swap;
-                void((int[]){(swap(tuple_leaf_getter::get<Is>(*this), tuple_leaf_getter::get<Is>(other)), 0)...});
+                using loop_t = int[sizeof...(Is)];
+                void(loop_t{(swap(tuple_leaf_getter::get<Is>(*this), tuple_leaf_getter::get<Is>(other)), 0)...});
             }
 
             template <class... Args,
@@ -110,7 +111,8 @@ namespace gridtools {
                                      conjunction<std::is_assignable<Ts &, Args const &>...>::value,
                     int> = 0>
             GT_FUNCTION void assign(tuple_impl<std::index_sequence<Is...>, Args...> const &src) noexcept {
-                void((int[]){(tuple_leaf_getter::get<Is>(*this) = tuple_leaf_getter::get<Is>(src), 0)...});
+                using loop_t = int[sizeof...(Is)];
+                void(loop_t{(tuple_leaf_getter::get<Is>(*this) = tuple_leaf_getter::get<Is>(src), 0)...});
             }
 
             template <class... Args,
@@ -118,7 +120,8 @@ namespace gridtools {
                                      conjunction<std::is_assignable<Ts &, Args &&>...>::value,
                     int> = 0>
             GT_FUNCTION void assign(tuple_impl<std::index_sequence<Is...>, Args...> &&src) noexcept {
-                void((int[]){(tuple_leaf_getter::get<Is>(*this) = tuple_leaf_getter::get<Is>(wstd::move(src)), 0)...});
+                using loop_t = int[sizeof...(Is)];
+                void(loop_t{(tuple_leaf_getter::get<Is>(*this) = tuple_leaf_getter::get<Is>(wstd::move(src)), 0)...});
             }
         };
     } // namespace impl_

--- a/include/gridtools/common/tuple_util.hpp
+++ b/include/gridtools/common/tuple_util.hpp
@@ -523,7 +523,8 @@ namespace gridtools {
                 struct for_each_in_cartesian_product_impl_f<Outer<Inners...>> {
                     template <class Fun, class... Tups>
                     GT_TARGET GT_FORCE_INLINE void operator()(Fun &&fun, Tups &&... tups) const {
-                        void((int[]){
+                        using loop_t = int[sizeof...(Inners)];
+                        void(loop_t{
                             (apply_to_elements_f<Inners>{}(wstd::forward<Fun>(fun), wstd::forward<Tups>(tups)...),
                                 0)...});
                     }

--- a/include/gridtools/stencil/frontend/expandable_run.hpp
+++ b/include/gridtools/stencil/frontend/expandable_run.hpp
@@ -74,7 +74,7 @@ namespace gridtools {
                     using type = expanded<I::value, Plh>;
                 };
 
-            }; // namespace lazy
+            } // namespace lazy
             GT_META_DELEGATE_TO_LAZY(convert_plh, class... Ts, Ts...);
 
             template <class Esf>

--- a/include/gridtools/stencil/frontend/run.hpp
+++ b/include/gridtools/stencil/frontend/run.hpp
@@ -228,7 +228,8 @@ namespace gridtools {
                         });
                     return 0;
                 };
-                (void)(int[]){check_bounds(arg<Is>(), fields)...};
+                using loop_t = int[sizeof...(Is)];
+                (void)loop_t{check_bounds(arg<Is>(), fields)...};
 #endif
                 entry_point_t()(grid, data_store_map_t{fields...});
             }

--- a/include/gridtools/storage/builder.hpp
+++ b/include/gridtools/storage/builder.hpp
@@ -43,7 +43,7 @@ namespace gridtools {
                     auto indices = info.indices(layout, i);
                     dst[i] = fun(indices[Is]...);
                 }
-            };
+            }
 
             template <class Fun>
             auto wrap_initializer(Fun fun) {

--- a/tests/include/test_environment.hpp
+++ b/tests/include/test_environment.hpp
@@ -81,7 +81,10 @@ namespace gridtools {
 
         template <int... Is>
         struct inlined_params {
-            static int d(size_t i) { return ((int[]){Is...})[i]; }
+            static int d(size_t i) {
+                using loop_t = int[sizeof...(Is)];
+                return (loop_t{Is...})[i];
+            }
             static size_t steps() { return 0; }
             static bool needs_verification() { return true; }
             static int &argc() {
@@ -95,7 +98,8 @@ namespace gridtools {
             }
             static std::string name() {
                 std::string res = "_domain_size";
-                for (int i : (int[]){Is...})
+                int is[] = {Is...};
+                for (int i : is)
                     res += "_" + std::to_string(i);
                 return res;
             }

--- a/tests/regression/icosahedral/neighbours_of.hpp
+++ b/tests/regression/icosahedral/neighbours_of.hpp
@@ -62,5 +62,5 @@ namespace gridtools {
         for (auto &item : _impl::get_offsets<FromLocation, ToLocation>(c))
             res.push_back({i + item[0], j + item[1], k + item[2], c + item[3]});
         return res;
-    };
+    }
 } // namespace gridtools

--- a/tests/unit_tests/common/test_atomic_functions.cpp
+++ b/tests/unit_tests/common/test_atomic_functions.cpp
@@ -18,7 +18,7 @@
 
 template <typename T>
 void TestAtomicAdd() {
-    int size = 360;
+    constexpr int size = 360;
     T field[size];
     T sum = 0;
     T sumRef = 0;
@@ -36,7 +36,7 @@ void TestAtomicAdd() {
 
 template <typename T>
 void TestAtomicSub() {
-    int size = 360;
+    constexpr int size = 360;
     T field[size];
     T sum = 0;
     T sumRef = 0;
@@ -54,7 +54,7 @@ void TestAtomicSub() {
 
 template <typename T>
 void TestAtomicMin() {
-    int size = 360;
+    constexpr int size = 360;
     T field[size];
     T min = 99999;
     T minRef = 99999;
@@ -72,7 +72,7 @@ void TestAtomicMin() {
 
 template <typename T>
 void TestAtomicMax() {
-    int size = 360;
+    constexpr int size = 360;
     T field[size];
     T max = 0;
     T maxRef = 0;

--- a/tests/unit_tests/stencil/frontend/cartesian/test_expressions.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_expressions.cpp
@@ -53,11 +53,11 @@ namespace gridtools {
         return result;                                                   \
     }
 
-                EXPRESSION_TEST(add_accessors, val{1} + val{2});
-                EXPRESSION_TEST(sub_accessors, val{1} - val{2});
-                EXPRESSION_TEST(negate_accessors, -val{1});
-                EXPRESSION_TEST(plus_sign_accessors, +val{1});
-                EXPRESSION_TEST(with_parenthesis_accessors, (val{1} + val{2}) * (val{1} - val{2}));
+                EXPRESSION_TEST(add_accessors, val{1} + val{2})
+                EXPRESSION_TEST(sub_accessors, val{1} - val{2})
+                EXPRESSION_TEST(negate_accessors, -val{1})
+                EXPRESSION_TEST(plus_sign_accessors, +val{1})
+                EXPRESSION_TEST(with_parenthesis_accessors, (val{1} + val{2}) * (val{1} - val{2}))
 
                 /*
                  * User API tests

--- a/tests/unit_tests/stencil/frontend/cartesian/test_kcache_fill.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_kcache_fill.cpp
@@ -22,7 +22,7 @@ namespace {
     using axis_t = axis<3, axis_config::offset_limit<3>>;
     using kfull = axis_t::full_interval;
 
-    double in(int i, int j, int k) { return i + j + k + 1; };
+    double in(int i, int j, int k) { return i + j + k + 1; }
 
     using env_t = vertical_test_environment<0, axis_t>;
 

--- a/tests/unit_tests/stencil/frontend/cartesian/test_kcache_fill_and_flush.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_kcache_fill_and_flush.cpp
@@ -22,7 +22,7 @@ namespace {
     using axis_t = axis<3, axis_config::offset_limit<3>>;
     using kfull = axis_t::full_interval;
 
-    double in(int i, int j, int k) { return i + j + k + 1; };
+    double in(int i, int j, int k) { return i + j + k + 1; }
 
     using env_t = vertical_test_environment<0, axis_t>;
 

--- a/tests/unit_tests/stencil/frontend/cartesian/test_kcache_flush.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_kcache_flush.cpp
@@ -22,7 +22,7 @@ namespace {
     using axis_t = axis<3, axis_config::offset_limit<3>>;
     using kfull = axis_t::full_interval;
 
-    double in(int i, int j, int k) { return i + j + k + 1; };
+    double in(int i, int j, int k) { return i + j + k + 1; }
 
     using env_t = vertical_test_environment<0, axis_t>;
 

--- a/tests/unit_tests/stencil/frontend/cartesian/test_kcache_local.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_kcache_local.cpp
@@ -23,7 +23,7 @@ namespace {
     using axis_t = axis<3, axis_config::offset_limit<3>>;
     using kfull = axis_t::full_interval;
 
-    double in(int i, int j, int k) { return i + j + k + 1; };
+    double in(int i, int j, int k) { return i + j + k + 1; }
 
     using env_t = vertical_test_environment<0, axis_t>;
 

--- a/tests/unit_tests/stencil/frontend/cartesian/test_multi_types.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_multi_types.cpp
@@ -109,7 +109,7 @@ namespace gridtools {
                 template <call_type Type, class Eval, class T, std::enable_if_t<Type == call_type::function, int> = 0>
                 GT_FUNCTION auto call_function0(Eval &eval, T obj) {
                     return call<function0>::with(eval, obj);
-                };
+                }
 
                 template <call_type Type, class Eval, class T, std::enable_if_t<Type == call_type::procedure, int> = 0>
                 GT_FUNCTION type1 call_function0(Eval &eval, T obj) {


### PR DESCRIPTION
Fixes compilation for `for_each` with an empty list on GCC in combination with `-Wpedantic`. Further, many warnings using `-Wpedantic` are fixed by removing unnecessary semicolons, replacing compound literals and avoiding variable-length arrays.