### PR TITLE
fix typo

### DIFF
--- a/include/gridtools/gcl/low_level/Generic_All_to_All.hpp
+++ b/include/gridtools/gcl/low_level/Generic_All_to_All.hpp
@@ -77,7 +77,7 @@ namespace gridtools {
 
                 \return true if the pointer in the packet is nullptr
              */
-            bool emtpy() const { return !full(); }
+            bool empty() const { return !full(); }
 
           private:
             friend struct all_to_all<value_type>;


### PR DESCRIPTION
`emtpy` isn't used anywhere but is clearly a typo since it is the logical complement of `full`.

Signed-off-by: Jeff Hammond <jeff.r.hammond@intel.com>