### PR TITLE
Minor changes to sid

### DIFF
--- a/include/gridtools/sid/concept.hpp
+++ b/include/gridtools/sid/concept.hpp
@@ -450,8 +450,9 @@ namespace gridtools {
              *  noop `shift` overload
              */
             template <class T, class Stride, class Offset>
-            GT_FUNCTION std::enable_if_t<!need_shift<T, Stride, Offset>::value> shift(
-                T &, Stride const &, Offset const &) {}
+            GT_FUNCTION std::enable_if_t<!(std::is_lvalue_reference<T>::value &&
+                                           need_shift<std::remove_reference_t<T>, std::decay_t<Stride>, Offset>::value)>
+            shift(T &&, Stride &&, Offset) {}
 
             /**
              * `shift` overload that delegates to `sid_shift`
@@ -731,6 +732,12 @@ namespace gridtools {
         decltype(auto) get_upper_bound(Bounds &&bounds) {
             return gridtools::host_device::at_key_with_default<Key,
                 integral_constant<int_t, std::numeric_limits<int_t>::max()>>(wstd::forward<Bounds>(bounds));
+        }
+
+        template <class T, class Stride, class Offset>
+        GT_FUNCTION T shifted(T obj, Stride const &stride, Offset offset) {
+            shift(obj, stride, offset);
+            return obj;
         }
     } // namespace sid
 

--- a/include/gridtools/sid/loop.hpp
+++ b/include/gridtools/sid/loop.hpp
@@ -40,7 +40,7 @@ namespace gridtools {
                     T m_step;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION operator()(Ptr &ptr, Strides const &strides) const {
+                    void GT_FUNCTION operator()(Ptr &&ptr, Strides const &strides) const {
                         assert(m_num_steps >= 0);
                         if (m_num_steps <= 0)
                             return;
@@ -49,7 +49,7 @@ namespace gridtools {
                             m_fun(ptr, strides);
                             shift(ptr, stride, m_step);
                         }
-                        shift(ptr, stride, -m_step * m_num_steps);
+                        shift(wstd::forward<Ptr>(ptr), stride, -m_step * m_num_steps);
                     }
                 };
 
@@ -66,16 +66,16 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         assert(m_num_steps >= 0);
                         if (m_num_steps <= 0)
                             return;
                         if (++m_pos == m_num_steps) {
                             shift(ptr, get_stride<Key>(strides), m_step * (1 - m_num_steps));
                             m_pos = 0;
-                            m_outer.next(ptr, strides);
+                            m_outer.next(wstd::forward<Ptr>(ptr), strides);
                         } else {
-                            shift(ptr, get_stride<Key>(strides), m_step);
+                            shift(wstd::forward<Ptr>(ptr), get_stride<Key>(strides), m_step);
                         }
                     }
 
@@ -92,9 +92,9 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         --m_pos;
-                        shift(ptr, get_stride<Key>(strides), m_step);
+                        shift(wstd::forward<Ptr>(ptr), get_stride<Key>(strides), m_step);
                     }
 
                     GT_FUNCTION bool done() const { return m_pos > 0; }
@@ -115,7 +115,7 @@ namespace gridtools {
                     T m_num_steps;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION operator()(Ptr &ptr, Strides const &strides) const {
+                    void GT_FUNCTION operator()(Ptr &&ptr, Strides const &strides) const {
                         assert(m_num_steps >= 0);
                         if (m_num_steps <= 0)
                             return;
@@ -125,7 +125,7 @@ namespace gridtools {
                             shift(ptr, stride, integral_constant<T, Step>{});
                         }
                         static constexpr T minus_step = -Step;
-                        shift(ptr, stride, minus_step * m_num_steps);
+                        shift(wstd::forward<Ptr>(ptr), stride, minus_step * m_num_steps);
                     }
                 };
 
@@ -141,16 +141,16 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         assert(m_num_steps >= 0);
                         if (m_num_steps <= 0)
                             return;
                         if (++m_pos == m_num_steps) {
                             shift(ptr, get_stride<Key>(strides), Step * (1 - m_num_steps));
                             m_pos = 0;
-                            m_outer.next(ptr, strides);
+                            m_outer.next(wstd::forward<Ptr>(ptr), strides);
                         } else {
-                            shift(ptr, get_stride<Key>(strides), integral_constant<T, Step>{});
+                            shift(wstd::forward<Ptr>(ptr), get_stride<Key>(strides), integral_constant<T, Step>{});
                         }
                     }
 
@@ -166,9 +166,9 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         --m_pos;
-                        shift(ptr, get_stride<Key>(strides), integral_constant<T, Step>{});
+                        shift(wstd::forward<Ptr>(ptr), get_stride<Key>(strides), integral_constant<T, Step>{});
                     }
 
                     GT_FUNCTION bool done() const { return m_pos > 0; }
@@ -189,10 +189,10 @@ namespace gridtools {
                     T m_num_steps;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION operator()(Ptr &ptr, const Strides &strides) const {
+                    void GT_FUNCTION operator()(Ptr &&ptr, const Strides &strides) const {
                         assert(m_num_steps >= 0);
                         for (T i = 0; i < m_num_steps; ++i)
-                            m_fun(ptr, strides);
+                            m_fun(wstd::forward<Ptr>(ptr), strides);
                     }
                 };
 
@@ -208,13 +208,13 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         assert(m_num_steps >= 0);
                         if (m_num_steps <= 0)
                             return;
                         if (++m_pos == m_num_steps) {
                             m_pos = 0;
-                            m_outer.next(ptr, strides);
+                            m_outer.next(wstd::forward<Ptr>(ptr), strides);
                         }
                     }
 
@@ -230,7 +230,7 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&, Strides const &) {
                         --m_pos;
                     }
 
@@ -252,7 +252,7 @@ namespace gridtools {
                     T m_step;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION operator()(Ptr &ptr, const Strides &strides) const {
+                    void GT_FUNCTION operator()(Ptr &&ptr, const Strides &strides) const {
                         auto &&stride = get_stride<Key>(strides);
                         // TODO(anstaf): to figure out if for_each<make_indices_c<NumSteps>>(...) produces better code.
                         for (T i = 0; i < NumSteps; ++i) {
@@ -260,7 +260,7 @@ namespace gridtools {
                             shift(ptr, stride, m_step);
                         }
                         static constexpr T minus_num_steps = -NumSteps;
-                        shift(ptr, stride, m_step * minus_num_steps);
+                        shift(wstd::forward<Ptr>(ptr), stride, m_step * minus_num_steps);
                     }
                 };
 
@@ -276,14 +276,14 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         if (++m_pos == NumSteps) {
                             constexpr T num_steps_back = 1 - NumSteps;
                             shift(ptr, get_stride<Key>(strides), m_step * num_steps_back);
                             m_pos = 0;
-                            m_outer.next(ptr, strides);
+                            m_outer.next(wstd::forward<Ptr>(ptr), strides);
                         } else {
-                            shift(ptr, get_stride<Key>(strides), m_step);
+                            shift(wstd::forward<Ptr>(ptr), get_stride<Key>(strides), m_step);
                         }
                     }
 
@@ -300,9 +300,9 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         --m_pos;
-                        shift(ptr, get_stride<Key>(strides), m_step);
+                        shift(wstd::forward<Ptr>(ptr), get_stride<Key>(strides), m_step);
                     }
 
                     GT_FUNCTION bool done() const { return m_pos > 0; }
@@ -320,13 +320,13 @@ namespace gridtools {
                     Fun m_fun;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION operator()(Ptr &ptr, const Strides &strides) const {
+                    void GT_FUNCTION operator()(Ptr &&ptr, const Strides &strides) const {
                         auto &&stride = get_stride<Key>(strides);
                         for (T i = 0; i < (T)NumSteps; ++i) {
                             m_fun(ptr, strides);
                             shift(ptr, stride, integral_constant<T, Step>{});
                         }
-                        shift(ptr, stride, integral_constant<T, -Step * NumSteps>{});
+                        shift(wstd::forward<Ptr>(ptr), stride, integral_constant<T, -Step * NumSteps>{});
                     }
                 };
 
@@ -341,14 +341,14 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         if (++m_pos == NumSteps) {
                             constexpr T offset_back = Step * (1 - NumSteps);
                             shift(ptr, get_stride<Key>(strides), offset_back);
                             m_pos = 0;
-                            m_outer.next(ptr, strides);
+                            m_outer.next(wstd::forward<Ptr>(ptr), strides);
                         } else {
-                            shift(ptr, get_stride<Key>(strides), Step);
+                            shift(wstd::forward<Ptr>(ptr), get_stride<Key>(strides), Step);
                         }
                     }
 
@@ -364,9 +364,9 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         --m_pos;
-                        shift(ptr, get_stride<Key>(strides), Step);
+                        shift(wstd::forward<Ptr>(ptr), get_stride<Key>(strides), Step);
                     }
 
                     GT_FUNCTION bool done() const { return m_pos > 0; }
@@ -384,7 +384,7 @@ namespace gridtools {
                     Fun m_fun;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION operator()(Ptr &ptr, Strides const &strides) const {
+                    void GT_FUNCTION operator()(Ptr &&ptr, Strides const &strides) const {
                         for (T i = 0; i < (T)NumSteps; ++i)
                             m_fun(ptr, strides);
                     }
@@ -401,10 +401,10 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &ptr, Strides const &strides) {
+                    void GT_FUNCTION next(Ptr &&ptr, Strides const &strides) {
                         if (++m_pos == NumSteps) {
                             m_pos = 0;
-                            m_outer.next(ptr, strides);
+                            m_outer.next(wstd::forward<Ptr>(ptr), strides);
                         }
                     }
 
@@ -420,7 +420,7 @@ namespace gridtools {
                     T m_pos;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &, Strides const &) {
+                    void GT_FUNCTION next(Ptr &&, Strides const &) {
                         --m_pos;
                     }
 
@@ -448,7 +448,7 @@ namespace gridtools {
                     bool m_done;
 
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &, Strides const &) {
+                    void GT_FUNCTION next(Ptr &&, Strides const &) {
                         m_done = true;
                     }
 
@@ -469,7 +469,7 @@ namespace gridtools {
 
                 struct cursor_f {
                     template <class Ptr, class Strides>
-                    void GT_FUNCTION next(Ptr &, Strides const &) {}
+                    void GT_FUNCTION next(Ptr &&, Strides const &) {}
 
                     GT_FUNCTION bool done() const { return true; }
                 };
@@ -530,7 +530,7 @@ namespace gridtools {
          *   @param num_steps number of iterations in the loop. Can be of integral or integral_constant type
          *   @param step (optional) a step for each iteration. Can be of integral or integral_constant type.
          *               The default is integral_constant<int, 1>
-         *   @return a functor that accepts another functor with the signature: `void(Ptr&, Strides const&)` and
+         *   @return a functor that accepts another functor with the signature: `void(Ptr&&, Strides const&)` and
          *           returns a functor also with the same signature.
          *
          *   Usage:

--- a/include/gridtools/sid/multi_shift.hpp
+++ b/include/gridtools/sid/multi_shift.hpp
@@ -65,6 +65,12 @@ namespace gridtools {
             std::enable_if_t<tuple_util::size<Offsets>::value == 0, int> = 0>
         GT_FUNCTION void multi_shift(Ptr &, Strides const &, Offsets) {}
 
+        template <class Ptr, class Strides, class Offsets>
+        GT_FUNCTION Ptr multi_shifted(Ptr ptr, Strides const &strides, Offsets offsets) {
+            multi_shift(ptr, strides, wstd::move(offsets));
+            return ptr;
+        }
+
         /**
          *   Variation of multi_shift that works with the strides of composite sid.
          */
@@ -85,5 +91,12 @@ namespace gridtools {
             class Offsets,
             std::enable_if_t<tuple_util::size<Offsets>::value == 0, int> = 0>
         GT_FUNCTION void multi_shift(Ptr &, Strides const &, Offsets) {}
+
+        template <class Arg, class Ptr, class Strides, class Offsets>
+        GT_FUNCTION Ptr multi_shifted(Ptr ptr, Strides const &strides, Offsets offsets) {
+            multi_shift<Arg>(ptr, strides, wstd::move(offsets));
+            return ptr;
+        }
+
     } // namespace sid
 } // namespace gridtools

--- a/include/gridtools/sid/sid_shift_origin.hpp
+++ b/include/gridtools/sid/sid_shift_origin.hpp
@@ -52,12 +52,9 @@ namespace gridtools {
               public:
                 template <class Arg, class Offsets>
                 shifted_sid(Arg &&original_sid, Offsets &&offsets) noexcept
-                    : delegate<Sid>(std::forward<Arg>(original_sid)), m_origin{[this, &offsets]() {
-                          auto &&strides = get_strides(this->m_impl);
-                          ptr_diff_type<Sid> ptr_offset{};
-                          multi_shift(ptr_offset, strides, offsets);
-                          return get_origin(this->m_impl) + ptr_offset;
-                      }()},
+                    : delegate<Sid>(std::forward<Arg>(original_sid)),
+                      m_origin(get_origin(this->m_impl) +
+                               multi_shifted(ptr_diff_type<Sid>(), get_strides(this->m_impl), offsets)),
                       m_lower_bounds(add_offsets(get_lower_bounds(this->m_impl), offsets)),
                       m_upper_bounds(add_offsets(get_upper_bounds(this->m_impl), offsets)) {}
             };

--- a/include/gridtools/stencil/cpu_kfirst.hpp
+++ b/include/gridtools/stencil/cpu_kfirst.hpp
@@ -78,10 +78,9 @@ namespace gridtools {
                         offset, sid::get_stride<dim::thread>(strides), thread_pool::get_thread_num(ThreadPool()));
                     sid::shift(offset, sid::get_stride<sid::blocked_dim<dim::i>>(strides), i_block);
                     sid::shift(offset, sid::get_stride<sid::blocked_dim<dim::j>>(strides), j_block);
-                    auto ptr = origin() + offset;
                     auto i_loop = sid::make_loop<dim::i>(extent_t::extend(dim::i(), i_size));
                     auto j_loop = sid::make_loop<dim::j>(extent_t::extend(dim::j(), j_size));
-                    i_loop(j_loop(k_loop))(ptr, strides);
+                    i_loop(j_loop(k_loop))(origin() + offset, strides);
                 };
             }
 

--- a/include/gridtools/stencil/frontend/cartesian/stage.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/stage.hpp
@@ -57,9 +57,8 @@ namespace gridtools {
                     template <class Accessor>
                     GT_FUNCTION decltype(auto) operator()(Accessor acc) const {
                         using key_t = meta::at_c<Keys, Accessor::index_t::value>;
-                        auto ptr = host_device::at_key<key_t>(m_ptr);
-                        sid::multi_shift<key_t>(ptr, m_strides, wstd::move(acc));
-                        return apply_intent<Accessor::intent_v>(Deref()(key_t(), ptr));
+                        return apply_intent<Accessor::intent_v>(Deref()(meta::at_c<Keys, Accessor::index_t::value>(),
+                            sid::multi_shifted<key_t>(host_device::at_key<key_t>(m_ptr), m_strides, wstd::move(acc))));
                     }
 
                     template <class Op, class... Ts>

--- a/include/gridtools/stencil/frontend/cartesian/stage.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/stage.hpp
@@ -57,7 +57,7 @@ namespace gridtools {
                     template <class Accessor>
                     GT_FUNCTION decltype(auto) operator()(Accessor acc) const {
                         using key_t = meta::at_c<Keys, Accessor::index_t::value>;
-                        return apply_intent<Accessor::intent_v>(Deref()(meta::at_c<Keys, Accessor::index_t::value>(),
+                        return apply_intent<Accessor::intent_v>(Deref()(key_t(),
                             sid::multi_shifted<key_t>(host_device::at_key<key_t>(m_ptr), m_strides, wstd::move(acc))));
                     }
 

--- a/include/gridtools/stencil/frontend/icosahedral/stage.hpp
+++ b/include/gridtools/stencil/frontend/icosahedral/stage.hpp
@@ -73,9 +73,8 @@ namespace gridtools {
 
                     template <class Key, class Offset>
                     GT_FUNCTION decltype(auto) get_ref(Offset offset) const {
-                        auto ptr = host_device::at_key<Key>(m_ptr);
-                        sid::multi_shift<Key>(ptr, m_strides, wstd::move(offset));
-                        return Deref()(Key(), ptr);
+                        return Deref()(Key(),
+                            sid::multi_shifted<Key>(host_device::at_key<Key>(m_ptr), m_strides, wstd::move(offset)));
                     }
 
                     template <class Accessor>

--- a/tests/unit_tests/sid/test_sid_concept.cpp
+++ b/tests/unit_tests/sid/test_sid_concept.cpp
@@ -138,6 +138,11 @@ namespace gridtools {
             tu::host::for_each_in_cartesian_product(verify_shift_f{}, samples, samples);
         }
 
+        TEST(shift, noop) {
+            // this should compile
+            sid::shift(3, 4, 5);
+        }
+
         namespace non_static_value {
             struct stride {
                 int value;

--- a/tests/unit_tests/sid/test_sid_loop.cpp
+++ b/tests/unit_tests/sid/test_sid_loop.cpp
@@ -52,6 +52,12 @@ namespace gridtools {
             for (int i = 0; i < 10; ++i)
                 for (int j = 0; j < 10; ++j)
                     EXPECT_EQ(88, data[i][j]) << " i:" << i << ", j:" << j;
+
+            // pass ptr as r-value
+            sid::make_loop<i_t>(10_c)(sid::make_loop<j_t>(10_c)(assignment_f{88}))(&data[0][0], strides);
+            for (int i = 0; i < 10; ++i)
+                for (int j = 0; j < 10; ++j)
+                    EXPECT_EQ(88, data[i][j]) << " i:" << i << ", j:" << j;
         }
 
         TEST(nest_loops, smoke) {


### PR DESCRIPTION
- `sid::shifted` and `sid::multi_shifted` helpers are added
- `sid::shift` can also accept now R-value as a pointer. In this case it is a noop.
-  `sid::loop` API is extended to accept `(Ptr&&, Strides const&)` (was only `(Ptr&, Strides const&)` previously). This means that now one can write: `sid::make_loop<dim::i>(size_i)(body)(origin(), strides);` instead of `auto ptr = origin(); sid::make_loop<dim::i>(size_i)(body)(ptr, strides);`. In the first variant the final shift to the initial point will be skipped (techicaly `noop` overload will be used for the final shift). 