### PR TITLE
Introduce dump backend 

### DIFF
--- a/cmake/public/gridtools_setup_targets.cmake
+++ b/cmake/public/gridtools_setup_targets.cmake
@@ -218,17 +218,24 @@ macro(_gt_setup_targets _config_mode clang_cuda_mode)
     _gt_add_library(${_config_mode} stencil_naive)
     target_link_libraries(${_gt_namespace}stencil_naive INTERFACE ${_gt_namespace}gridtools)
 
-    include(FetchContent)
-
-    FetchContent_Declare(json
-            GIT_REPOSITORY https://github.com/nlohmann/json.git
-            GIT_TAG v3.7.3)
-
-    FetchContent_GetProperties(json)
-    if(NOT json_POPULATED)
-        FetchContent_Populate(json)
-        set(JSON_BuildTests OFF CACHE INTERNAL "")
-        add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
+    set(_required_nlohmann_json_version "3.7.3")
+    if(NOT _nlohmann_json_already_fetched)
+        find_package(nlohmann_json ${_required_nlohmann_json_version})
+    endif()
+    if(NOT nlohmann_json_FOUND)
+        set(_gridtools_repository "https://github.com/GridTools/gridtools.git")
+        set(_gridtools_tag        "v${_required_gridtools_version}")
+        include(FetchContent)
+        FetchContent_Declare(json
+                GIT_REPOSITORY https://github.com/nlohmann/json.git
+                GIT_TAG "v${_required_nlohmann_json_version}")
+        FetchContent_GetProperties(json)
+        if(NOT json_POPULATED)
+            FetchContent_Populate(json)
+            set(JSON_BuildTests OFF CACHE INTERNAL "")
+            add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
+        endif()
+        set(_nlohmann_json_already_fetched ON CACHE INTERNAL "")
     endif()
 
     _gt_add_library(${_config_mode} stencil_dump)

--- a/cmake/public/gridtools_setup_targets.cmake
+++ b/cmake/public/gridtools_setup_targets.cmake
@@ -218,6 +218,21 @@ macro(_gt_setup_targets _config_mode clang_cuda_mode)
     _gt_add_library(${_config_mode} stencil_naive)
     target_link_libraries(${_gt_namespace}stencil_naive INTERFACE ${_gt_namespace}gridtools)
 
+    include(FetchContent)
+
+    FetchContent_Declare(json
+            GIT_REPOSITORY https://github.com/nlohmann/json.git
+            GIT_TAG v3.7.3)
+
+    FetchContent_GetProperties(json)
+    if(NOT json_POPULATED)
+        FetchContent_Populate(json)
+        add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
+    endif()
+
+    _gt_add_library(${_config_mode} stencil_dump)
+    target_link_libraries(${_gt_namespace}stencil_dump INTERFACE ${_gt_namespace}gridtools nlohmann_json::nlohmann_json)
+
     set(GT_STENCILS naive)
     set(GT_STORAGES cpu_kfirst cpu_ifirst)
     set(GT_GCL_ARCHS)

--- a/cmake/public/gridtools_setup_targets.cmake
+++ b/cmake/public/gridtools_setup_targets.cmake
@@ -227,6 +227,7 @@ macro(_gt_setup_targets _config_mode clang_cuda_mode)
     FetchContent_GetProperties(json)
     if(NOT json_POPULATED)
         FetchContent_Populate(json)
+        set(JSON_BuildTests OFF CACHE INTERNAL "")
         add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
     endif()
 

--- a/include/gridtools/stencil/core/backend.hpp
+++ b/include/gridtools/stencil/core/backend.hpp
@@ -30,18 +30,18 @@ namespace gridtools {
                         std::move(data_stores));
                 }
 
-                template <class Backend, class Spec>
-                struct backend_entry_point_f {
-                    template <class Grid, class DataStores>
-                    void operator()(Grid const &grid, DataStores data_stores) const {
-                        gridtools_backend_entry_point(Backend(),
+                template <class Spec>
+                struct call_entry_point_f {
+                    template <class Backend, class Grid, class DataStores>
+                    void operator()(Backend &&be, Grid const &grid, DataStores data_stores) const {
+                        gridtools_backend_entry_point(std::forward<Backend>(be),
                             convert_fe_to_be_spec<Spec, typename Grid::interval_t, DataStores>(),
                             grid,
                             shift_origin(grid, std::move(data_stores)));
                     }
                 };
             } // namespace backend_impl_
-            using backend_impl_::backend_entry_point_f;
+            using backend_impl_::call_entry_point_f;
         } // namespace core
     }     // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/convert_fe_to_be_spec.hpp
+++ b/include/gridtools/stencil/core/convert_fe_to_be_spec.hpp
@@ -39,7 +39,7 @@ namespace gridtools {
 
                 template <class Plh, bool = is_tmp_arg<Plh>::value>
                 struct get_num_colors {
-                    using type = void;
+                    using type = integral_constant<int, -1>;
                 };
 
                 template <class Plh>

--- a/include/gridtools/stencil/core/functor_metafunctions.hpp
+++ b/include/gridtools/stencil/core/functor_metafunctions.hpp
@@ -233,6 +233,7 @@ namespace gridtools {
                     meta::transform<item_maker_f<Functor, Interval>::template apply, split_interval<Interval>>;
 
             } // namespace functor_metafunctions_impl_
+            using functor_metafunctions_impl_::bound_functor;
             using functor_metafunctions_impl_::check_valid_apply_overloads;
             using functor_metafunctions_impl_::make_functor_map;
         } // namespace core

--- a/include/gridtools/stencil/dump.hpp
+++ b/include/gridtools/stencil/dump.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <ostream>
+#include <string>
 #include <typeinfo>
 
 #include <boost/core/demangle.hpp>
@@ -23,6 +24,7 @@
 #include "core/execution_types.hpp"
 #include "core/functor_metafunctions.hpp"
 #include "core/interval.hpp"
+#include "core/is_tmp_arg.hpp"
 #include "core/level.hpp"
 
 namespace gridtools {
@@ -59,7 +61,7 @@ namespace gridtools {
 
             template <class Plh>
             auto from_plh(Plh) {
-                return typeid(Plh).name();
+                return (core::is_tmp_arg<Plh>() ? "tmp" : "arg") + std::to_string(Plh::value);
             }
 
             template <template <class...> class L,

--- a/include/gridtools/stencil/dump.hpp
+++ b/include/gridtools/stencil/dump.hpp
@@ -1,0 +1,127 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2019, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+#include <array>
+#include <ostream>
+
+#include <boost/a>
+#include <nlohmann/json.hpp>
+
+#include "../common/defs.hpp"
+#include "../common/tuple_util.hpp"
+#include "../meta.hpp"
+#include "be_api.hpp"
+#include "common/caches.hpp"
+#include "common/extent.hpp"
+#include "core/execution_types.hpp"
+#include "core/interval.hpp"
+#include "core/level.hpp"
+
+namespace gridtools {
+    namespace stencil {
+        namespace dump_backend {
+
+            inline auto from_execution(core::parallel) { return "parallel"; }
+            inline auto from_execution(core::backward) { return "backward"; }
+            inline auto from_execution(core::forward) { return "forward"; }
+            inline auto from_cache(cache_type::ij) { return "ij"; }
+            inline auto from_cache(cache_type::k) { return "k"; }
+            inline auto from_cache_io_policy(cache_io_policy::fill) { return "fill"; }
+            inline auto from_cache_io_policy(cache_io_policy::flush) { return "flush"; }
+
+            template <int... Is>
+            auto from_extent(extent<Is...>) {
+                return tuple_util::make<std::array, int>(Is...);
+            }
+
+            template <uint_t Splitter, int_t Offset, int_t Limit>
+            auto from_level(core::level<Splitter, Offset, Limit>) {
+                return tuple_util::make<std::array, int>(Splitter, Offset);
+            }
+
+            template <class From, class To>
+            auto from_interval(core::interval<From, To>) {
+                return tuple_util::make<std::array>(from_level(From()), from_level(To()));
+            }
+
+            template <class Fun>
+            nlohmann::json from_fun(Fun) {
+                return {};
+            }
+
+            template <class Plh,
+                class... Caches,
+                class IsTmp,
+                class Data,
+                class NumColors,
+                class IsConst,
+                class Extent,
+                class... CacheIoPolicies>
+            nlohmann::json from_plh_info(be_api::plh_info<meta::list<Plh, Caches...>,
+                IsTmp,
+                Data,
+                NumColors,
+                IsConst,
+                Extent,
+                meta::list<CacheIoPolicies...>>) {
+                return {{"plh", "bar"},
+                    {"caches", {from_cache(Caches())...}},
+                    {"is_tmp", IsTmp::value},
+                    {"data_type", "foo"},
+                    {"num_colors", NumColors::value},
+                    {"is_const", IsConst::value},
+                    {"extent", from_extent(Extent())},
+                    {"cache_io_policies", {from_cache_io_policy(CacheIoPolicies())...}}};
+            }
+
+            template <template <class...> class L,
+                template <class...> class LL,
+                class... Funs,
+                class Interval,
+                class... PlhInfos,
+                class Extent,
+                class Execution,
+                class NeedSync>
+            nlohmann::json from_cell(be_api::cell<L<Funs...>, Interval, LL<PlhInfos...>, Extent, Execution, NeedSync>) {
+                return {{"funs", {from_fun(Funs())...}},
+                    {"interval", from_interval(Interval())},
+                    {"plh_infos", {from_plh_info(PlhInfos())...}},
+                    {"extent", from_extent(Extent())},
+                    {"execution", from_execution(Execution())},
+                    {"need_sync", NeedSync::value}};
+            }
+
+            template <template <class...> class L, class... Cells>
+            nlohmann::json from_row(L<Cells...>) {
+                return {{"cells", {from_cell(Cells())...}}};
+            }
+
+            template <template <class...> class L, class... Rows>
+            nlohmann::json from_matrix(L<Rows...>) {
+                return {{"rows", {from_row(Rows())...}}};
+            }
+
+            template <template <class...> class L, class... Matrices>
+            nlohmann::json from_matrices(L<Matrices...>) {
+                return {{"matrices", {from_matrix(Matrices())...}}};
+            }
+
+            struct dump {
+                std::ostream &m_sink;
+                template <class Spec, class... Ts>
+                friend void gridtools_backend_entry_point(dump obj, Spec spec, Ts &&...) {
+                    obj.m_sink << from_matrices(spec) << std::endl;
+                }
+            };
+        } // namespace dump_backend
+        using dump_backend::dump;
+    } // namespace stencil
+} // namespace gridtools

--- a/include/gridtools/stencil/dump.hpp
+++ b/include/gridtools/stencil/dump.hpp
@@ -32,6 +32,11 @@ namespace gridtools {
         namespace dump_backend {
             using nlohmann::json;
 
+            template <class T>
+            auto get_type_name() {
+                return boost::core::demangle(typeid(T).name());
+            }
+
             inline auto from(core::parallel) { return "parallel"; }
             inline auto from(core::backward) { return "backward"; }
             inline auto from(core::forward) { return "forward"; }
@@ -79,7 +84,7 @@ namespace gridtools {
                 json res = {{"plh", from_plh(Plh())},
                     {"caches", json::array({from(Caches())...})},
                     {"is_tmp", IsTmp::value},
-                    {"data", boost::core::demangle(typeid(Data).name())},
+                    {"data", get_type_name<Data>()},
                     {"is_const", IsConst::value},
                     {"extent", from(Extent())},
                     {"cache_io_policies", json::array({from(CacheIoPolicies())...})}};
@@ -95,12 +100,12 @@ namespace gridtools {
 
             template <class F>
             json from_fun(F) {
-                return {{"functor", boost::core::demangle(typeid(F).name())}};
+                return {{"functor", get_type_name<F>()}};
             }
 
             template <class F, class Interval>
             json from_fun(core::bound_functor<F, Interval>) {
-                return {{"functor", boost::core::demangle(typeid(F).name())}, {"interval", from(Interval())}};
+                return {{"functor", get_type_name<F>()}, {"interval", from(Interval())}};
             }
 
             template <template <class...> class L, template <class...> class LL, class Fun, class... Args>

--- a/include/gridtools/stencil/frontend/cartesian/tmp_arg.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/tmp_arg.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 #include <boost/preprocessor/punctuation/remove_parens.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
@@ -36,8 +37,8 @@
 namespace gridtools {
     namespace stencil {
         namespace cartesian {
-            template <size_t, class Data>
-            struct tmp_arg {
+            template <size_t I, class Data>
+            struct tmp_arg : std::integral_constant<size_t, I> {
                 using data_t = Data;
                 using num_colors_t = integral_constant<int_t, 1>;
                 using tmp_tag = std::true_type;

--- a/include/gridtools/stencil/frontend/expandable_run.hpp
+++ b/include/gridtools/stencil/frontend/expandable_run.hpp
@@ -25,8 +25,8 @@ namespace gridtools {
             template <size_t, class T>
             struct expanded : T {};
 
-            template <size_t>
-            struct arg {};
+            template <size_t I>
+            struct arg : integral_constant<size_t, I> {};
 
             template <size_t, size_t>
             struct expanded_arg {};

--- a/include/gridtools/stencil/frontend/icosahedral/tmp_arg.hpp
+++ b/include/gridtools/stencil/frontend/icosahedral/tmp_arg.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 #include <boost/preprocessor/punctuation/remove_parens.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
@@ -40,8 +41,8 @@
 namespace gridtools {
     namespace stencil {
         namespace icosahedral {
-            template <size_t, class NumColors, class Data>
-            struct tmp_arg {
+            template <size_t I, class NumColors, class Data>
+            struct tmp_arg : std::integral_constant<size_t, I> {
                 using data_t = Data;
                 using num_colors_t = NumColors;
                 using tmp_tag = std::true_type;

--- a/include/gridtools/stencil/frontend/run.hpp
+++ b/include/gridtools/stencil/frontend/run.hpp
@@ -189,8 +189,8 @@ namespace gridtools {
                 static_assert(sizeof...(Ts) < 0, "Unexpected arguments of gridtools::stencil::multi_pass.");
             }
 
-            template <size_t>
-            struct arg {};
+            template <size_t I>
+            struct arg : std::integral_constant<size_t, I> {};
 
             template <class Interval>
             struct check_valid_apply_overloads {

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -122,6 +122,9 @@ add_executable(c_array_copy c_array_copy.cpp)
 target_link_libraries(c_array_copy gtest_main gmock gridtools)
 add_test(NAME c_array_copy COMMAND $<TARGET_FILE:c_array_copy>)
 
+add_executable(dump dump.cpp)
+target_link_libraries(dump gtest_main gmock gridtools stencil_dump)
+
 add_subdirectory(icosahedral)
 add_subdirectory(c_bindings)
 add_subdirectory(py_bindings)

--- a/tests/regression/dump.cpp
+++ b/tests/regression/dump.cpp
@@ -13,82 +13,78 @@
 #include <gridtools/stencil/cartesian.hpp>
 #include <gridtools/stencil/dump.hpp>
 
-namespace {
-    using namespace gridtools;
-    using namespace stencil;
-    using namespace cartesian;
+using namespace gridtools;
+using namespace stencil;
+using namespace cartesian;
 
-    struct lap_function {
-        using out = inout_accessor<0>;
-        using in = in_accessor<1, extent<-1, 1, -1, 1>>;
+struct lap_function {
+    using out = inout_accessor<0>;
+    using in = in_accessor<1, extent<-1, 1, -1, 1>>;
 
-        using param_list = make_param_list<out, in>;
+    using param_list = make_param_list<out, in>;
 
-        template <typename Evaluation>
-        GT_FUNCTION static void apply(Evaluation eval) {
-            using float_t = std::decay_t<decltype(eval(out()))>;
-            eval(out()) =
-                float_t{4} * eval(in()) - (eval(in(1, 0)) + eval(in(0, 1)) + eval(in(-1, 0)) + eval(in(0, -1)));
-        }
-    };
-
-    struct flx_function {
-        using out = inout_accessor<0>;
-        using in = in_accessor<1, extent<0, 1, 0, 0>>;
-        using lap = in_accessor<2, extent<0, 1, 0, 0>>;
-
-        using param_list = make_param_list<out, in, lap>;
-
-        template <typename Evaluation>
-        GT_FUNCTION static void apply(Evaluation eval) {
-            auto res = eval(lap(1, 0)) - eval(lap(0, 0));
-            eval(out()) = res * (eval(in(1, 0)) - eval(in(0, 0))) > 0 ? 0 : res;
-        }
-    };
-
-    struct fly_function {
-        using out = inout_accessor<0>;
-        using in = in_accessor<1, extent<0, 0, 0, 1>>;
-        using lap = in_accessor<2, extent<0, 0, 0, 1>>;
-
-        using param_list = make_param_list<out, in, lap>;
-
-        template <typename Evaluation>
-        GT_FUNCTION static void apply(Evaluation eval) {
-            auto res = eval(lap(0, 1)) - eval(lap(0, 0));
-            eval(out()) = res * (eval(in(0, 1)) - eval(in(0, 0))) > 0 ? 0 : res;
-        }
-    };
-
-    struct out_function {
-        using out = inout_accessor<0>;
-        using in = in_accessor<1>;
-        using flx = in_accessor<2, extent<-1, 0, 0, 0>>;
-        using fly = in_accessor<3, extent<0, 0, -1, 0>>;
-        using coeff = in_accessor<4>;
-
-        using param_list = make_param_list<out, in, flx, fly, coeff>;
-
-        template <typename Evaluation>
-        GT_FUNCTION static void apply(Evaluation eval) {
-            eval(out()) =
-                eval(in()) - eval(coeff()) * (eval(flx()) - eval(flx(-1, 0)) + eval(fly()) - eval(fly(0, -1)));
-        }
-    };
-
-    auto const horizontal_diffusion = [](auto in, auto coeff, auto out) {
-        GT_DECLARE_TMP(double, lap, flx, fly);
-        return execute_parallel()
-            .ij_cached(lap, flx, fly)
-            .stage(lap_function(), lap, in)
-            .stage(flx_function(), flx, in, lap)
-            .stage(fly_function(), fly, in, lap)
-            .stage(out_function(), out, in, flx, fly, coeff);
-    };
-
-    TEST(dump, horizontal_diffusion) {
-        double fake[5][5][5];
-        halo_descriptor hd(2, 2, 2, 2, 5);
-        run(horizontal_diffusion, dump{std::cout}, make_grid(hd, hd, 1), fake, fake, fake);
+    template <typename Evaluation>
+    GT_FUNCTION static void apply(Evaluation eval) {
+        using float_t = std::decay_t<decltype(eval(out()))>;
+        eval(out()) = float_t{4} * eval(in()) - (eval(in(1, 0)) + eval(in(0, 1)) + eval(in(-1, 0)) + eval(in(0, -1)));
     }
-} // namespace
+};
+
+struct flx_function {
+    using out = inout_accessor<0>;
+    using in = in_accessor<1, extent<0, 1, 0, 0>>;
+    using lap = in_accessor<2, extent<0, 1, 0, 0>>;
+
+    using param_list = make_param_list<out, in, lap>;
+
+    template <typename Evaluation>
+    GT_FUNCTION static void apply(Evaluation eval) {
+        auto res = eval(lap(1, 0)) - eval(lap(0, 0));
+        eval(out()) = res * (eval(in(1, 0)) - eval(in(0, 0))) > 0 ? 0 : res;
+    }
+};
+
+struct fly_function {
+    using out = inout_accessor<0>;
+    using in = in_accessor<1, extent<0, 0, 0, 1>>;
+    using lap = in_accessor<2, extent<0, 0, 0, 1>>;
+
+    using param_list = make_param_list<out, in, lap>;
+
+    template <typename Evaluation>
+    GT_FUNCTION static void apply(Evaluation eval) {
+        auto res = eval(lap(0, 1)) - eval(lap(0, 0));
+        eval(out()) = res * (eval(in(0, 1)) - eval(in(0, 0))) > 0 ? 0 : res;
+    }
+};
+
+struct out_function {
+    using out = inout_accessor<0>;
+    using in = in_accessor<1>;
+    using flx = in_accessor<2, extent<-1, 0, 0, 0>>;
+    using fly = in_accessor<3, extent<0, 0, -1, 0>>;
+    using coeff = in_accessor<4>;
+
+    using param_list = make_param_list<out, in, flx, fly, coeff>;
+
+    template <typename Evaluation>
+    GT_FUNCTION static void apply(Evaluation eval) {
+        eval(out()) = eval(in()) - eval(coeff()) * (eval(flx()) - eval(flx(-1, 0)) + eval(fly()) - eval(fly(0, -1)));
+    }
+};
+
+auto const horizontal_diffusion = [](auto in, auto coeff, auto out) {
+    GT_DECLARE_TMP(double, lap, flx, fly);
+    return execute_parallel()
+        .ij_cached(lap, flx, fly)
+        .stage(lap_function(), lap, in)
+        .stage(flx_function(), flx, in, lap)
+        .stage(fly_function(), fly, in, lap)
+        .stage(out_function(), out, in, flx, fly, coeff);
+};
+
+TEST(dump, horizontal_diffusion) {
+    double fake[5][5][1];
+    halo_descriptor hd(2, 2, 2, 2, 5);
+    run(horizontal_diffusion, dump{std::cout << std::setw(1)}, make_grid(hd, hd, 1), fake, fake, fake);
+}

--- a/tests/regression/dump.cpp
+++ b/tests/regression/dump.cpp
@@ -1,0 +1,94 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2019, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <gtest/gtest.h>
+
+#include <gridtools/stencil/cartesian.hpp>
+#include <gridtools/stencil/dump.hpp>
+
+namespace {
+    using namespace gridtools;
+    using namespace stencil;
+    using namespace cartesian;
+
+    struct lap_function {
+        using out = inout_accessor<0>;
+        using in = in_accessor<1, extent<-1, 1, -1, 1>>;
+
+        using param_list = make_param_list<out, in>;
+
+        template <typename Evaluation>
+        GT_FUNCTION static void apply(Evaluation eval) {
+            using float_t = std::decay_t<decltype(eval(out()))>;
+            eval(out()) =
+                float_t{4} * eval(in()) - (eval(in(1, 0)) + eval(in(0, 1)) + eval(in(-1, 0)) + eval(in(0, -1)));
+        }
+    };
+
+    struct flx_function {
+        using out = inout_accessor<0>;
+        using in = in_accessor<1, extent<0, 1, 0, 0>>;
+        using lap = in_accessor<2, extent<0, 1, 0, 0>>;
+
+        using param_list = make_param_list<out, in, lap>;
+
+        template <typename Evaluation>
+        GT_FUNCTION static void apply(Evaluation eval) {
+            auto res = eval(lap(1, 0)) - eval(lap(0, 0));
+            eval(out()) = res * (eval(in(1, 0)) - eval(in(0, 0))) > 0 ? 0 : res;
+        }
+    };
+
+    struct fly_function {
+        using out = inout_accessor<0>;
+        using in = in_accessor<1, extent<0, 0, 0, 1>>;
+        using lap = in_accessor<2, extent<0, 0, 0, 1>>;
+
+        using param_list = make_param_list<out, in, lap>;
+
+        template <typename Evaluation>
+        GT_FUNCTION static void apply(Evaluation eval) {
+            auto res = eval(lap(0, 1)) - eval(lap(0, 0));
+            eval(out()) = res * (eval(in(0, 1)) - eval(in(0, 0))) > 0 ? 0 : res;
+        }
+    };
+
+    struct out_function {
+        using out = inout_accessor<0>;
+        using in = in_accessor<1>;
+        using flx = in_accessor<2, extent<-1, 0, 0, 0>>;
+        using fly = in_accessor<3, extent<0, 0, -1, 0>>;
+        using coeff = in_accessor<4>;
+
+        using param_list = make_param_list<out, in, flx, fly, coeff>;
+
+        template <typename Evaluation>
+        GT_FUNCTION static void apply(Evaluation eval) {
+            eval(out()) =
+                eval(in()) - eval(coeff()) * (eval(flx()) - eval(flx(-1, 0)) + eval(fly()) - eval(fly(0, -1)));
+        }
+    };
+
+    auto const horizontal_diffusion = [](auto in, auto coeff, auto out) {
+        GT_DECLARE_TMP(double, lap, flx, fly);
+        return execute_parallel()
+            .ij_cached(lap, flx, fly)
+            .stage(lap_function(), lap, in)
+            .stage(flx_function(), flx, in, lap)
+            .stage(fly_function(), fly, in, lap)
+            .stage(out_function(), out, in, flx, fly, coeff);
+    };
+
+    TEST(dump, horizontal_diffusion) {
+        double fake[5][5][5];
+        halo_descriptor hd(2, 2, 2, 2, 5);
+        run(horizontal_diffusion, dump{std::cout}, make_grid(hd, hd, 1), fake, fake, fake);
+    }
+} // namespace


### PR DESCRIPTION
Stencil `dump` backend is added. It doesn't perform calculations. Instead it outputs `JSON` representation of the spec (the type that is passed to the backend entry point). Unlike other backends `dump` is stateful -- it contains the reference to the `std::ostream` that is served as an output sink. The usage is like that:
 ```
  run(fe_spec, dump{std::cout}, ...);
```
The context of this PR is the following: It is a step to extract the cosmo dycore model from the gt2 based source and to pass it into gt4py in the future. The main showstopper on this way is the fact that the elementary stencils are represented in the generated `json` as `C++` demangled type names. The next step could be to parse the sources with the python based tool and to extract the AST's from the stencil bodies. 