### PR TITLE
compile time lengths support in data stores

### DIFF
--- a/docs_src/manuals/getting_started/code/CMakeLists.txt
+++ b/docs_src/manuals/getting_started/code/CMakeLists.txt
@@ -4,7 +4,7 @@ project(GridTools-laplacian LANGUAGES CXX)
 
 set(CMAKE_CXX_EXTENSIONS OFF) # Currently required for HIP
 
-find_package(GridTools 2.0.0 REQUIRED QUIET)
+find_package(GridTools 2.1.0 REQUIRED QUIET)
 
 if(TARGET GridTools::stencil_cpu_ifirst)
     add_executable(gt_laplacian test_gt_laplacian.cpp)

--- a/include/gridtools/common/integral_constant.hpp
+++ b/include/gridtools/common/integral_constant.hpp
@@ -15,6 +15,25 @@
 #include "host_device.hpp"
 
 namespace gridtools {
+
+    // This predicate checks if the the class has `std::integral_constant` as a public base.
+    // Note that it is not the same as `class is an instantiation of gridtools::integral_constant`.
+    // Also it is not the same as `class has `integral nested value_type type and value static member`.
+    template <class, class = void>
+    struct is_integral_constant : std::false_type {};
+
+    template <class T>
+    struct is_integral_constant<T,
+        std::enable_if_t<std::is_base_of<std::integral_constant<typename T::value_type, T::value>, T>::value>>
+        : std::true_type {};
+
+    template <class T, int Val, class = void>
+    struct is_integral_constant_of : std::false_type {};
+
+    template <class T, int Val>
+    struct is_integral_constant_of<T, Val, std::enable_if_t<is_integral_constant<T>::value && T() == Val>>
+        : std::true_type {};
+
     template <class T, T V>
     struct integral_constant : std::integral_constant<T, V> {
         using type = integral_constant;

--- a/include/gridtools/common/tuple_util.hpp
+++ b/include/gridtools/common/tuple_util.hpp
@@ -243,6 +243,15 @@ namespace gridtools {
         }
         GT_META_DELEGATE_TO_LAZY(element, (size_t I, class T), (I, T));
 
+        template <class T, class = void>
+        struct is_empty_or_tuple_of_empties : std::is_empty<T> {};
+
+        template <class Tup, class Types = traits::to_types<Tup>>
+        using is_tuple_of_empties = meta::all_of<is_empty_or_tuple_of_empties, Types>;
+
+        template <class Tup>
+        struct is_empty_or_tuple_of_empties<Tup, std::enable_if_t<is_tuple_of_empties<Tup>::value>> : std::true_type {};
+
         // Here goes the stuff that is common for all targets (meta functions)
         namespace _impl {
 

--- a/include/gridtools/sid/concept.hpp
+++ b/include/gridtools/sid/concept.hpp
@@ -206,21 +206,12 @@ namespace gridtools {
             using default_ptr_diff = decltype(::gridtools::sid::concept_impl_::sid_get_default_ptr_diff(
                 std::declval<std::add_lvalue_reference_t<std::add_const_t<Ptr>>>()));
 
-            template <class T, class = void>
-            struct is_empty_or_tuple_of_empties : std::is_empty<T> {};
-
-            template <class Tup, class Types = tuple_util::traits::to_types<Tup>>
-            using is_tuple_of_empties = meta::all_of<is_empty_or_tuple_of_empties, Types>;
-
-            template <class Tup>
-            struct is_empty_or_tuple_of_empties<Tup, std::enable_if_t<is_tuple_of_empties<Tup>::value>>
-                : std::true_type {};
-
             namespace lazy {
                 template <class, class = void>
                 struct default_kind;
                 template <class T>
-                struct default_kind<T, std::enable_if_t<is_empty_or_tuple_of_empties<std::decay_t<T>>::value>>
+                struct default_kind<T,
+                    std::enable_if_t<tuple_util::is_empty_or_tuple_of_empties<std::decay_t<T>>::value>>
                     : std::decay<T> {};
             } // namespace lazy
             GT_META_DELEGATE_TO_LAZY(default_kind, class T, T);

--- a/include/gridtools/sid/concept.hpp
+++ b/include/gridtools/sid/concept.hpp
@@ -748,12 +748,12 @@ namespace gridtools {
          *  If `Bounds` doesn't have `Key`, integral_constant<int_t, min/max> is returned.
          */
         template <class Key, class Bounds>
-        GT_CONSTEXPR GT_FUNCTION decltype(auto) get_lower_bound(Bounds &&bounds) {
+        decltype(auto) get_lower_bound(Bounds &&bounds) {
             return gridtools::host_device::at_key_with_default<Key,
                 integral_constant<int_t, std::numeric_limits<int_t>::min()>>(wstd::forward<Bounds>(bounds));
         }
         template <class Key, class Bounds>
-        GT_CONSTEXPR GT_FUNCTION decltype(auto) get_upper_bound(Bounds &&bounds) {
+        decltype(auto) get_upper_bound(Bounds &&bounds) {
             return gridtools::host_device::at_key_with_default<Key,
                 integral_constant<int_t, std::numeric_limits<int_t>::max()>>(wstd::forward<Bounds>(bounds));
         }

--- a/include/gridtools/sid/concept.hpp
+++ b/include/gridtools/sid/concept.hpp
@@ -172,31 +172,6 @@ namespace gridtools {
                                  !std::is_member_pointer<decltype(&T::value)>::value>>
                 : std::integral_constant<decltype(T::value), T::value> {};
 
-            /**
-             *  generic trait for integral constant
-             *
-             *  TODO(anstaf) : consider moving it to `meta` or to `common`
-             */
-            template <class T, class = void>
-            struct is_integral_constant : std::false_type {};
-            template <class T>
-            struct is_integral_constant<T,
-                std::enable_if_t<std::is_empty<T>::value && std::is_integral<decltype(T::value)>::value &&
-                                 std::is_convertible<T, typename get_static_const_value<T>::value_type>::value &&
-                                 T() == get_static_const_value<T>::value>> : std::true_type {};
-
-            /**
-             *  generic trait for integral constant of Val
-             *
-             *  TODO(anstaf) : consider moving it to `meta` or to `common`
-             */
-            template <class T, int Val, class = void>
-            struct is_integral_constant_of : std::false_type {};
-
-            template <class T, int Val>
-            struct is_integral_constant_of<T, Val, std::enable_if_t<is_integral_constant<T>::value && T() == Val>>
-                : std::true_type {};
-
             /////// BEGIN defaults PART /////
 
             template <class Ptr>

--- a/include/gridtools/storage/builder.hpp
+++ b/include/gridtools/storage/builder.hpp
@@ -37,14 +37,6 @@ namespace gridtools {
                 struct layout {};
             } // namespace param
 
-            template <class, class = void>
-            struct is_integral_constant : std::false_type {};
-
-            template <class T>
-            struct is_integral_constant<T,
-                std::enable_if_t<std::is_base_of<std::integral_constant<typename T::value_type, T::value>, T>::value>>
-                : std::true_type {};
-
             template <class T>
             integral_constant<int_t, T::value> normalize_dimension(T, std::true_type) {
                 return {};

--- a/include/gridtools/storage/data_store.hpp
+++ b/include/gridtools/storage/data_store.hpp
@@ -16,6 +16,7 @@
 #include "../common/array.hpp"
 #include "../common/array_addons.hpp"
 #include "../common/defs.hpp"
+#include "../common/integral_constant.hpp"
 #include "../common/layout_map.hpp"
 #include "data_view.hpp"
 #include "info.hpp"
@@ -34,40 +35,47 @@ namespace gridtools {
                 return gcd(b, a % b);
             }
 
-            template <class Traits, class T, size_t N, class Id>
+            template <class Traits, class T, size_t ByteAlignment = traits::alignment<Traits>>
+            using get_alignment = integral_constant<int, ByteAlignment / gcd(sizeof(T), ByteAlignment)>;
+
+            template <class Traits, class T, class Info, class Id>
             class base {
                 static constexpr size_t byte_alignment = traits::alignment<Traits>;
                 static_assert(byte_alignment > 0, GT_INTERNAL_ERROR);
 
-                static constexpr size_t alignment = byte_alignment / gcd(sizeof(T), byte_alignment);
+                using alignment_t = get_alignment<Traits, T>;
+                using strides_t = decltype(std::declval<Info const &>().native_strides());
 
                 using mutable_data_t = std::remove_const_t<T>;
 
                 std::string m_name;
-                storage::info<N> m_info;
+                Info m_info;
                 traits::target_ptr_type<Traits, mutable_data_t> m_target_ptr_holder;
                 mutable_data_t *m_target_ptr;
 
               public:
-                using layout_t = traits::layout_type<Traits, N>;
+                using layout_t = traits::layout_type<Traits, Info::ndims>;
                 using data_t = T;
-                static constexpr size_t ndims = N;
+                static constexpr size_t ndims = Info::ndims;
 
-                using kind_t = meta::list<layout_t,
-                    meta::if_c<(layout_t::unmasked_length > 0), Id, void>,
-                    meta::if_c<(layout_t::unmasked_length > 1), std::integral_constant<size_t, alignment>, void>>;
+                using kind_t = meta::if_<tuple_util::is_empty_or_tuple_of_empties<strides_t>,
+                    strides_t,
+                    meta::list<layout_t, Id, meta::if_c<(layout_t::unmasked_length > 1), alignment_t, void>>>;
 
                 auto const &name() const { return m_name; }
                 auto const &info() const { return m_info; }
-                auto const &lengths() const { return m_info.lengths(); }
-                auto const &strides() const { return m_info.strides(); }
-                auto length() const { return m_info.length(); }
+                decltype(auto) native_lengths() const { return m_info.native_lengths(); }
+                decltype(auto) native_strides() const { return m_info.native_strides(); }
+                decltype(auto) lengths() const { return m_info.lengths(); }
+                decltype(auto) strides() const { return m_info.strides(); }
+                decltype(auto) length() const { return m_info.length(); }
 
               protected:
-                base(std::string name, array<uint_t, N> const &lengths, array<int, N> const &halos)
-                    : m_name(std::move(name)), m_info(layout_t(), alignment, lengths),
-                      m_target_ptr_holder(traits::allocate<Traits, mutable_data_t>(m_info.length() + alignment)) {
-                    auto offset_to_align = m_info.index(halos);
+                template <class Halos>
+                base(std::string name, Info info, Halos const &halos)
+                    : m_name(std::move(name)), m_info(std::move(info)),
+                      m_target_ptr_holder(traits::allocate<Traits, mutable_data_t>(m_info.length() + alignment_t())) {
+                    auto offset_to_align = m_info.index_from_tuple(halos);
                     auto byte_offset = offset_to_align * sizeof(T);
                     auto address_to_align = reinterpret_cast<std::uintptr_t>(m_target_ptr_holder.get()) + byte_offset;
                     m_target_ptr = reinterpret_cast<mutable_data_t *>(
@@ -79,14 +87,14 @@ namespace gridtools {
 
             template <class Traits,
                 class T,
-                size_t N,
+                class Info,
                 class Id,
                 bool = std::is_const<T>::value,
                 bool = traits::is_host_referenceable<Traits>>
-            class data_store_impl;
+            class data_store;
 
-            template <class Traits, class T, size_t N, class Id>
-            class data_store_impl<Traits, T, N, Id, false, false> : public base<Traits, T, N, Id> {
+            template <class Traits, class T, class Info, class Id>
+            class data_store<Traits, T, Info, Id, false, false> : public base<Traits, T, Info, Id> {
                 enum state { synced, invalid_host, invalid_target };
                 state m_state;
                 std::unique_ptr<T[]> m_host_ptr;
@@ -106,21 +114,16 @@ namespace gridtools {
                 }
 
               public:
-                data_store_impl(std::string name,
-                    array<uint_t, N> const &lengths,
-                    array<int, N> const &halos,
-                    uninitialized const &)
-                    : data_store_impl::base(std::move(name), lengths, halos), m_state(synced),
+                template <class Halos>
+                data_store(std::string name, Info info, Halos const &halos, uninitialized const &)
+                    : data_store::base(std::move(name), std::move(info), halos), m_state(synced),
                       m_host_ptr(std::make_unique<T[]>(this->info().length())) {}
 
-                template <class Initializer>
-                data_store_impl(std::string name,
-                    array<uint_t, N> const &lengths,
-                    array<int, N> const &halos,
-                    Initializer const &initializer)
-                    : data_store_impl::base(std::move(name), lengths, halos), m_state(invalid_target),
+                template <class Initializer, class Halos>
+                data_store(std::string name, Info info, Halos const &halos, Initializer const &initializer)
+                    : data_store::base(std::move(name), std::move(info), halos), m_state(invalid_target),
                       m_host_ptr(std::make_unique<T[]>(this->info().length())) {
-                    initializer(m_host_ptr.get(), typename data_store_impl::layout_t(), this->info());
+                    initializer(m_host_ptr.get(), typename data_store::layout_t(), this->info());
                 }
 
                 T *get_target_ptr() {
@@ -154,22 +157,17 @@ namespace gridtools {
                 }
             };
 
-            template <class Traits, class T, size_t N, class Id>
-            class data_store_impl<Traits, T, N, Id, false, true> : public base<Traits, T, N, Id> {
+            template <class Traits, class T, class Info, class Id>
+            class data_store<Traits, T, Info, Id, false, true> : public base<Traits, T, Info, Id> {
               public:
-                data_store_impl(std::string name,
-                    array<uint_t, N> const &lengths,
-                    array<int, N> const &halos,
-                    uninitialized const &)
-                    : data_store_impl::base(std::move(name), lengths, halos) {}
+                template <class Halos>
+                data_store(std::string name, Info info, Halos const &halos, uninitialized const &)
+                    : data_store::base(std::move(name), std::move(info), halos) {}
 
-                template <class Initializer>
-                data_store_impl(std::string name,
-                    array<uint_t, N> const &lengths,
-                    array<int, N> const &halos,
-                    Initializer const &initializer)
-                    : data_store_impl::base(std::move(name), lengths, halos) {
-                    initializer(this->raw_target_ptr(), typename data_store_impl::layout_t(), this->info());
+                template <class Initializer, class Halos>
+                data_store(std::string name, Info info, Halos const &halos, Initializer const &initializer)
+                    : data_store::base(std::move(name), std::move(info), halos) {
+                    initializer(this->raw_target_ptr(), typename data_store::layout_t(), this->info());
                 }
 
                 T *get_target_ptr() const { return this->raw_target_ptr(); }
@@ -186,9 +184,9 @@ namespace gridtools {
                 auto const_host_view() const { return const_target_view(); }
             };
 
-            template <class Traits, class T, size_t N, class Id, bool IsHostRefrenceable>
-            class data_store_impl<Traits, T const, N, Id, true, IsHostRefrenceable>
-                : public base<Traits, T const, N, Id> {
+            template <class Traits, class T, class Info, class Id, bool IsHostRefrenceable>
+            class data_store<Traits, T const, Info, Id, true, IsHostRefrenceable>
+                : public base<Traits, T const, Info, Id> {
 
                 template <class>
                 struct is_host_refrenceable : bool_constant<IsHostRefrenceable> {};
@@ -196,27 +194,22 @@ namespace gridtools {
                 template <class Initializer, std::enable_if_t<!is_host_refrenceable<Initializer>::value, int> = 0>
                 void init(Initializer const &initializer) {
                     auto host_ptr = std::make_unique<T[]>(this->info().length());
-                    initializer(host_ptr.get(), typename data_store_impl::layout_t(), this->info());
+                    initializer(host_ptr.get(), typename data_store::layout_t(), this->info());
                     traits::update_target<Traits>(this->raw_target_ptr(), host_ptr.get(), this->info().length());
                 }
 
                 template <class Initializer, std::enable_if_t<is_host_refrenceable<Initializer>::value, int> = 0>
                 void init(Initializer const &initializer) {
-                    initializer(this->raw_target_ptr(), typename data_store_impl::layout_t(), this->info());
+                    initializer(this->raw_target_ptr(), typename data_store::layout_t(), this->info());
                 }
 
               public:
-                data_store_impl(std::string name,
-                    array<uint_t, N> const &lengths,
-                    array<int, N> const &halos,
-                    uninitialized const &) = delete;
+                template <class Halos>
+                data_store(std::string, Info, Halos const &, uninitialized const &) = delete;
 
-                template <class Initializer>
-                data_store_impl(std::string name,
-                    array<uint_t, N> const &lengths,
-                    array<int, N> const &halos,
-                    Initializer const &initializer)
-                    : base<Traits, T const, N, Id>(std::move(name), lengths, halos) {
+                template <class Initializer, class Halos>
+                data_store(std::string name, Info info, Halos const &halos, Initializer const &initializer)
+                    : base<Traits, T const, Info, Id>(std::move(name), std::move(info), halos) {
                     init(initializer);
                 }
                 T const *get_target_ptr() const { return this->raw_target_ptr(); }
@@ -224,43 +217,51 @@ namespace gridtools {
                 auto get_const_target_ptr() const { return get_target_ptr(); }
                 auto const_target_view() const { return target_view(); }
             };
-        } // namespace data_store_impl_
 
-        template <class Traits, class T, size_t N, class Id>
-        struct data_store : data_store_impl_::data_store_impl<Traits, T, N, Id> {
-            using data_store_impl_::data_store_impl<Traits, T, N, Id>::data_store_impl;
-        };
+            template <class>
+            struct is_data_store : std::false_type {};
 
-        template <class>
-        struct is_data_store : std::false_type {};
+            template <class Traits, class T, class Info, class Id>
+            struct is_data_store<data_store<Traits, T, Info, Id>> : std::true_type {};
 
-        template <class Traits, class T, size_t N, class Id>
-        struct is_data_store<data_store<Traits, T, N, Id>> : std::true_type {};
+            template <class>
+            struct is_data_store_ptr : std::false_type {};
 
-        template <class>
-        struct is_data_store_ptr : std::false_type {};
+            template <class Traits, class T, class Info, class Id>
+            struct is_data_store_ptr<std::shared_ptr<data_store<Traits, T, Info, Id>>> : std::true_type {};
 
-        template <class Traits, class T, size_t N, class Id>
-        struct is_data_store_ptr<std::shared_ptr<data_store<Traits, T, N, Id>>> : std::true_type {};
-
-        template <class Traits, class T, class Id, size_t N, class Initializer>
-        auto make_data_store(std::string name,
-            array<uint_t, N> const &lengths,
-            array<int, N> const &halos,
-            Initializer const &initializer) {
-            return std::make_shared<data_store<Traits, T, N, Id>>(std::move(name), lengths, halos, initializer);
-        }
-
-        template <class DataStore>
-        auto make_total_lengths(DataStore const &ds) {
-            auto &&strides = ds.strides();
-            using layout_t = typename DataStore::layout_t;
-            std::decay_t<decltype(ds.lengths())> res;
-            for (int i = 0; i != DataStore::ndims; ++i) {
-                auto n = layout_t::at(i);
-                res[i] = n == -1 ? 1 : n == 0 ? ds.lengths()[i] : strides[layout_t::find(n - 1)] / strides[i];
+            template <class Traits, class T, class Id, class Info, class Halos, class Initializer>
+            auto make_data_store_helper(
+                std::string name, Info info, Halos const &halos, Initializer const &initializer) {
+                return std::make_shared<data_store<Traits, T, Info, Id>>(
+                    std::move(name), std::move(info), halos, initializer);
             }
-            return res;
-        }
+
+            template <class Traits, class T, class Id, class Lengths, class Halos, class Initializer>
+            auto make_data_store(
+                std::string name, Lengths const &lengths, Halos const &halos, Initializer const &initializer) {
+                return make_data_store_helper<Traits, T, Id>(std::move(name),
+                    make_info<traits::layout_type<Traits, tuple_util::size<Lengths>::value>>(
+                        get_alignment<Traits, T>(), lengths),
+                    halos,
+                    initializer);
+            }
+
+            template <class DataStore>
+            auto make_total_lengths(DataStore const &ds) {
+                auto &&strides = ds.strides();
+                using layout_t = typename DataStore::layout_t;
+                std::decay_t<decltype(ds.lengths())> res;
+                for (int i = 0; i != DataStore::ndims; ++i) {
+                    auto n = layout_t::at(i);
+                    res[i] = n == -1 ? 1 : n == 0 ? ds.lengths()[i] : strides[layout_t::find(n - 1)] / strides[i];
+                }
+                return res;
+            }
+        } // namespace data_store_impl_
+        using data_store_impl_::is_data_store;
+        using data_store_impl_::is_data_store_ptr;
+        using data_store_impl_::make_data_store;
+        using data_store_impl_::make_total_lengths;
     } // namespace storage
 } // namespace gridtools

--- a/include/gridtools/storage/data_view.hpp
+++ b/include/gridtools/storage/data_view.hpp
@@ -16,26 +16,32 @@
 
 namespace gridtools {
     namespace storage {
-        template <class T, size_t N>
+        template <class T, class Info>
         struct host_view {
             T *m_ptr;
-            storage::info<N> const *m_info;
+            Info const *m_info;
 
-            constexpr auto const &info() const { return *m_info; }
-            constexpr auto length() const { return m_info->length(); }
-            constexpr auto const &lengths() const { return m_info->lengths(); }
             auto *data() const { return m_ptr; }
+            auto const &info() const { return *m_info; }
+
+            decltype(auto) length() const { return m_info->length(); }
+            decltype(auto) lengths() const { return m_info->lengths(); }
+            decltype(auto) strides() const { return m_info->strides(); }
+            decltype(auto) native_lengths() const { return m_info->native_lengths(); }
+            decltype(auto) native_strides() const { return m_info->native_strides(); }
 
             template <class... Args>
             auto operator()(Args &&... args) const -> decltype(m_ptr[m_info->index(std::forward<Args>(args)...)]) {
                 return m_ptr[m_info->index(std::forward<Args>(args)...)];
             }
 
-            decltype(auto) operator()(array<int, N> const &arg) const { return m_ptr[m_info->index(arg)]; }
+            decltype(auto) operator()(array<int, Info::ndims> const &arg) const {
+                return m_ptr[m_info->index_from_tuple(arg)];
+            }
         };
 
-        template <class T, size_t N>
-        host_view<T, N> make_host_view(T *ptr, info<N> const &info) {
+        template <class T, class Info>
+        host_view<T, Info> make_host_view(T *ptr, Info const &info) {
             return {ptr, &info};
         }
     } // namespace storage

--- a/include/gridtools/storage/data_view.hpp
+++ b/include/gridtools/storage/data_view.hpp
@@ -12,7 +12,6 @@
 #include <utility>
 
 #include "../common/array.hpp"
-#include "info.hpp"
 
 namespace gridtools {
     namespace storage {

--- a/include/gridtools/storage/gpu.hpp
+++ b/include/gridtools/storage/gpu.hpp
@@ -19,6 +19,7 @@
 #include "../common/generic_metafunctions/utility.hpp"
 #include "../common/host_device.hpp"
 #include "../common/integral_constant.hpp"
+#include "../common/layout_map.hpp"
 
 namespace gridtools {
     namespace storage {

--- a/include/gridtools/storage/gpu.hpp
+++ b/include/gridtools/storage/gpu.hpp
@@ -19,7 +19,6 @@
 #include "../common/generic_metafunctions/utility.hpp"
 #include "../common/host_device.hpp"
 #include "../common/integral_constant.hpp"
-#include "info.hpp"
 
 namespace gridtools {
     namespace storage {
@@ -49,11 +48,11 @@ namespace gridtools {
                 GT_FUNCTION_DEVICE auto *data() const { return m_ptr; }
                 GT_FUNCTION_DEVICE auto const &info() const { return m_info; }
 
-                GT_FUNCTION_DEVICE decltype(auto) length() const { return m_info->length(); }
-                GT_FUNCTION_DEVICE decltype(auto) lengths() const { return m_info->lengths(); }
-                GT_FUNCTION_DEVICE decltype(auto) strides() const { return m_info->strides(); }
-                GT_FUNCTION_DEVICE decltype(auto) native_lengths() const { return m_info->native_lengths(); }
-                GT_FUNCTION_DEVICE decltype(auto) native_strides() const { return m_info->native_strides(); }
+                GT_FUNCTION_DEVICE decltype(auto) length() const { return m_info.length(); }
+                GT_FUNCTION_DEVICE decltype(auto) lengths() const { return m_info.lengths(); }
+                GT_FUNCTION_DEVICE decltype(auto) strides() const { return m_info.strides(); }
+                GT_FUNCTION_DEVICE decltype(auto) native_lengths() const { return m_info.native_lengths(); }
+                GT_FUNCTION_DEVICE decltype(auto) native_strides() const { return m_info.native_strides(); }
 
                 template <class... Args>
                 GT_FUNCTION_DEVICE auto operator()(Args &&... args) const

--- a/include/gridtools/storage/gpu.hpp
+++ b/include/gridtools/storage/gpu.hpp
@@ -40,15 +40,20 @@ namespace gridtools {
                 using type = layout_map<(N - 1 - Dims)...>;
             };
 
-            template <class T, size_t N>
+            template <class T, class Info>
             struct target_view {
                 T *m_ptr;
-                storage::info<N> m_info;
+                Info m_info;
 
 #if defined(GT_CUDA_ARCH) or (defined(GT_CUDACC) and defined(__clang__))
+                GT_FUNCTION_DEVICE auto *data() const { return m_ptr; }
                 GT_FUNCTION_DEVICE auto const &info() const { return m_info; }
 
-                GT_FUNCTION_DEVICE auto *data() const { return m_ptr; }
+                GT_FUNCTION_DEVICE decltype(auto) length() const { return m_info->length(); }
+                GT_FUNCTION_DEVICE decltype(auto) lengths() const { return m_info->lengths(); }
+                GT_FUNCTION_DEVICE decltype(auto) strides() const { return m_info->strides(); }
+                GT_FUNCTION_DEVICE decltype(auto) native_lengths() const { return m_info->native_lengths(); }
+                GT_FUNCTION_DEVICE decltype(auto) native_strides() const { return m_info->native_strides(); }
 
                 template <class... Args>
                 GT_FUNCTION_DEVICE auto operator()(Args &&... args) const
@@ -56,13 +61,9 @@ namespace gridtools {
                     return m_ptr[m_info.index(wstd::forward<Args>(args)...)];
                 }
 
-                GT_FUNCTION_DEVICE decltype(auto) operator()(array<int, N> const &arg) const {
-                    return m_ptr[m_info.index(arg)];
+                GT_FUNCTION_DEVICE decltype(auto) operator()(array<int, Info::ndims> const &arg) const {
+                    return m_ptr[m_info.index_from_tuple(arg)];
                 }
-
-                GT_FUNCTION_DEVICE GT_CONSTEXPR auto length() const { return m_info.length(); }
-
-                GT_FUNCTION_DEVICE GT_CONSTEXPR auto const &lengths() const { return m_info.lengths(); }
 #endif
             };
         } // namespace gpu_impl_
@@ -99,8 +100,8 @@ namespace gridtools {
                     cudaMemcpyDeviceToHost));
             }
 
-            template <class T, size_t N>
-            friend gpu_impl_::target_view<T, N> storage_make_target_view(gpu, T *ptr, info<N> const &info) {
+            template <class T, class Info>
+            friend gpu_impl_::target_view<T, Info> storage_make_target_view(gpu, T *ptr, Info const &info) {
                 return {ptr, info};
             }
         };

--- a/include/gridtools/storage/info.hpp
+++ b/include/gridtools/storage/info.hpp
@@ -18,22 +18,149 @@
 #include "../common/defs.hpp"
 #include "../common/generic_metafunctions/accumulate.hpp"
 #include "../common/host_device.hpp"
+#include "../common/integral_constant.hpp"
 #include "../common/layout_map.hpp"
+#include "../common/tuple.hpp"
+#include "../common/tuple_util.hpp"
 
 namespace gridtools {
     namespace storage {
         namespace info_impl_ {
-            template <class Layout>
-            constexpr uint_t make_padded_length(Layout, int layout_arg, uint_t align, uint_t length) {
-                if (layout_arg == -1)
-                    return 1;
-                if (layout_arg == Layout::max_arg && layout_arg != 0)
-                    return (length + align - 1) / align * align;
-                return length;
+
+            template <class>
+            struct layout_tuple;
+
+            template <int... Is>
+            struct layout_tuple<layout_map<Is...>> {
+                using type = tuple<integral_constant<int, Is>...>;
+            };
+
+            template <class Layout, class Align>
+            struct make_padded_length_f {
+                Align m_align;
+                template <class Length>
+                integral_constant<int, 1> operator()(integral_constant<int, -1>, Length) const {
+                    return {};
+                }
+                template <int Max = Layout::max_arg, class Length, std::enable_if_t<Max != 0 && Max != -1, int> = 0>
+                auto operator()(integral_constant<int, Layout::max_arg>, Length length) const {
+                    return (length + m_align - integral_constant<int, 1>()) / m_align * m_align;
+                }
+                template <int I, class Length>
+                auto operator()(integral_constant<int, I>, Length length) const {
+                    return length;
+                }
+            };
+
+            template <class Layout, class Align, class Lengths>
+            auto make_padded_lengths(Align align, Lengths const &lengths) {
+                return tuple_util::transform(
+                    make_padded_length_f<Layout, Align>{align}, typename layout_tuple<Layout>::type(), lengths);
+            }
+
+            template <class Layout, class Lengths>
+            struct make_stride_f {
+                Lengths const &m_lengths;
+                integral_constant<int, 0> operator()(integral_constant<int, -1>) const { return {}; }
+                template <int Max = Layout::max_arg, std::enable_if_t<Max != -1, int> = 0>
+                integral_constant<int, 1> operator()(integral_constant<int, Layout::max_arg>) const {
+                    return {};
+                }
+                template <int I>
+                auto operator()(integral_constant<int, I>) const {
+                    static constexpr size_t next = Layout::find(I + 1);
+                    return tuple_util::get<next>(m_lengths) * (*this)(integral_constant<int, I + 1>());
+                }
+            };
+
+            template <class Layout, class Lengths>
+            auto make_strides_helper(Lengths const &lengths) {
+                return tuple_util::transform(
+                    make_stride_f<Layout, Lengths>{lengths}, typename layout_tuple<Layout>::type());
+            }
+
+            template <class Layout, class Align, class Lengths>
+            auto make_strides(Align align, Lengths const &lengths) {
+                return make_strides_helper<Layout>(make_padded_lengths<Layout>(align, lengths));
+            }
+
+            template <class Lengths, class Strides, class = std::make_index_sequence<tuple_util::size<Lengths>::value>>
+            class info;
+
+            template <class Lengths, class Strides, size_t... Dims>
+            class info<Lengths, Strides, std::index_sequence<Dims...>> : tuple<Lengths, Strides> {
+                static_assert(tuple_util::size<Lengths>::value == tuple_util::size<Strides>::value, GT_INTERNAL_ERROR);
+
+                GT_FUNCTION tuple<Lengths, Strides> const &base() const { return *this; }
+
+              public:
+                static constexpr size_t ndims = tuple_util::size<Lengths>::value;
+
+                info(Lengths lengths, Strides strides)
+                    : tuple<Lengths, Strides>{std::move(lengths), std::move(strides)} {}
+
+                GT_FUNCTION auto const &native_lengths() const { return tuple_util::host_device::get<0>(base()); }
+                GT_FUNCTION auto const &native_strides() const { return tuple_util::host_device::get<1>(base()); }
+                GT_FUNCTION int length() const {
+                    return accumulate(logical_and(), true, lengths()[Dims]...) ? index((lengths()[Dims] - 1)...) + 1
+                                                                               : 0;
+                }
+                GT_FUNCTION array<int_t, ndims> lengths() const {
+                    return {(int_t)tuple_util::host_device::get<Dims>(native_lengths())...};
+                }
+                GT_FUNCTION array<int_t, ndims> strides() const {
+                    return {(int_t)tuple_util::host_device::get<Dims>(native_strides())...};
+                }
+
+                template <class... Is>
+                GT_FUNCTION auto index(Is... indices) const {
+                    static_assert(sizeof...(Is) == ndims, GT_INTERNAL_ERROR);
+                    assert(accumulate(
+                        logical_and(), true, (indices < tuple_util::host_device::get<Dims>(native_lengths()))...));
+                    return accumulate(plus_functor(),
+                        integral_constant<int, 0>(),
+                        indices * tuple_util::host_device::get<Dims>(native_strides())...);
+                    //                    return tuple_util::host_device::fold([](auto l, auto r) { return l + r; },
+                    //                        tuple_util::host_device::transform([](auto l, auto r) { return l * r; },
+                    //                            tuple_util::host_device::make<tuple>(indices...),
+                    //                            native_strides()));
+                }
+
+                template <class Indices>
+                GT_FUNCTION auto index_from_tuple(Indices const &indices) const {
+                    return index(tuple_util::host_device::get<Dims>(indices)...);
+                }
+
+                template <int... LayoutArgs>
+                GT_FUNCTION array<int, ndims> indices(layout_map<LayoutArgs...>, int_t index) const {
+                    return {(LayoutArgs == -1
+                                 ? lengths()[Dims] - 1
+                                 : LayoutArgs ? index % strides()[layout_map<LayoutArgs...>::find(LayoutArgs - 1)] /
+                                                    strides()[Dims]
+                                              : index / strides()[Dims])...};
+                }
+            };
+
+            template <class Lengths, class Strides>
+            info<Lengths, Strides> make_info_helper(Lengths lengths, Strides strides) {
+                return {std::move(lengths), std::move(strides)};
+            }
+
+            template <class Layout, class Align, class Lengths>
+            auto make_info(Align align, Lengths const &lengths) {
+                return make_info_helper(lengths, make_strides<Layout>(align, lengths));
+            }
+
+            template <class Layout, class Align, class Length>
+            uint_t make_padded_length(Layout, int layout_arg, Align align, Length length) {
+                return layout_arg == -1
+                           ? 1
+                           : layout_arg == Layout::max_arg && layout_arg != 0 ? (length + align - 1) / align * align
+                                                                              : length;
             }
 
             template <class Layout, class Array>
-            constexpr uint_t make_stride(Layout, int layout_arg, Array const &padded_lengths) {
+            uint_t make_stride(Layout, int layout_arg, Array const &padded_lengths) {
                 if (layout_arg == -1)
                     return 0;
                 uint_t res = 1;
@@ -42,18 +169,19 @@ namespace gridtools {
                 return res;
             }
 
-            template <int... Dims, int... LayoutArgs, class Array>
-            constexpr Array make_strides(layout_map<LayoutArgs...> layout, uint_t align, Array const &lengths) {
+            template <int... Dims, int... LayoutArgs, class Align, class Lengths>
+            Lengths make_strides_old(layout_map<LayoutArgs...> layout, Align align, Lengths const &lengths) {
                 assert(align > 0);
-                Array padded_lengths = {make_padded_length(layout, LayoutArgs, align, lengths[Dims])...};
+                Lengths padded_lengths = {
+                    make_padded_length(layout, LayoutArgs, align, tuple_util::get<Dims>(lengths))...};
                 return {make_stride(layout, LayoutArgs, padded_lengths)...};
             }
 
-            template <class>
+            template <class, class>
             struct base;
 
-            template <size_t... Dims>
-            struct base<std::index_sequence<Dims...>> {
+            template <class Lengths, size_t... Dims>
+            struct base<Lengths, std::index_sequence<Dims...>> {
                 static constexpr size_t ndims = sizeof...(Dims);
 
               private:
@@ -61,16 +189,15 @@ namespace gridtools {
                 template <size_t>
                 using index_type = uint_t;
 
-                array_t m_lengths;
+                Lengths m_lengths;
                 array_t m_strides;
                 uint_t m_length;
 
               public:
-                constexpr base() : m_lengths{}, m_strides{}, m_length(0) {}
-
-                template <int... LayoutArgs>
-                constexpr base(layout_map<LayoutArgs...> layout, uint_t align, array_t const &lengths)
-                    : m_lengths(lengths), m_strides(make_strides<Dims...>(layout, align, m_lengths)),
+                template <int... LayoutArgs, class Align, class Lens>
+                base(layout_map<LayoutArgs...> layout, Align align, Lens const &lengths)
+                    : m_lengths{tuple_util::get<Dims>(lengths)...},
+                      m_strides(make_strides_old<Dims...>(layout, align, m_lengths)),
                       m_length(accumulate(logical_and(), true, m_lengths[Dims]...) ? index((m_lengths[Dims] - 1)...) + 1
                                                                                    : 0) {}
 
@@ -98,9 +225,11 @@ namespace gridtools {
             };
         } // namespace info_impl_
 
+        using info_impl_::make_info;
+
         template <size_t N>
-        struct info : info_impl_::base<std::make_index_sequence<N>> {
-            using info_impl_::base<std::make_index_sequence<N>>::base;
+        struct info : info_impl_::base<array<uint_t, N>, std::make_index_sequence<N>> {
+            using info_impl_::base<array<uint_t, N>, std::make_index_sequence<N>>::base;
         };
 
         template <size_t N>

--- a/include/gridtools/storage/sid.hpp
+++ b/include/gridtools/storage/sid.hpp
@@ -19,79 +19,12 @@
 #include "../common/layout_map.hpp"
 #include "../common/tuple.hpp"
 #include "../common/tuple_util.hpp"
-#include "../meta/if.hpp"
-#include "../meta/macros.hpp"
-#include "../meta/make_indices.hpp"
-#include "../meta/transform.hpp"
+#include "../meta.hpp"
 #include "data_store.hpp"
 
 namespace gridtools {
     namespace storage {
         namespace storage_sid_impl_ {
-
-            enum class dimension_kind { masked, innermost, dynamic };
-
-            constexpr dimension_kind get_dimension_kind(int i, size_t n_dim) {
-                return i < 0 ? dimension_kind::masked
-                             : i + 1 == n_dim ? dimension_kind::innermost : dimension_kind::dynamic;
-            }
-
-            template <dimension_kind Kind>
-            struct stride_type;
-
-            template <>
-            struct stride_type<dimension_kind::masked> {
-                using type = integral_constant<int_t, 0>;
-            };
-
-            template <>
-            struct stride_type<dimension_kind::innermost> {
-                using type = integral_constant<int_t, 1>;
-            };
-
-            template <>
-            struct stride_type<dimension_kind::dynamic> {
-                using type = int_t;
-            };
-
-            template <class I, class Res>
-            struct stride_generator_f;
-
-            template <class I, int V>
-            struct stride_generator_f<I, integral_constant<int_t, V>> {
-                using type = stride_generator_f;
-                template <class Src>
-                integral_constant<int_t, V> operator()(Src const &src) {
-                    assert(src[I::value] == V);
-                    return {};
-                }
-            };
-
-            template <class I>
-            struct stride_generator_f<I, int_t> {
-                using type = stride_generator_f;
-                template <class Src>
-                int_t operator()(Src const &src) {
-                    assert(src[I::value] != 0);
-                    return (int_t)src[I::value];
-                }
-            };
-
-            template <class Layout>
-            struct convert_strides_f;
-
-            template <int... Is>
-            struct convert_strides_f<layout_map<Is...>> {
-                using res_t =
-                    tuple<typename stride_type<get_dimension_kind(Is, layout_map<Is...>::unmasked_length)>::type...>;
-                using generators_t = meta::transform<stride_generator_f, meta::make_indices_c<sizeof...(Is)>, res_t>;
-
-                template <class Src>
-                res_t operator()(Src const &src) const {
-                    return tuple_util::generate<generators_t, res_t>(src);
-                }
-            };
-
             struct empty_ptr_diff {
                 template <class T>
                 friend GT_CONSTEXPR GT_FUNCTION T *operator+(T *lhs, empty_ptr_diff) {
@@ -111,40 +44,27 @@ namespace gridtools {
                 friend GT_FORCE_INLINE constexpr ptr_holder operator+(ptr_holder obj, empty_ptr_diff) { return obj; }
             };
 
-            template <class Src>
-            using to_dim = integral_constant<int_t, Src::value>;
-
-            namespace lazy {
-                template <class Layout>
-                struct get_unmasked_dims;
-                template <int... Is>
-                struct get_unmasked_dims<layout_map<Is...>> {
-                    using indices_t = meta::make_indices_c<sizeof...(Is), tuple>;
-                    using dims_t = meta::transform<to_dim, indices_t>;
-                    using items_t = meta::zip<dims_t, meta::list<bool_constant<Is >= 0>...>>;
-                    using filtered_items_t = meta::filter<meta::second, items_t>;
-                    using type = meta::transform<meta::first, filtered_items_t>;
-                };
-            } // namespace lazy
-            GT_META_DELEGATE_TO_LAZY(get_unmasked_dims, class Layout, Layout);
-
-            template <class DataStore,
-                class Value,
-                class Layout = typename DataStore::layout_t,
-                class Dims = get_unmasked_dims<Layout>,
-                class Values = meta::repeat_c<Layout::unmasked_length, Value>>
-            using bounds_type = hymap::from_keys_values<Dims, Values>;
-
             template <class Dim>
-            struct upper_bound_generator_f {
-                using type = upper_bound_generator_f;
-
+            struct bound_generator_f {
                 template <class Lengths>
-                int_t operator()(Lengths const &lengths) const {
-                    return lengths[Dim::value];
+                auto operator()(Lengths const &lengths) const {
+                    return tuple_util::get<Dim::value>(lengths);
                 }
             };
 
+            template <int... Is, class Bounds>
+            auto filter_unmasked_bounds(layout_map<Is...>, Bounds const &bounds) {
+                using all_keys_t = get_keys<Bounds>;
+                using all_values_t = tuple_util::traits::to_types<Bounds>;
+                using is_unmasked_t = meta::list<bool_constant<Is >= 0>...>;
+                using all_items_t = meta::zip<is_unmasked_t, all_keys_t, all_values_t>;
+                using items_t = meta::filter<meta::first, all_items_t>;
+                using keys_t = meta::transform<meta::second, items_t>;
+                using values_t = meta::transform<meta::third, items_t>;
+                using res_t = hymap::from_keys_values<keys_t, values_t>;
+                using generators_t = meta::transform<bound_generator_f, keys_t>;
+                return tuple_util::generate<generators_t, res_t>(bounds);
+            }
         } // namespace storage_sid_impl_
 
         /**
@@ -157,7 +77,7 @@ namespace gridtools {
 
         template <class DataStore, std::enable_if_t<is_data_store<DataStore>::value, int> = 0>
         auto sid_get_strides(std::shared_ptr<DataStore> const &ds) {
-            return storage_sid_impl_::convert_strides_f<typename DataStore::layout_t>{}(ds->strides());
+            return ds->native_strides();
         }
 
         template <class DataStore, std::enable_if_t<is_data_store<DataStore>::value, int> = 0>
@@ -168,17 +88,16 @@ namespace gridtools {
         sid_get_ptr_diff(std::shared_ptr<DataStore> const &);
 
         template <class DataStore, std::enable_if_t<is_data_store<DataStore>::value, int> = 0>
-        storage_sid_impl_::bounds_type<DataStore, integral_constant<int_t, 0>> sid_get_lower_bounds(
-            std::shared_ptr<DataStore> const &) {
-            return {};
+        auto sid_get_lower_bounds(std::shared_ptr<DataStore> const &) {
+            using layout_t = typename DataStore::layout_t;
+            using bounds_t = meta::rename<tuple, meta::repeat_c<DataStore::ndims, integral_constant<int_t, 0>>>;
+            return storage_sid_impl_::filter_unmasked_bounds(layout_t(), bounds_t());
         }
 
         template <class DataStore, std::enable_if_t<is_data_store<DataStore>::value, int> = 0>
         auto sid_get_upper_bounds(std::shared_ptr<DataStore> const &ds) {
-            using res_t = storage_sid_impl_::bounds_type<DataStore, int_t>;
-            using keys_t = get_keys<res_t>;
-            using generators_t = meta::transform<storage_sid_impl_::upper_bound_generator_f, keys_t>;
-            return tuple_util::generate<generators_t, res_t>(ds->lengths());
+            using layout_t = typename DataStore::layout_t;
+            return storage_sid_impl_::filter_unmasked_bounds(layout_t(), ds->native_lengths());
         }
     } // namespace storage
 } // namespace gridtools

--- a/include/gridtools/storage/traits.hpp
+++ b/include/gridtools/storage/traits.hpp
@@ -13,7 +13,6 @@
 
 #include "../meta.hpp"
 #include "data_view.hpp"
-#include "info.hpp"
 
 namespace gridtools {
     namespace storage {

--- a/include/gridtools/storage/traits.hpp
+++ b/include/gridtools/storage/traits.hpp
@@ -49,13 +49,13 @@ namespace gridtools {
                 storage_update_host(Traits(), dst, src, size);
             }
 
-            template <class Traits, class T, size_t N, std::enable_if_t<is_host_referenceable<Traits>, int> = 0>
-            auto storage_make_target_view(Traits, T *ptr, info<N> const &info) {
+            template <class Traits, class T, class Info, std::enable_if_t<is_host_referenceable<Traits>, int> = 0>
+            auto storage_make_target_view(Traits, T *ptr, Info const &info) {
                 return make_host_view(ptr, info);
             }
 
-            template <class Traits, class T, size_t N>
-            auto make_target_view(T *ptr, info<N> const &info) {
+            template <class Traits, class T, class Info>
+            auto make_target_view(T *ptr, Info const &info) {
                 return storage_make_target_view(Traits(), ptr, info);
             }
         } // namespace traits

--- a/tests/unit_tests/storage/test_storage_info.cpp
+++ b/tests/unit_tests/storage/test_storage_info.cpp
@@ -12,67 +12,71 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <gridtools/common/integral_constant.hpp>
+#include <gridtools/common/tuple.hpp>
+#include <gridtools/common/tuple_util.hpp>
+
 namespace gridtools {
     namespace storage {
         namespace {
             using testing::ElementsAre;
+            namespace tu = tuple_util;
+            using namespace literals;
 
             TEST(StorageInfo, Strides) {
                 {
-                    info<3> si(layout_map<0, 1, 2>(), 1, {3, 4, 5});
+                    auto si = make_info<layout_map<0, 1, 2>>(1_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_THAT(si.strides(), ElementsAre(20, 5, 1));
                     EXPECT_EQ(si.length(), 3 * 4 * 5);
                 }
                 {
-                    info<3> si(layout_map<2, 0, 1>(), 1, {3, 4, 5});
+                    auto si = make_info<layout_map<2, 0, 1>>(1_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_THAT(si.strides(), ElementsAre(1, 15, 3));
                     EXPECT_EQ(si.length(), 3 * 4 * 5);
                 }
                 {
-                    info<3> si(layout_map<-1, 0, 1>(), 1, {3, 4, 5});
+                    auto si = make_info<layout_map<-1, 0, 1>>(1_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_THAT(si.strides(), ElementsAre(0, 5, 1));
                     EXPECT_EQ(si.length(), 4 * 5);
                 }
             }
-
             TEST(StorageInfo, StridesAlignment) {
                 {
-                    info<3> si(layout_map<0, 1, 2>(), 32, {3, 4, 5});
+                    auto si = make_info<layout_map<0, 1, 2>>(32_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_THAT(si.strides(), ElementsAre(128, 32, 1));
                     EXPECT_GE(si.length(), 3 * 4 * 5);
                     EXPECT_LE(si.length(), 3 * 4 * 32);
                 }
                 {
-                    info<3> si(layout_map<2, 0, 1>(), 32, {3, 4, 5});
+                    auto si = make_info<layout_map<2, 0, 1>>(32_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_THAT(si.strides(), ElementsAre(1, 32 * 5, 32));
                     EXPECT_GE(si.length(), 3 * 4 * 5);
                     EXPECT_LE(si.length(), 32 * 4 * 5);
                 }
                 {
-                    info<3> si(layout_map<-1, 0, 1>(), 32, {3, 4, 5});
+                    auto si = make_info<layout_map<-1, 0, 1>>(32_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_THAT(si.strides(), ElementsAre(0, 32, 1));
                     EXPECT_GE(si.length(), 4 * 5);
                     EXPECT_LE(si.length(), 4 * 32);
                 }
             }
-
             TEST(StorageInfo, IndexVariadic) {
                 {
-                    info<3> si(layout_map<0, 1, 2>(), 1, {3, 4, 5});
+                    auto si = make_info<layout_map<0, 1, 2>>(1_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_EQ(si.index(0, 0, 0), 0);
                     EXPECT_EQ(si.index(0, 0, 1), 1);
                     EXPECT_EQ(si.index(0, 1, 0), 5);
                     EXPECT_EQ(si.index(1, 0, 0), 20);
                 }
                 {
-                    info<3> si(layout_map<2, 0, 1>(), 1, {3, 4, 5});
+                    auto si = make_info<layout_map<2, 0, 1>>(1_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_EQ(si.index(0, 0, 0), 0);
                     EXPECT_EQ(si.index(0, 0, 1), 3);
                     EXPECT_EQ(si.index(0, 1, 0), 15);
                     EXPECT_EQ(si.index(1, 0, 0), 1);
                 }
                 {
-                    info<3> si(layout_map<-1, 0, 1>(), 1, {3, 4, 5});
+                    auto si = make_info<layout_map<-1, 0, 1>>(1_c, tu::make<tuple>(3, 4, 5));
                     EXPECT_EQ(si.index(0, 0, 0), 0);
                     EXPECT_EQ(si.index(0, 0, 1), 1);
                     EXPECT_EQ(si.index(0, 1, 0), 5);
@@ -83,7 +87,7 @@ namespace gridtools {
 
             TEST(StorageInfo, Simple) {
                 {
-                    info<3> si(layout_map<2, 1, 0>(), 1, {3, 3, 3});
+                    auto si = make_info<layout_map<2, 1, 0>>(1_c, tu::make<tuple>(3, 3, 3));
                     EXPECT_EQ(si.index(0, 0, 0), 0);
                     EXPECT_EQ(si.index(0, 0, 1), 9);
                     EXPECT_EQ(si.index(0, 0, 2), 18);
@@ -101,7 +105,7 @@ namespace gridtools {
                     EXPECT_EQ(si.index(1, 0, 2), 19);
                 }
                 {
-                    info<3> si(layout_map<0, 1, 2>(), 1, {3, 3, 3});
+                    auto si = make_info<layout_map<0, 1, 2>>(1_c, tu::make<tuple>(3, 3, 3));
                     EXPECT_EQ(si.index(0, 0, 0), 0);
                     EXPECT_EQ(si.index(0, 0, 1), 1);
                     EXPECT_EQ(si.index(0, 0, 2), 2);
@@ -119,7 +123,7 @@ namespace gridtools {
                     EXPECT_EQ(si.index(1, 0, 2), 11);
                 }
                 {
-                    info<3> si(layout_map<1, 0, 2>(), 1, {3, 3, 3});
+                    auto si = make_info<layout_map<1, 0, 2>>(1_c, tu::make<tuple>(3, 3, 3));
                     EXPECT_EQ(si.index(0, 0, 0), 0);
                     EXPECT_EQ(si.index(0, 0, 1), 1);
                     EXPECT_EQ(si.index(0, 0, 2), 2);
@@ -138,76 +142,19 @@ namespace gridtools {
                 }
 
                 // test with different dims
-                info<4> x(layout_map<1, 2, 3, 0>(), 1, {5, 7, 8, 2});
+                auto x = make_info<layout_map<1, 2, 3, 0>>(1_c, tu::make<tuple>(5, 7, 8, 2));
                 EXPECT_THAT(x.lengths(), ElementsAre(5, 7, 8, 2));
                 EXPECT_THAT(x.strides(), ElementsAre(56, 8, 1, 280));
             }
 
-            TEST(StorageInfo, ArrayAccess) {
-                {
-                    info<3> si(layout_map<2, 1, 0>(), 1, {3, 3, 3});
-                    EXPECT_EQ(si.index({0, 0, 0}), 0);
-                    EXPECT_EQ(si.index({0, 0, 1}), 9);
-                    EXPECT_EQ(si.index({0, 0, 2}), 18);
-
-                    EXPECT_EQ(si.index({0, 1, 0}), 3);
-                    EXPECT_EQ(si.index({0, 1, 1}), 12);
-                    EXPECT_EQ(si.index({0, 1, 2}), 21);
-
-                    EXPECT_EQ(si.index({0, 2, 0}), 6);
-                    EXPECT_EQ(si.index({0, 2, 1}), 15);
-                    EXPECT_EQ(si.index({0, 2, 2}), 24);
-
-                    EXPECT_EQ(si.index({1, 0, 0}), 1);
-                    EXPECT_EQ(si.index({1, 0, 1}), 10);
-                    EXPECT_EQ(si.index({1, 0, 2}), 19);
-                }
-                {
-                    info<3> si(layout_map<0, 1, 2>(), 1, {3, 3, 3});
-                    EXPECT_EQ(si.index({0, 0, 0}), 0);
-                    EXPECT_EQ(si.index({0, 0, 1}), 1);
-                    EXPECT_EQ(si.index({0, 0, 2}), 2);
-
-                    EXPECT_EQ(si.index({0, 1, 0}), 3);
-                    EXPECT_EQ(si.index({0, 1, 1}), 4);
-                    EXPECT_EQ(si.index({0, 1, 2}), 5);
-
-                    EXPECT_EQ(si.index({0, 2, 0}), 6);
-                    EXPECT_EQ(si.index({0, 2, 1}), 7);
-                    EXPECT_EQ(si.index({0, 2, 2}), 8);
-
-                    EXPECT_EQ(si.index({1, 0, 0}), 9);
-                    EXPECT_EQ(si.index({1, 0, 1}), 10);
-                    EXPECT_EQ(si.index({1, 0, 2}), 11);
-                }
-                {
-                    info<3> si(layout_map<1, 0, 2>(), 1, {3, 3, 3});
-                    EXPECT_EQ(si.index({0, 0, 0}), 0);
-                    EXPECT_EQ(si.index({0, 0, 1}), 1);
-                    EXPECT_EQ(si.index({0, 0, 2}), 2);
-
-                    EXPECT_EQ(si.index({0, 1, 0}), 9);
-                    EXPECT_EQ(si.index({0, 1, 1}), 10);
-                    EXPECT_EQ(si.index({0, 1, 2}), 11);
-
-                    EXPECT_EQ(si.index({0, 2, 0}), 18);
-                    EXPECT_EQ(si.index({0, 2, 1}), 19);
-                    EXPECT_EQ(si.index({0, 2, 2}), 20);
-
-                    EXPECT_EQ(si.index({1, 0, 0}), 3);
-                    EXPECT_EQ(si.index({1, 0, 1}), 4);
-                    EXPECT_EQ(si.index({1, 0, 2}), 5);
-                }
-            }
-
             TEST(StorageInfo, Alignment) {
                 {
-                    info<4> x(layout_map<1, 2, 3, 0>(), 32, {5, 7, 32, 2});
+                    auto x = make_info<layout_map<1, 2, 3, 0>>(32_c, tu::make<tuple>(5, 7, 32, 2));
                     EXPECT_THAT(x.lengths(), ElementsAre(5, 7, 32, 2));
                     EXPECT_THAT(x.strides(), ElementsAre(32 * 7, 32, 1, 5 * 32 * 7));
                 }
                 {
-                    info<4> x(layout_map<1, 2, 3, 0>(), 32, {7, 11, 3, 10});
+                    auto x = make_info<layout_map<1, 2, 3, 0>>(32_c, tu::make<tuple>(7, 11, 3, 10));
                     EXPECT_THAT(x.lengths(), ElementsAre(7, 11, 3, 10));
                     EXPECT_THAT(x.strides(), ElementsAre(32 * 11, 32, 1, 32 * 11 * 7));
                     EXPECT_EQ(x.index(0, 0, 0, 0), 0);
@@ -215,7 +162,7 @@ namespace gridtools {
                     EXPECT_EQ(x.index(0, 0, 2, 0), 2);
                 }
                 {
-                    info<4> x(layout_map<3, 2, 1, 0>(), 32, {3, 11, 14, 10});
+                    auto x = make_info<layout_map<3, 2, 1, 0>>(32_c, tu::make<tuple>(3, 11, 14, 10));
                     EXPECT_THAT(x.lengths(), ElementsAre(3, 11, 14, 10));
                     EXPECT_THAT(x.strides(), ElementsAre(1, 32, 32 * 11, 32 * 11 * 14));
                     EXPECT_EQ(x.index(0, 0, 0, 0), 0);
@@ -224,7 +171,7 @@ namespace gridtools {
                     EXPECT_EQ(x.index(0, 0, 0, 1), 32 * 11 * 14);
                 }
                 {
-                    info<4> x(layout_map<1, -1, -1, 0>(), 32, {7, 7, 8, 10});
+                    auto x = make_info<layout_map<1, -1, -1, 0>>(32_c, tu::make<tuple>(7, 7, 8, 10));
                     EXPECT_THAT(x.lengths(), ElementsAre(7, 7, 8, 10));
                     EXPECT_THAT(x.strides(), ElementsAre(1, 0, 0, 32));
                     EXPECT_EQ(x.index(0, 0, 0, 0), 0);
@@ -235,19 +182,6 @@ namespace gridtools {
                     EXPECT_LE(x.length(), 32 * 10);
                 }
             }
-
-            TEST(StorageInfo, Equal) {
-                info<3> si1(layout_map<0, 1, 2>(), 16, {9, 11, 13});
-                info<3> si2(layout_map<0, 1, 2>(), 16, {9, 11, 13});
-                EXPECT_EQ(si1, si2);
-            }
-
-            TEST(StorageInfo, SizesNotEqual) {
-                info<3> si1(layout_map<0, 1, 2>(), 16, {9, 11, 13});
-                info<3> si2(layout_map<0, 1, 2>(), 16, {9, 11, 15});
-                EXPECT_NE(si1, si2);
-            }
-
         } // namespace
     }     // namespace storage
 } // namespace gridtools

--- a/tests/unit_tests/storage/test_storage_sid.cpp
+++ b/tests/unit_tests/storage/test_storage_sid.cpp
@@ -25,6 +25,7 @@ namespace gridtools {
     namespace {
         namespace tu = tuple_util;
         using tuple_util::get;
+        using namespace literals;
 
         const auto builder = storage::builder<storage_traits_t>.type<double>().layout<1, -1, 2, 0>();
 
@@ -101,5 +102,16 @@ namespace gridtools {
             static_assert(tuple_util::size<lower_bounds_t>() == 0, "");
             static_assert(tuple_util::size<upper_bounds_t>() == 0, "");
         }
-    } // namespace
+
+        namespace compile_time_lengths {
+            using testee_t =
+                decltype(storage::builder<storage_traits_t>.type<int>().layout<0, 1>().dimensions(10_c, 10_c)());
+
+            static_assert(sid::concept_impl_::is_sid<testee_t>(), "");
+
+            static_assert(tuple_util::is_empty_or_tuple_of_empties<sid::strides_type<testee_t>>(), "");
+            static_assert(tuple_util::is_empty_or_tuple_of_empties<sid::lower_bounds_type<testee_t>>(), "");
+            static_assert(tuple_util::is_empty_or_tuple_of_empties<sid::upper_bounds_type<testee_t>>(), "");
+        } // namespace compile_time_lengths
+    }     // namespace
 } // namespace gridtools

--- a/tests/unit_tests/storage/test_storage_sid.cpp
+++ b/tests/unit_tests/storage/test_storage_sid.cpp
@@ -103,15 +103,26 @@ namespace gridtools {
             static_assert(tuple_util::size<upper_bounds_t>() == 0, "");
         }
 
-        namespace compile_time_lengths {
-            using testee_t =
-                decltype(storage::builder<storage_traits_t>.type<int>().layout<0, 1>().dimensions(10_c, 10_c)());
+        TEST(storage_sid, compile_time_lengths) {
+            auto testee = storage::builder<storage_traits_t>.type<int>().layout<0, 1>().dimensions(10_c, 10_c)();
+            using testee_t = decltype(testee);
 
             static_assert(sid::concept_impl_::is_sid<testee_t>(), "");
 
-            static_assert(tuple_util::is_empty_or_tuple_of_empties<sid::strides_type<testee_t>>(), "");
-            static_assert(tuple_util::is_empty_or_tuple_of_empties<sid::lower_bounds_type<testee_t>>(), "");
-            static_assert(tuple_util::is_empty_or_tuple_of_empties<sid::upper_bounds_type<testee_t>>(), "");
-        } // namespace compile_time_lengths
-    }     // namespace
+            using strides_t = sid::strides_type<testee_t>;
+            using bounds_t = sid::upper_bounds_type<testee_t>;
+
+            static_assert(tuple_util::is_empty_or_tuple_of_empties<strides_t>(), "");
+            static_assert(tuple_util::is_empty_or_tuple_of_empties<bounds_t>(), "");
+
+            static_assert(tu::size<bounds_t>() == 2, "");
+            static_assert(tu::element<1, bounds_t>::value == 10, "");
+            static_assert(tu::element<0, bounds_t>::value == 10, "");
+
+            auto expected_strides = testee->strides();
+            static_assert(tu::size<strides_t>() == 2, "");
+            EXPECT_EQ(expected_strides[0], (tu::element<0, strides_t>::value));
+            EXPECT_EQ(expected_strides[1], (tu::element<1, strides_t>::value));
+        }
+    } // namespace
 } // namespace gridtools


### PR DESCRIPTION
The changes is the storage API:
- Data store builder `dimensions` method now accepts both integers and integral constants. Type information is propagated to the data store that is built.
- The properly typed lengths and strides are available to the user via the `native_lengths()` and `native_strides()` methods from data_store/view/info.
- Data store sid adapter uses `native_lengths()`/`native_strides()` now. So the knowledge of the compile time lengths is propagated to the SID API
- call operator of the data store view is now also `compile time aware`. I.e. if the dimension offsets are provided as integral constants and all strides are also known in compile time, no stride computations are performed in run time.  
- There are minor backward incompatibilities to the public API:
  - `data_store` and `info` template classes are moved from the public `gridtools::storage` namespace. They should be considered implementation details now.
  - `lengths()` and `strides()` methods now return by value, not by const reference.  