### PR TITLE
Fix C++ concepts detection

### DIFF
--- a/include/gridtools/sid/concept.hpp
+++ b/include/gridtools/sid/concept.hpp
@@ -747,7 +747,7 @@ namespace gridtools {
      */
     using sid::is_sid;
 
-#if __cplusplus > 201703L
+#ifdef __cpp_concepts
     template <class T>
     concept Sid = is_sid<T>::value;
 #endif

--- a/tests/unit_tests/sid/test_sid_concept.cpp
+++ b/tests/unit_tests/sid/test_sid_concept.cpp
@@ -239,7 +239,7 @@ namespace gridtools {
             EXPECT_EQ(5, tuple_util::get<3>(upper_bounds));
         }
 
-#if __cplusplus > 201703L
+#ifdef __cpp_concepts
         namespace cpp20_concept {
             std::false_type foo(...);
             std::true_type foo(Sid auto const &);


### PR DESCRIPTION
Replace C++ version check by feature test macro for concepts.

E.g. GCC 9 reports `201709L` for `-std=c++2a` but doesn't have concepts support.