### PR TITLE
C++17 implementation of meta fold

### DIFF
--- a/include/gridtools/meta/fold.hpp
+++ b/include/gridtools/meta/fold.hpp
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "curry_fun.hpp"
 #include "macros.hpp"
 
@@ -112,19 +114,17 @@ namespace gridtools {
                 folder<F, F<S, T>> &&operator+(folder<F, S> &&, id<T> *);
                 template <template <class...> class F, class S, class T>
                 folder<F, F<T, S>> &&operator+(id<T> *, folder<F, S> &&);
-                template <class T>
-                T &&make();
             } // namespace fold_impl_
 
             template <template <class...> class F, class S, template <class...> class L, class... Ts>
             struct lfold<F, S, L<Ts...>>
                 : fold_impl_::state<decltype(
-                      (fold_impl_::make<fold_impl_::folder<F, S>>() + ... + (fold_impl_::id<Ts> *)0))> {};
+                      (std::declval<fold_impl_::folder<F, S> &&>() + ... + (fold_impl_::id<Ts> *)0))> {};
 
             template <template <class...> class F, class S, template <class...> class L, class... Ts>
             struct rfold<F, S, L<Ts...>>
                 : fold_impl_::state<decltype(
-                      ((fold_impl_::id<Ts> *)0 + ... + fold_impl_::make<fold_impl_::folder<F, S>>()))> {};
+                      ((fold_impl_::id<Ts> *)0 + ... + std::declval<fold_impl_::folder<F, S> &&>()))> {};
 #endif
         } // namespace lazy
     }     // namespace meta

--- a/include/gridtools/meta/fold.hpp
+++ b/include/gridtools/meta/fold.hpp
@@ -37,6 +37,11 @@ namespace gridtools {
             struct lfold<F> {
                 using type = curry_fun<meta::lfold, F>;
             };
+            template <template <class...> class F>
+            struct rfold<F> {
+                using type = curry_fun<meta::rfold, F>;
+            };
+#if __cplusplus < 201703
             template <template <class...> class F, class S, template <class...> class L>
             struct lfold<F, S, L<>> {
                 using type = S;
@@ -63,11 +68,6 @@ namespace gridtools {
                 class... Ts>
             struct lfold<F, S, L<T1, T2, T3, T4, Ts...>> {
                 using type = typename lfold<F, F<F<F<F<S, T1>, T2>, T3>, T4>, L<Ts...>>::type;
-            };
-
-            template <template <class...> class F>
-            struct rfold<F> {
-                using type = curry_fun<meta::rfold, F>;
             };
             template <template <class...> class F, class S, template <class...> class L>
             struct rfold<F, S, L<>> {
@@ -96,6 +96,36 @@ namespace gridtools {
             struct rfold<F, S, L<T1, T2, T3, T4, Ts...>> {
                 using type = F<T1, F<T2, F<T3, F<T4, typename rfold<F, S, L<Ts...>>::type>>>>;
             };
+#else
+            namespace fold_impl_ {
+                template <class>
+                struct id;
+                template <class>
+                struct state;
+                template <template <class...> class, class>
+                struct folder;
+                template <template <class...> class F, class S>
+                struct state<folder<F, S> &&> {
+                    using type = S;
+                };
+                template <template <class...> class F, class S, class T>
+                folder<F, F<S, T>> &&operator+(folder<F, S> &&, id<T> *);
+                template <template <class...> class F, class S, class T>
+                folder<F, F<T, S>> &&operator+(id<T> *, folder<F, S> &&);
+                template <class T>
+                T &&make();
+            } // namespace fold_impl_
+
+            template <template <class...> class F, class S, template <class...> class L, class... Ts>
+            struct lfold<F, S, L<Ts...>>
+                : fold_impl_::state<decltype(
+                      (fold_impl_::make<fold_impl_::folder<F, S>>() + ... + (fold_impl_::id<Ts> *)0))> {};
+
+            template <template <class...> class F, class S, template <class...> class L, class... Ts>
+            struct rfold<F, S, L<Ts...>>
+                : fold_impl_::state<decltype(
+                      ((fold_impl_::id<Ts> *)0 + ... + fold_impl_::make<fold_impl_::folder<F, S>>()))> {};
+#endif
         } // namespace lazy
     }     // namespace meta
 } // namespace gridtools


### PR DESCRIPTION
`meta::lfold`/`meta::rfold` now use variadic operator expression if compiled with C++17
For the record: on my mac pro the new code reduces compilation time of the fold on the list with 3000 elements from 4 to 2 seconds.   