### PR TITLE
Jenkins: add dom env

### DIFF
--- a/jenkins/envs/dom.sh
+++ b/jenkins/envs/dom.sh
@@ -11,7 +11,7 @@ export BOOST_ROOT=/project/c14/install/daint/boost/boost_1_67_0/
 export CUDATOOLKIT_HOME=$CUDA_PATH
 export CUDA_ARCH=sm_60
 
-export GTRUN_BUILD_COMMAND='srun --account c14 -C gpu -p cscsci --time=00:20:00 make -j 24'
+export GTRUN_BUILD_COMMAND='srun --account c14 -C gpu --time=00:20:00 make -j 24'
 export GTRUN_SBATCH_ACCOUNT='c14'
 export GTRUN_SBATCH_PARTITION='cscsci'
 export GTRUN_SBATCH_NODES=1

--- a/jenkins/envs/dom.sh
+++ b/jenkins/envs/dom.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source $(dirname "$BASH_SOURCE")/base.sh
+
+module load daint-gpu
+module load cudatoolkit
+module rm CMake
+module load /users/jenkins/easybuild/daint/haswell/modules/all/CMake/3.14.5
+
+export BOOST_ROOT=/project/c14/install/daint/boost/boost_1_67_0/
+export CUDATOOLKIT_HOME=$CUDA_PATH
+export CUDA_ARCH=sm_60
+
+export GTRUN_BUILD_COMMAND='srun -C gpu -p cscsci --time=00:20:00 make -j 24'
+export GTRUN_SBATCH_PARTITION='cscsci'
+export GTRUN_SBATCH_NODES=1
+export GTRUN_SBATCH_NTASKS_PER_CORE=2
+export GTRUN_SBATCH_NTASKS_PER_NODE=1
+export GTRUN_SBATCH_CPUS_PER_TASK=24
+export GTRUN_SBATCH_CONSTRAINT='gpu'
+export GTRUN_SBATCH_CPU_FREQ='high'
+export GTRUNMPI_SBATCH_PARTITION='normal'
+export GTRUNMPI_SBATCH_NODES=4
+
+export CUDA_AUTO_BOOST=0
+export GCLOCK=1328
+export MPICH_RDMA_ENABLED_CUDA=1
+export MPICH_G2G_PIPELINE=30
+export OMP_NUM_THREADS=24
+export OMP_PLACES='{0}:24'

--- a/jenkins/envs/dom.sh
+++ b/jenkins/envs/dom.sh
@@ -13,7 +13,7 @@ export CUDA_ARCH=sm_60
 
 export GTRUN_BUILD_COMMAND='srun --account c14 -C gpu --time=00:20:00 make -j 24'
 export GTRUN_SBATCH_ACCOUNT='c14'
-export GTRUN_SBATCH_PARTITION='cscsci'
+export GTRUN_SBATCH_PARTITION='normal'
 export GTRUN_SBATCH_NODES=1
 export GTRUN_SBATCH_NTASKS_PER_CORE=2
 export GTRUN_SBATCH_NTASKS_PER_NODE=1

--- a/jenkins/envs/dom.sh
+++ b/jenkins/envs/dom.sh
@@ -11,7 +11,8 @@ export BOOST_ROOT=/project/c14/install/daint/boost/boost_1_67_0/
 export CUDATOOLKIT_HOME=$CUDA_PATH
 export CUDA_ARCH=sm_60
 
-export GTRUN_BUILD_COMMAND='srun -C gpu -p cscsci --time=00:20:00 make -j 24'
+export GTRUN_BUILD_COMMAND='srun --account c14 -C gpu -p cscsci --time=00:20:00 make -j 24'
+export GTRUN_SBATCH_ACCOUNT='c14'
 export GTRUN_SBATCH_PARTITION='cscsci'
 export GTRUN_SBATCH_NODES=1
 export GTRUN_SBATCH_NTASKS_PER_CORE=2

--- a/jenkins/envs/dom_nvcc_gcc.sh
+++ b/jenkins/envs/dom_nvcc_gcc.sh
@@ -1,3 +1,19 @@
 #!/bin/bash
 
-source $(dirname "$BASH_SOURCE")/daint_nvcc_gcc.sh # daint on purpose until it breaks
+source $(dirname "$BASH_SOURCE")/dom.sh
+
+module swap PrgEnv-cray PrgEnv-gnu
+
+if [ "$build_type" != "debug" ]; then
+  module load HPX/1.5.0-CrayGNU-20.08-cuda
+fi
+
+export CXX=$(which CC)
+export CC=$(which cc)
+export FC=$(which ftn)
+export CUDAHOSTCXX="$CXX"
+
+export GTCMAKE_CMAKE_CXX_FLAGS='-march=haswell'
+export GTCMAKE_CMAKE_CXX_FLAGS_RELEASE='-Ofast -DNDEBUG'
+
+export CTEST_PARALLEL_LEVEL=1

--- a/jenkins/envs/dom_nvcc_gcc.sh
+++ b/jenkins/envs/dom_nvcc_gcc.sh
@@ -6,10 +6,6 @@ module switch cudatoolkit cudatoolkit/11.0.2_3.33-7.0.2.1_3.1__g1ba0366
 
 module swap PrgEnv-cray PrgEnv-gnu
 
-if [ "$build_type" != "debug" ]; then
-  module load HPX/1.5.0-CrayGNU-20.08-cuda
-fi
-
 export CXX=$(which CC)
 export CC=$(which cc)
 export FC=$(which ftn)

--- a/jenkins/envs/dom_nvcc_gcc.sh
+++ b/jenkins/envs/dom_nvcc_gcc.sh
@@ -2,6 +2,8 @@
 
 source $(dirname "$BASH_SOURCE")/dom.sh
 
+module switch cudatoolkit cudatoolkit/11.0.2_3.33-7.0.2.1_3.1__g1ba0366
+
 module swap PrgEnv-cray PrgEnv-gnu
 
 if [ "$build_type" != "debug" ]; then

--- a/jenkins/envs/dom_nvcc_gcc.sh
+++ b/jenkins/envs/dom_nvcc_gcc.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+source $(dirname "$BASH_SOURCE")/daint_nvcc_gcc.sh # daint on purpose until it breaks


### PR DESCRIPTION
Add nvcc_gcc environment for dom, enable dom release plan on jenkins.
For reference: for whatever reason the debug build doesn't work on jenkins (doesn't detect CUDA), but works if I ran the plan myself.