### PR TITLE
CMake + Jenkins: add c++17 testing

### DIFF
--- a/cmake/public/gridtools_setup_targets.cmake
+++ b/cmake/public/gridtools_setup_targets.cmake
@@ -199,6 +199,13 @@ macro(_gt_setup_targets _config_mode clang_cuda_mode)
             set(_gt_setup_root_dir ${CUDAToolkit_BIN_DIR}/..)
             target_compile_options(_gridtools_cuda INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-xcuda --cuda-path=${_gt_setup_root_dir}>)
             target_link_libraries(_gridtools_cuda INTERFACE CUDA::cudart)
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0.0)
+                # Workaround for Clang in CUDA mode:
+                # The default std in Clang 10 is c++14, however in CUDA mode the compiler falls back to pre-c++11.
+                # CMake tries to be smart and only puts `-std=c++14` if needed, but isn't aware of the CUDA problem...
+                # TODO check if fixed in Clang 11
+                target_compile_options(_gridtools_cuda INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>)
+            endif()
         elseif(type STREQUAL HIPCC-AMDGPU)
             target_compile_options(_gridtools_cuda INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-xhip>)
         endif()

--- a/cmake/public/gridtools_setup_targets.cmake
+++ b/cmake/public/gridtools_setup_targets.cmake
@@ -200,9 +200,9 @@ macro(_gt_setup_targets _config_mode clang_cuda_mode)
             target_compile_options(_gridtools_cuda INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-xcuda --cuda-path=${_gt_setup_root_dir}>)
             target_link_libraries(_gridtools_cuda INTERFACE CUDA::cudart)
             if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0.0)
-                # Workaround for Clang in CUDA mode:
+                # Workaround for problem seen with Clang 10.0.1 in CUDA mode (havogt):
                 # The default std in Clang 10 is c++14, however in CUDA mode the compiler falls back to pre-c++11.
-                # CMake tries to be smart and only puts `-std=c++14` if needed, but isn't aware of the CUDA problem...
+                # Hypothesis: CMake tries to be smart and only puts `-std=c++14` if needed, but isn't aware of the CUDA problem...
                 # TODO check if fixed in Clang 11
                 target_compile_options(_gridtools_cuda INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>)
             endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -53,5 +53,12 @@ if(GT_INSTALL_EXAMPLES)
     configure_file(cmake_skeletons/CMakeLists.txt.driver.in ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeLists.txt @ONLY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeLists.txt DESTINATION ${GT_INSTALL_EXAMPLES_PATH})
 
-    install(FILES ${PROJECT_SOURCE_DIR}/cmake/public/workaround_check_language.cmake DESTINATION ${GT_INSTALL_EXAMPLES_PATH})
+    install(
+        FILES
+            ${PROJECT_SOURCE_DIR}/cmake/public/workaround_check_language.cmake
+            ${PROJECT_SOURCE_DIR}/cmake/public/detect_features.cmake
+            ${PROJECT_SOURCE_DIR}/cmake/public/try_compile_clang_cuda.cmake
+            ${PROJECT_SOURCE_DIR}/cmake/public/try_compile_hip.cmake
+        DESTINATION ${GT_INSTALL_EXAMPLES_PATH}
+    )
 endif()

--- a/examples/c_bindings/CMakeLists.txt.in
+++ b/examples/c_bindings/CMakeLists.txt.in
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION @CMAKE_MINIMUM_REQUIRED_VERSION@)
 # 1) GridTools needs the language CXX
 project(GridTools-examples LANGUAGES CXX)
 
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CUDA_EXTENSIONS OFF)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 # detect CUDA variant (Clang with CUDA support or NVCC)

--- a/examples/c_bindings/CMakeLists.txt.in
+++ b/examples/c_bindings/CMakeLists.txt.in
@@ -3,12 +3,15 @@ cmake_minimum_required(VERSION @CMAKE_MINIMUM_REQUIRED_VERSION@)
 # 1) GridTools needs the language CXX
 project(GridTools-examples LANGUAGES CXX)
 
-# enable CUDA if it is found on the system
-include(../workaround_check_language.cmake) # see https://gitlab.kitware.com/cmake/cmake/issues/19013
-_workaround_check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
-    # 2) Enable the CUDA language if you want to run your code on a CUDA-capable GPU. This
-    #    must be done before calling `find_package(GridTools)`
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
+
+# detect CUDA variant (Clang with CUDA support or NVCC)
+include(detect_features)
+detect_cuda_type(GT_CUDA_TYPE AUTO)
+
+if(GT_CUDA_TYPE STREQUAL "NVCC-CUDA")
+    # 2) Enable the CUDA language if you want to run your code on a CUDA-capable GPU.
+    #    This needs to be done before find_package(GridTools) to properly setup the GridTools targets for CUDA.
     enable_language(CUDA)
 endif()
 
@@ -64,6 +67,7 @@ if(TARGET GridTools::stencil_gpu)
 
     bindgen_add_library(copy_stencil_lib_gpu SOURCES copy_stencil_wrapper.cpp)
     target_link_libraries(copy_stencil_lib_gpu PUBLIC GridTools::stencil_gpu)
+    target_compile_options(copy_stencil_lib_gpu PRIVATE "-std=c++14") # TODO shouldn't be here
     gridtools_setup_target(copy_stencil_lib_gpu CUDA_ARCH ${EXAMPLE_CUDA_ARCH})
 
     if(CMAKE_C_COMPILER_LOADED)

--- a/examples/c_bindings/CMakeLists.txt.in
+++ b/examples/c_bindings/CMakeLists.txt.in
@@ -70,7 +70,6 @@ if(TARGET GridTools::stencil_gpu)
 
     bindgen_add_library(copy_stencil_lib_gpu SOURCES copy_stencil_wrapper.cpp)
     target_link_libraries(copy_stencil_lib_gpu PUBLIC GridTools::stencil_gpu)
-    target_compile_options(copy_stencil_lib_gpu PRIVATE "-std=c++14") # TODO shouldn't be here
     gridtools_setup_target(copy_stencil_lib_gpu CUDA_ARCH ${EXAMPLE_CUDA_ARCH})
 
     if(CMAKE_C_COMPILER_LOADED)

--- a/examples/cmake_skeletons/CMakeLists.txt.driver.in
+++ b/examples/cmake_skeletons/CMakeLists.txt.driver.in
@@ -7,14 +7,7 @@ include(ExternalProject)
 
 enable_testing()
 
-include(workaround_check_language.cmake) # see https://gitlab.kitware.com/cmake/cmake/issues/19013
-_workaround_check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
-    set(EXAMPLE_CUDA_ARCH "@GT_CUDA_ARCH@" CACHE STRING "CUDA compute capability to be used for this example.")
-endif()
-if(GT_EXAMPLES_FORCE_CUDA AND NOT CMAKE_CUDA_COMPILER) #TODO fix me
-    message(FATAL_ERROR "No CUDA compiler is available, but CUDA compilation was requested.")
-endif()
+set(EXAMPLE_CUDA_ARCH "@GT_CUDA_ARCH@" CACHE STRING "CUDA compute capability to be used for this example.")
 
 foreach(ex IN ITEMS @enabled_examples@)
     ExternalProject_Add(${ex}_example

--- a/examples/cmake_skeletons/CMakeLists.txt.example.in
+++ b/examples/cmake_skeletons/CMakeLists.txt.example.in
@@ -6,6 +6,9 @@ cmake_minimum_required(VERSION @CMAKE_MINIMUM_REQUIRED_VERSION@)
 # 1) GridTools needs the language CXX
 project(GridTools-examples LANGUAGES CXX)
 
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CUDA_EXTENSIONS OFF)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 # detect CUDA variant (Clang with CUDA support or NVCC)
@@ -32,8 +35,6 @@ foreach(srcfile IN LISTS EXAMPLES_SRCFILES)
     target_link_libraries(${srcfile}_cpu_ifirst GridTools::stencil_cpu_ifirst)
     add_test(NAME ${srcfile}_cpu_ifirst COMMAND $<TARGET_FILE:${srcfile}_cpu_ifirst> 33 44 55)
 endforeach()
-
-message(STATUS "---------> ${EXAMPLE_CUDA_ARCH}")
 
 if(TARGET GridTools::stencil_gpu)
     set(EXAMPLE_CUDA_ARCH "@GT_CUDA_ARCH@" CACHE STRING "CUDA compute capability to be used for this example.")

--- a/examples/cmake_skeletons/CMakeLists.txt.example.in
+++ b/examples/cmake_skeletons/CMakeLists.txt.example.in
@@ -6,10 +6,13 @@ cmake_minimum_required(VERSION @CMAKE_MINIMUM_REQUIRED_VERSION@)
 # 1) GridTools needs the language CXX
 project(GridTools-examples LANGUAGES CXX)
 
-# enable CUDA if it is found on the system
-include(../workaround_check_language.cmake) # see https://gitlab.kitware.com/cmake/cmake/issues/19013
-_workaround_check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
+
+# detect CUDA variant (Clang with CUDA support or NVCC)
+include(detect_features)
+detect_cuda_type(GT_CUDA_TYPE AUTO)
+
+if(GT_CUDA_TYPE STREQUAL "NVCC-CUDA")
     # 2) Enable the CUDA language if you want to run your code on a CUDA-capable GPU.
     #    This needs to be done before find_package(GridTools) to properly setup the GridTools targets for CUDA.
     enable_language(CUDA)
@@ -29,6 +32,8 @@ foreach(srcfile IN LISTS EXAMPLES_SRCFILES)
     target_link_libraries(${srcfile}_cpu_ifirst GridTools::stencil_cpu_ifirst)
     add_test(NAME ${srcfile}_cpu_ifirst COMMAND $<TARGET_FILE:${srcfile}_cpu_ifirst> 33 44 55)
 endforeach()
+
+message(STATUS "---------> ${EXAMPLE_CUDA_ARCH}")
 
 if(TARGET GridTools::stencil_gpu)
     set(EXAMPLE_CUDA_ARCH "@GT_CUDA_ARCH@" CACHE STRING "CUDA compute capability to be used for this example.")

--- a/examples/stencil_type_erasure/CMakeLists.txt.in
+++ b/examples/stencil_type_erasure/CMakeLists.txt.in
@@ -1,12 +1,15 @@
 cmake_minimum_required(VERSION @CMAKE_MINIMUM_REQUIRED_VERSION@)
 project(stencil_type_erasure LANGUAGES CXX)
 
-# enable CUDA if it is found on the system
-include(../workaround_check_language.cmake) # see https://gitlab.kitware.com/cmake/cmake/issues/19013
-_workaround_check_language(CUDA)
-if(CMAKE_CUDA_COMPILER)
-    # 2) Enable the CUDA language if you want to run your code on a CUDA-capable GPU. This
-    #    must be done before calling `find_package(GridTools)`
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
+
+# detect CUDA variant (Clang with CUDA support or NVCC)
+include(detect_features)
+detect_cuda_type(GT_CUDA_TYPE AUTO)
+
+if(GT_CUDA_TYPE STREQUAL "NVCC-CUDA")
+    # 2) Enable the CUDA language if you want to run your code on a CUDA-capable GPU.
+    #    This needs to be done before find_package(GridTools) to properly setup the GridTools targets for CUDA.
     enable_language(CUDA)
 endif()
 

--- a/examples/stencil_type_erasure/CMakeLists.txt.in
+++ b/examples/stencil_type_erasure/CMakeLists.txt.in
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION @CMAKE_MINIMUM_REQUIRED_VERSION@)
 project(stencil_type_erasure LANGUAGES CXX)
 
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CUDA_EXTENSIONS OFF)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 # detect CUDA variant (Clang with CUDA support or NVCC)

--- a/jenkins/envs/daint_cray_cxx17.sh
+++ b/jenkins/envs/daint_cray_cxx17.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-source $(dirname "$BASH_SOURCE")/daint_nvcc_gcc.sh
+source $(dirname "$BASH_SOURCE")/daint_cray.sh
 
 export GTCMAKE_GT_TESTS_CXX_STANDARD=17

--- a/jenkins/envs/daint_nvcc_gcc_cxx17.sh
+++ b/jenkins/envs/daint_nvcc_gcc_cxx17.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source $(dirname "$BASH_SOURCE")/daint_nvcc_gcc.sh
+
+export GTCMAKE_GT_TESTS_CXX_STANDARD=17

--- a/jenkins/setup.sh
+++ b/jenkins/setup.sh
@@ -20,7 +20,7 @@ if [[ $label != "tsa" ]]; then
     export SBATCH_ACCOUNT=d75
 fi
 
-if [[ ! -v build_examples ]] && [[ $env =~ ^(cray|hip)$ ]]; then
+if [[ ! -v build_examples ]] && [[ $env =~ ^(cray|cray_cxx17|hip)$ ]]; then
     build_examples=false
 fi
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,9 @@
+set(GT_TESTS_CXX_STANDARD "DEFAULT" CACHE STRING "C++ standard for compiling tests.")
+set_property(CACHE GT_TESTS_CXX_STANDARD PROPERTY STRINGS "DEFAULT;17")
+if(NOT GT_TESTS_CXX_STANDARD STREQUAL "DEFAULT")
+    set(CMAKE_CXX_STANDARD ${GT_TESTS_CXX_STANDARD})
+    set(CMAKE_CUDA_STANDARD ${GT_TESTS_CXX_STANDARD})
+endif()
 
 add_library(GridToolsTest INTERFACE)
 target_link_libraries(GridToolsTest INTERFACE gridtools)


### PR DESCRIPTION
Add cray_cxx_17 environment which enables C++17 for tests.

Unrelated:
- Improve testing setup for examples, they nearly work with Cray except for #1575 