### PR TITLE
Add protection against misuse of device namespace

### DIFF
--- a/include/gridtools/common/host_device.hpp
+++ b/include/gridtools/common/host_device.hpp
@@ -67,7 +67,6 @@
 #endif
 #else
 #define GT_HOST_DEVICE
-#define GT_DEVICE
 #define GT_HOST
 #endif
 

--- a/include/gridtools/common/hugepage_alloc.hpp
+++ b/include/gridtools/common/hugepage_alloc.hpp
@@ -156,7 +156,7 @@ namespace gridtools {
             // here we hope that aligning to hugepage_size will return transparent huge pages
             void *ptr;
             size = ((size + hugepage_size() - 1) / hugepage_size()) * hugepage_size();
-            if (posix_memalign(&ptr, hugepage_size, size))
+            if (posix_memalign(&ptr, hugepage_size(), size))
                 throw std::bad_alloc();
             return {ptr, size};
         }

--- a/include/gridtools/common/iterate_on_host_device.hpp
+++ b/include/gridtools/common/iterate_on_host_device.hpp
@@ -82,9 +82,6 @@
 #define GT_TARGET_NAMESPACE_NAME host
 #define GT_TARGET_NAMESPACE   \
     inline namespace host {}  \
-    namespace device {        \
-        using namespace host; \
-    }                         \
     namespace host_device {   \
         using namespace host; \
     }                         \


### PR DESCRIPTION
This PR protects against a fragile design pattern that I already observed in `gtc` code:
`foo.hpp`:
```c++
void foo() {device::bar();}
```
`baz.cpp`:
```c++
#include "foo.hpp"
int main() {foo();}  // ok
```
`baz.cu`
```c++
#include "foo.hpp"
int main {foo();} // opps
```
