### PR TITLE
Improvemements for Hugepage Allocation

### DIFF
--- a/include/gridtools/common/hugepage_alloc.hpp
+++ b/include/gridtools/common/hugepage_alloc.hpp
@@ -16,9 +16,8 @@
 #include <cstring>
 #include <new>
 #include <stdexcept>
-#if __cpp_lib_int_pow2 >= 202002L
-#include <bit>
-#endif
+#include <tuple>
+
 #ifdef __linux__
 #include <cstdio>
 
@@ -38,8 +37,10 @@ namespace gridtools {
             return log;
         }
 
+        enum class hugepage_mode { disabled, transparent, explicit_allocation };
+
 #ifdef __linux__
-        inline std::size_t get_sys_info(const char *info, std::size_t default_value) {
+        inline std::size_t get_sysinfo(const char *info, std::size_t default_value) {
             int fd = open(info, O_RDONLY);
             if (fd != -1) {
                 char buffer[16];
@@ -50,27 +51,123 @@ namespace gridtools {
             }
             return default_value;
         }
-#endif
+
+        inline std::size_t get_meminfo(const char *pattern, std::size_t default_value) {
+            auto *fp = std::fopen("/proc/meminfo", "r");
+            if (fp) {
+                char *line = nullptr;
+                size_t line_length;
+                while (getline(&line, &line_length, fp) != -1) {
+                    if (sscanf(line, pattern, &default_value) == 1)
+                        break;
+                }
+                free(line);
+                std::fclose(fp);
+            }
+            return default_value;
+        }
 
         inline std::size_t cache_line_size() {
-            std::size_t default_value = 64; // default value for x86-64 archs
-#ifdef __linux__
-            return get_sys_info("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", default_value);
-#else
-            return default_value;
-#endif
+            static const std::size_t value =
+                get_sysinfo("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", 64);
+            return value;
         }
 
         inline std::size_t cache_sets() {
-            std::size_t default_value = 64; // default value for (most?) x86-64 archs
-#ifdef __linux__
-            return get_sys_info("/sys/devices/system/cpu/cpu0/cache/index0/number_of_sets", default_value);
-#else
-            return default_value;
-#endif
+            static const std::size_t value =
+                get_sysinfo("/sys/devices/system/cpu/cpu0/cache/index0/number_of_sets", 64);
+            return value;
         }
 
-        enum class hugepage_mode { disabled, transparent, explicit_allocation };
+        inline std::size_t hugepage_size() {
+            static const std::size_t value = get_meminfo("Hugepagesize: %lu kB", 2 * 1024) * 1024;
+            return value;
+        }
+
+        inline std::size_t page_size() {
+            static const std::size_t value = sysconf(_SC_PAGESIZE);
+            return value;
+        }
+
+        inline std::pair<void *, std::size_t> allocate(std::size_t size, hugepage_mode mode) {
+            void *ptr;
+            switch (mode) {
+            case hugepage_mode::disabled:
+                // here we just align to small/normal page size
+                size = ((size + page_size() - 1) / page_size()) * page_size();
+                if (posix_memalign(&ptr, page_size(), size))
+                    throw std::bad_alloc();
+                // explicitly forbid usage of huge pages
+                madvise(ptr, size, MADV_NOHUGEPAGE);
+                break;
+            case hugepage_mode::transparent:
+                // here we try to get transparent huge pages
+                size = ((size + hugepage_size() - 1) / hugepage_size()) * hugepage_size();
+                ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+                if (ptr == MAP_FAILED)
+                    throw std::bad_alloc();
+                madvise(ptr, size, MADV_HUGEPAGE);
+                break;
+            case hugepage_mode::explicit_allocation:
+                // here we force huge page allocation (fails with a bus error if none are available)
+                size = ((size + hugepage_size() - 1) / hugepage_size()) * hugepage_size();
+                ptr = mmap(nullptr,
+                    size,
+                    PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_NORESERVE,
+                    -1,
+                    0);
+                if (ptr == MAP_FAILED)
+                    throw std::bad_alloc();
+                break;
+            }
+            return {ptr, size};
+        }
+
+        inline void deallocate(void *ptr, std::size_t size, hugepage_mode mode) {
+            switch (mode) {
+            case hugepage_mode::disabled:
+                free(ptr);
+                break;
+            default:
+                if (munmap(ptr, size))
+                    throw std::bad_alloc();
+                break;
+            }
+        }
+#else
+        inline std::size_t cache_line_size() {
+            return 64; // default value for x86-64 archs
+        }
+
+        inline std::size_t cache_sets() {
+            return 64; // default value for (most?) x86-64 archs
+        }
+
+        inline std::size_t hugepage_size() {
+            return 2 * 1024 * 1024; // 2MB is the default on most systems
+        }
+
+        inline std::size_t page_size() {
+            return 4 * 1024; // 4kB is the default on most systems
+        }
+
+        inline std::tuple<void *, std::size_t> allocate(std::size_t size, hugepage_mode) {
+            // here we hope that aligning to hugepage_size will return transparent huge pages
+            void *ptr;
+            size = ((size + hugepage_size() - 1) / hugepage_size()) * hugepage_size();
+            if (posix_memalign(&ptr, hugepage_size, size))
+                throw std::bad_alloc();
+            return {ptr, size};
+        }
+
+        inline void deallocate(void *ptr, std::size_t, hugepage_mode) { free(ptr); }
+#endif
+
+        inline std::size_t allocation_offset() {
+            static std::atomic<std::size_t> s_offset(0);
+            return ((s_offset++ % cache_sets()) << ilog2(cache_line_size())) + cache_line_size();
+        }
 
         inline hugepage_mode hugepage_mode_from_env() {
             const char *env_value = std::getenv("GT_HUGEPAGE_MODE");
@@ -82,26 +179,6 @@ namespace gridtools {
                 return hugepage_mode::explicit_allocation;
             std::fprintf(stderr, "warning: env variable GT_HUGEPAGE_MODE set to invalid value '%s'\n", env_value);
             return hugepage_mode::transparent;
-        }
-
-        inline std::size_t hugepage_size() {
-            std::size_t default_value = 2 * 1024 * 1024; // 2MB is the default on most systems
-#ifdef __linux__
-            auto *fp = std::fopen("/proc/meminfo", "r");
-            if (fp) {
-                char *line = nullptr;
-                size_t line_length;
-                while (getline(&line, &line_length, fp) != -1) {
-                    if (sscanf(line, "Hugepagesize: %lu kB", &default_value) == 1) {
-                        default_value *= 1024;
-                        break;
-                    }
-                }
-                free(line);
-                std::fclose(fp);
-            }
-#endif
-            return default_value;
         }
 
         struct ptr_metadata {
@@ -116,69 +193,20 @@ namespace gridtools {
      * reduce cache set conflicts.
      */
     inline void *hugepage_alloc(std::size_t size) {
-        static std::atomic<std::size_t> s_offset(0);
-        static const std::size_t cache_line_size = hugepage_alloc_impl_::cache_line_size();
-        static const std::size_t cache_sets = hugepage_alloc_impl_::cache_sets();
-        static const std::size_t hugepage_size = hugepage_alloc_impl_::hugepage_size();
-#ifdef __linux__
-        static const std::size_t page_size = sysconf(_SC_PAGESIZE);
-#else
-        static const std::size_t page_size = 4096; // just assume 4KB, default on most systems
-#endif
-        assert(cache_line_size >= sizeof(hugepage_alloc_impl_::ptr_metadata));
+        // get allocation offset to reduce L1 cache conflicts
+        std::size_t offset = hugepage_alloc_impl_::allocation_offset();
+        assert(offset >= sizeof(hugepage_alloc_impl_::ptr_metadata));
 
-        std::size_t offset =
-            ((s_offset++ % cache_sets) << hugepage_alloc_impl_::ilog2(cache_line_size)) + cache_line_size;
-
-        std::size_t full_size = size + offset;
-
-        void *ptr = nullptr;
+        // get allocation mode from environment
         auto mode = hugepage_alloc_impl_::hugepage_mode_from_env();
-        switch (mode) {
-        case hugepage_alloc_impl_::hugepage_mode::disabled:
-            // here we just align to small/normal page size
-            full_size = ((full_size + page_size - 1) / page_size) * page_size;
-            if (posix_memalign(&ptr, page_size, full_size))
-                throw std::bad_alloc();
-#ifdef __linux__
-            // explicitly forbid usage of huge pagese
-            madvise(ptr, full_size, MADV_NOHUGEPAGE);
-#endif
-            break;
-#ifdef __linux__
-        case hugepage_alloc_impl_::hugepage_mode::transparent:
-            // here we try to get transparent huge pages
-            full_size = ((full_size + hugepage_size - 1) / hugepage_size) * hugepage_size;
-            ptr = mmap(nullptr, full_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
-            if (ptr == MAP_FAILED)
-                throw std::bad_alloc();
-            madvise(ptr, full_size, MADV_HUGEPAGE);
-            break;
-        case hugepage_alloc_impl_::hugepage_mode::explicit_allocation:
-            // here we force huge page allocation (fails with a bus error if none are available)
-            full_size = ((full_size + hugepage_size - 1) / hugepage_size) * hugepage_size;
-            ptr = mmap(nullptr,
-                full_size,
-                PROT_READ | PROT_WRITE,
-                MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_NORESERVE,
-                -1,
-                0);
-            if (ptr == MAP_FAILED)
-                throw std::bad_alloc();
-            break;
-#else
-        case hugepage_alloc_impl_::hugepage_mode::transparent:
-        case hugepage_alloc_impl_::hugepage_mode::explicit_allocation:
-            // here we hope that aligning to hugepage_size will return transparent huge pages
-            full_size = ((full_size + hugepage_size - 1) / hugepage_size) * hugepage_size;
-            if (posix_memalign(&ptr, hugepage_size, full_size))
-                throw std::bad_alloc();
-            break;
-#endif
-        }
 
+        // allocate memory with additional space for offsetting
+        void *ptr;
+        std::tie(ptr, size) = hugepage_alloc_impl_::allocate(size + offset, mode);
+
+        // offset pointer and write pointer metadata required for deallocation
         ptr = static_cast<char *>(ptr) + offset;
-        static_cast<hugepage_alloc_impl_::ptr_metadata *>(ptr)[-1] = {offset, full_size, mode};
+        static_cast<hugepage_alloc_impl_::ptr_metadata *>(ptr)[-1] = {offset, size, mode};
         return ptr;
     }
 
@@ -188,20 +216,10 @@ namespace gridtools {
     inline void hugepage_free(void *ptr) {
         if (!ptr)
             return;
+        // read pointer metadata and compute originally allocated ptr value
         auto &metadata = static_cast<hugepage_alloc_impl_::ptr_metadata *>(ptr)[-1];
-        ptr = static_cast<char *>(ptr) - metadata.offset;
-        switch (metadata.mode) {
-#ifdef __linux__
-        case hugepage_alloc_impl_::hugepage_mode::transparent:
-        case hugepage_alloc_impl_::hugepage_mode::explicit_allocation:
-            if (munmap(ptr, metadata.full_size))
-                throw std::bad_alloc();
-            break;
-#endif
-        default:
-            free(ptr);
-            break;
-        }
+        // free originally allocated pointer
+        hugepage_alloc_impl_::deallocate(static_cast<char *>(ptr) - metadata.offset, metadata.full_size, metadata.mode);
     }
 
 } // namespace gridtools

--- a/include/gridtools/common/hugepage_alloc.hpp
+++ b/include/gridtools/common/hugepage_alloc.hpp
@@ -83,12 +83,12 @@ namespace gridtools {
     inline void *hugepage_alloc(std::size_t size) {
         static std::atomic<std::size_t> s_offset(0);
         static const std::size_t cache_line_size = hugepage_alloc_impl_::cache_line_size();
-        static const std::size_t cache_set_size = hugepage_alloc_impl_::cache_sets();
+        static const std::size_t cache_sets = hugepage_alloc_impl_::cache_sets();
         static const std::size_t hugepage_size = hugepage_alloc_impl_::hugepage_size();
         assert(cache_line_size >= 2 * sizeof(std::size_t));
 
         std::size_t offset =
-            ((s_offset++ % cache_set_size) << hugepage_alloc_impl_::ilog2(cache_line_size)) + cache_line_size;
+            ((s_offset++ % cache_sets) << hugepage_alloc_impl_::ilog2(cache_line_size)) + cache_line_size;
         std::size_t full_size = ((size + offset + hugepage_size - 1) / hugepage_size) * hugepage_size;
 
         void *ptr;

--- a/include/gridtools/common/hugepage_alloc.hpp
+++ b/include/gridtools/common/hugepage_alloc.hpp
@@ -32,14 +32,10 @@
 namespace gridtools {
     namespace hugepage_alloc_impl_ {
         inline std::size_t ilog2(std::size_t i) {
-#if __cpp_lib_int_pow2 >= 202002L
-            return std::bit_width(t) - 1;
-#else
             std::size_t log = 0;
             while (i >>= 1)
                 ++log;
             return log;
-#endif
         }
 
 #ifdef __linux__

--- a/include/gridtools/common/hugepage_alloc.hpp
+++ b/include/gridtools/common/hugepage_alloc.hpp
@@ -15,13 +15,14 @@
 #include <cstdlib>
 #include <fstream>
 #include <new>
+#include <stdexcept>
 #if __cpp_lib_int_pow2 >= 202002L
 #include <bit>
 #endif
 #ifdef __linux__
+#include <iostream>
 #include <regex>
 
-#include <errno.h>
 #include <sys/mman.h>
 #endif
 
@@ -58,22 +59,37 @@ namespace gridtools {
             return value;
         }
 
-        inline std::size_t hugepage_size() {
-            std::size_t value = 2 * 1024 * 1024; // 2MB default on most systems
 #ifdef __linux__
+        inline std::size_t parse_proc_meminfo(std::string const &regex) {
             std::ifstream file("/proc/meminfo");
             if (file.is_open()) {
-                std::regex re("^Hugepagesize: *([0-9]+) *kB$");
+                std::regex re(regex);
                 std::string line;
                 while (std::getline(file, line)) {
                     std::smatch match;
                     if (std::regex_match(line, match, re))
-                        return std::stoll(match[1].str()) * 1024;
+                        return std::stoll(match[1].str());
                 }
             }
-#endif
-            return value;
+            throw std::runtime_error("regex '" + regex + "' did not match /proc/meminfo");
         }
+#endif
+
+        inline std::size_t hugepage_size() {
+#ifdef GT_NO_HUGETLB
+            return 1;
+#else
+#ifdef __linux__
+            return parse_proc_meminfo("^Hugepagesize: *([0-9]+) *kB$") * 1024;
+#else
+            return 2 * 1024 * 1024; // 2MB is the default on most systems
+#endif
+#endif
+        }
+
+#ifdef __linux__
+        inline std::size_t free_hugepages() { return parse_proc_meminfo("^HugePages_Free: *([0-9]+) *$"); }
+#endif
     } // namespace hugepage_alloc_impl_
 
     /**
@@ -91,18 +107,35 @@ namespace gridtools {
             ((s_offset++ % cache_sets) << hugepage_alloc_impl_::ilog2(cache_line_size)) + cache_line_size;
         std::size_t full_size = ((size + offset + hugepage_size - 1) / hugepage_size) * hugepage_size;
 
-        void *ptr;
+        void *ptr = nullptr;
 #if defined(__linux__) && !defined(GT_NO_HUGETLB)
-        ptr = mmap(nullptr,
-            full_size,
-            PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_NORESERVE,
-            -1,
-            0);
-        if (ptr == MAP_FAILED)
+        // we test if explicit huge pages are available to make sure that mmap does not trigger a bus error there is
+        // probably no full-system thread-safe way to do so, so we might still run into one, but the main functionality
+        // is to avoid bus errors if explicit huge pages are not enabled on the system and thus free_hugepages() returns
+        // zero always
+        if (hugepage_alloc_impl_::free_hugepages() * hugepage_size >= full_size) {
+            ptr = mmap(nullptr,
+                full_size,
+                PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_NORESERVE,
+                -1,
+                0);
+            if (ptr == MAP_FAILED)
+                throw std::bad_alloc();
+        } else {
+            // here we try to get transparent huge pages
+            ptr = mmap(nullptr, full_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+            if (ptr == MAP_FAILED)
+                throw std::bad_alloc();
+            madvise(ptr, full_size, MADV_HUGEPAGE);
+        }
+#elif !defined(GT_NO_HUGETLB)
+        // here we hope that aligning to hugepage_size will return transparent huge pages
+        if (posix_memalign(&ptr, hugepage_size, full_size))
             throw std::bad_alloc();
 #else
-        if (posix_memalign(&ptr, hugepage_size, full_size))
+        // here we just align to cache line size
+        if (posix_memalign(&ptr, cache_line_size, full_size))
             throw std::bad_alloc();
 #endif
 

--- a/include/gridtools/common/hugepage_alloc.hpp
+++ b/include/gridtools/common/hugepage_alloc.hpp
@@ -24,6 +24,7 @@
 #include <regex>
 
 #include <sys/mman.h>
+#include <unistd.h>
 #endif
 
 namespace gridtools {
@@ -59,37 +60,40 @@ namespace gridtools {
             return value;
         }
 
+        enum class hugepage_mode { disabled, transparent, explicit_allocation };
+
+        inline hugepage_mode hugepage_mode_from_env() {
+            const char *env_value = std::getenv("GT_HUGEPAGE_MODE");
+            if (!env_value || std::strcmp(env_value, "transparent") == 0)
+                return hugepage_mode::transparent;
+            if (std::strcmp(env_value, "disabled") == 0)
+                return hugepage_mode::disabled;
+            if (std::strcmp(env_value, "explicit") == 0)
+                return hugepage_mode::explicit_allocation;
+            return hugepage_mode::transparent;
+        }
+
+        inline std::size_t hugepage_size() {
 #ifdef __linux__
-        inline std::size_t parse_proc_meminfo(std::string const &regex) {
             std::ifstream file("/proc/meminfo");
             if (file.is_open()) {
-                std::regex re(regex);
+                std::regex re("^Hugepagesize: *([0-9]+) *kB$");
                 std::string line;
                 while (std::getline(file, line)) {
                     std::smatch match;
                     if (std::regex_match(line, match, re))
-                        return std::stoll(match[1].str());
+                        return std::stoll(match[1].str()) * 1024;
                 }
             }
-            throw std::runtime_error("regex '" + regex + "' did not match /proc/meminfo");
-        }
 #endif
-
-        inline std::size_t hugepage_size() {
-#ifdef GT_NO_HUGETLB
-            return 1;
-#else
-#ifdef __linux__
-            return parse_proc_meminfo("^Hugepagesize: *([0-9]+) *kB$") * 1024;
-#else
             return 2 * 1024 * 1024; // 2MB is the default on most systems
-#endif
-#endif
         }
 
-#ifdef __linux__
-        inline std::size_t free_hugepages() { return parse_proc_meminfo("^HugePages_Free: *([0-9]+) *$"); }
-#endif
+        struct ptr_metadata {
+            std::size_t offset, full_size;
+            hugepage_mode mode;
+        };
+
     } // namespace hugepage_alloc_impl_
 
     /**
@@ -101,19 +105,39 @@ namespace gridtools {
         static const std::size_t cache_line_size = hugepage_alloc_impl_::cache_line_size();
         static const std::size_t cache_sets = hugepage_alloc_impl_::cache_sets();
         static const std::size_t hugepage_size = hugepage_alloc_impl_::hugepage_size();
-        assert(cache_line_size >= 2 * sizeof(std::size_t));
+#ifdef __linux__
+        static const std::size_t page_size = sysconf(_SC_PAGESIZE);
+#else
+        static const std::size_t page_size = 4096; // just assume 4KB, default on most systems
+#endif
+        assert(cache_line_size >= sizeof(hugepage_alloc_impl_::ptr_metadata));
 
         std::size_t offset =
             ((s_offset++ % cache_sets) << hugepage_alloc_impl_::ilog2(cache_line_size)) + cache_line_size;
-        std::size_t full_size = ((size + offset + hugepage_size - 1) / hugepage_size) * hugepage_size;
+
+        std::size_t full_size = size + offset;
 
         void *ptr = nullptr;
-#if defined(__linux__) && !defined(GT_NO_HUGETLB)
-        // we test if explicit huge pages are available to make sure that mmap does not trigger a bus error there is
-        // probably no full-system thread-safe way to do so, so we might still run into one, but the main functionality
-        // is to avoid bus errors if explicit huge pages are not enabled on the system and thus free_hugepages() returns
-        // zero always
-        if (hugepage_alloc_impl_::free_hugepages() * hugepage_size >= full_size) {
+        auto mode = hugepage_alloc_impl_::hugepage_mode_from_env();
+        switch (mode) {
+        case hugepage_alloc_impl_::hugepage_mode::disabled:
+            // here we just align to small/normal page size
+            full_size = ((full_size + page_size - 1) / page_size) * page_size;
+            if (posix_memalign(&ptr, page_size, full_size))
+                throw std::bad_alloc();
+            break;
+#ifdef __linux__
+        case hugepage_alloc_impl_::hugepage_mode::transparent:
+            // here we try to get transparent huge pages
+            full_size = ((full_size + hugepage_size - 1) / hugepage_size) * hugepage_size;
+            ptr = mmap(nullptr, full_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+            if (ptr == MAP_FAILED)
+                throw std::bad_alloc();
+            madvise(ptr, full_size, MADV_HUGEPAGE);
+            break;
+        case hugepage_alloc_impl_::hugepage_mode::explicit_allocation:
+            // here we force huge page allocation (fails with a bus error if none are available)
+            full_size = ((full_size + hugepage_size - 1) / hugepage_size) * hugepage_size;
             ptr = mmap(nullptr,
                 full_size,
                 PROT_READ | PROT_WRITE,
@@ -122,26 +146,20 @@ namespace gridtools {
                 0);
             if (ptr == MAP_FAILED)
                 throw std::bad_alloc();
-        } else {
-            // here we try to get transparent huge pages
-            ptr = mmap(nullptr, full_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
-            if (ptr == MAP_FAILED)
-                throw std::bad_alloc();
-            madvise(ptr, full_size, MADV_HUGEPAGE);
-        }
-#elif !defined(GT_NO_HUGETLB)
-        // here we hope that aligning to hugepage_size will return transparent huge pages
-        if (posix_memalign(&ptr, hugepage_size, full_size))
-            throw std::bad_alloc();
+            break;
 #else
-        // here we just align to cache line size
-        if (posix_memalign(&ptr, cache_line_size, full_size))
-            throw std::bad_alloc();
+        case hugepage_alloc_impl_::hugepage_mode::transparent:
+        case hugepage_alloc_impl_::hugepage_mode::explicit_allocation:
+            // here we hope that aligning to hugepage_size will return transparent huge pages
+            full_size = ((full_size + hugepage_size - 1) / hugepage_size) * hugepage_size;
+            if (posix_memalign(&ptr, hugepage_size, full_size))
+                throw std::bad_alloc();
+            break;
 #endif
+        }
 
         ptr = static_cast<char *>(ptr) + offset;
-        static_cast<std::size_t *>(ptr)[-1] = offset;
-        static_cast<std::size_t *>(ptr)[-2] = full_size;
+        static_cast<hugepage_alloc_impl_::ptr_metadata *>(ptr)[-1] = {offset, full_size, mode};
         return ptr;
     }
 
@@ -151,15 +169,20 @@ namespace gridtools {
     inline void hugepage_free(void *ptr) {
         if (!ptr)
             return;
-        std::size_t offset = static_cast<std::size_t *>(ptr)[-1];
-        std::size_t full_size = static_cast<std::size_t *>(ptr)[-2];
-        ptr = static_cast<char *>(ptr) - offset;
-#if defined(__linux__) && !defined(GT_NO_HUGETLB)
-        if (munmap(ptr, full_size))
-            throw std::bad_alloc();
-#else
-        free(ptr);
+        auto &metadata = static_cast<hugepage_alloc_impl_::ptr_metadata *>(ptr)[-1];
+        ptr = static_cast<char *>(ptr) - metadata.offset;
+        switch (metadata.mode) {
+#ifdef __linux__
+        case hugepage_alloc_impl_::hugepage_mode::transparent:
+        case hugepage_alloc_impl_::hugepage_mode::explicit_allocation:
+            if (munmap(ptr, metadata.full_size))
+                throw std::bad_alloc();
+            break;
 #endif
+        default:
+            free(ptr);
+            break;
+        }
     }
 
 } // namespace gridtools

--- a/include/gridtools/common/hugepage_alloc.hpp
+++ b/include/gridtools/common/hugepage_alloc.hpp
@@ -144,6 +144,10 @@ namespace gridtools {
             full_size = ((full_size + page_size - 1) / page_size) * page_size;
             if (posix_memalign(&ptr, page_size, full_size))
                 throw std::bad_alloc();
+#ifdef __linux__
+            // explicitly forbid usage of huge pagese
+            madvise(ptr, full_size, MADV_NOHUGEPAGE);
+#endif
             break;
 #ifdef __linux__
         case hugepage_alloc_impl_::hugepage_mode::transparent:

--- a/tests/unit_tests/common/test_hugepage_alloc.cpp
+++ b/tests/unit_tests/common/test_hugepage_alloc.cpp
@@ -36,7 +36,7 @@ namespace gridtools {
         }
 
         TEST(hugepage_alloc, cache_line_size) {
-            EXPECT_GE(hugepage_alloc_impl_::cache_line_size(), 2 * sizeof(std::size_t));
+            EXPECT_GE(hugepage_alloc_impl_::cache_line_size(), sizeof(hugepage_alloc_impl_::ptr_metadata));
         }
 
         TEST(hugepage_alloc, cache_sets) { EXPECT_GT(hugepage_alloc_impl_::cache_sets(), 0); }

--- a/tests/unit_tests/common/test_hugepage_alloc.cpp
+++ b/tests/unit_tests/common/test_hugepage_alloc.cpp
@@ -37,6 +37,9 @@ namespace gridtools {
 
         TEST(hugepage_alloc, cache_line_size) {
             EXPECT_GE(hugepage_alloc_impl_::cache_line_size(), sizeof(hugepage_alloc_impl_::ptr_metadata));
+#ifdef __x86_64__
+            EXPECT_EQ(hugepage_alloc_impl_::cache_line_size(), 64);
+#endif
         }
 
         TEST(hugepage_alloc, cache_sets) { EXPECT_GT(hugepage_alloc_impl_::cache_sets(), 0); }

--- a/tests/unit_tests/common/test_hugepage_alloc.cpp
+++ b/tests/unit_tests/common/test_hugepage_alloc.cpp
@@ -39,6 +39,8 @@ namespace gridtools {
 
         TEST(hugepage_alloc, cache_sets) { EXPECT_GT(hugepage_alloc_impl_::cache_sets(), 0); }
 
+        TEST(hugepage_alloc, hugepage_size) { EXPECT_GT(hugepage_alloc_impl_::hugepage_size(), 0); }
+
         TEST(hugepage_alloc, offsets) {
             // test shifting of the allocated data: hugepage_alloc guarantees that consecutive allocations return
             // pointers with different last X bits to reduce number of cache set conflict misses

--- a/tests/unit_tests/common/test_hugepage_alloc.cpp
+++ b/tests/unit_tests/common/test_hugepage_alloc.cpp
@@ -30,18 +30,30 @@ namespace gridtools {
             hugepage_free(ptr);
         }
 
+        TEST(hugepage_alloc, ilog2) {
+            for (std::size_t i = 0; i < 10; ++i)
+                EXPECT_EQ(hugepage_alloc_impl_::ilog2(1 << i), i);
+        }
+
+        TEST(hugepage_alloc, cache_line_size) { EXPECT_GT(hugepage_alloc_impl_::cache_line_size(), 0); }
+
+        TEST(hugepage_alloc, cache_sets) { EXPECT_GT(hugepage_alloc_impl_::cache_sets(), 0); }
+
         TEST(hugepage_alloc, offsets) {
             // test shifting of the allocated data: hugepage_alloc guarantees that consecutive allocations return
-            // pointers with different last 12bits to reduce number of cache set conflict misses
+            // pointers with different last X bits to reduce number of cache set conflict misses
+            std::size_t cache_sets = hugepage_alloc_impl_::cache_sets();
+            std::size_t different_bits = hugepage_alloc_impl_::ilog2(hugepage_alloc_impl_::cache_line_size()) +
+                                         hugepage_alloc_impl_::ilog2(cache_sets);
+            std::uintptr_t mask = (1ULL << different_bits) - 1;
             std::set<std::uintptr_t> offsets;
-            std::size_t checks = 7;
-            for (std::size_t i = 0; i < checks; ++i) {
+            for (std::size_t i = 0; i < cache_sets; ++i) {
                 double *ptr = static_cast<double *>(hugepage_alloc(sizeof(double)));
-                offsets.insert(reinterpret_cast<std::uintptr_t>(ptr) & 0xfff);
+                offsets.insert(reinterpret_cast<std::uintptr_t>(ptr) & mask);
                 hugepage_free(ptr);
             }
 #ifndef __cray__ // Cray clang version 10.0.2 seems to do a wrong optimization
-            EXPECT_EQ(offsets.size(), checks);
+            EXPECT_EQ(offsets.size(), cache_sets);
 #endif
         }
 

--- a/tests/unit_tests/common/test_hugepage_alloc.cpp
+++ b/tests/unit_tests/common/test_hugepage_alloc.cpp
@@ -35,7 +35,9 @@ namespace gridtools {
                 EXPECT_EQ(hugepage_alloc_impl_::ilog2(1 << i), i);
         }
 
-        TEST(hugepage_alloc, cache_line_size) { EXPECT_GT(hugepage_alloc_impl_::cache_line_size(), 0); }
+        TEST(hugepage_alloc, cache_line_size) {
+            EXPECT_GE(hugepage_alloc_impl_::cache_line_size(), 2 * sizeof(std::size_t));
+        }
 
         TEST(hugepage_alloc, cache_sets) { EXPECT_GT(hugepage_alloc_impl_::cache_sets(), 0); }
 


### PR DESCRIPTION
This improves the behavior of hugepage_alloc in several ways (fixes #1561):
- Fixed hardcoded values: queries architecture-dependent L1 cache line size and set size at run time (Linux only).
- More conservative offsetting: makes sure that each cache set is considered.
- Explicit control over huge page allocation: introduces the environment variable GT_HUGEPAGE_MODE that can be used to switch between explicit huge page allocation, use of transparent huge pages and disabling huge pages (Linux only).