### PR TITLE
More stable ROCm Environment on Ault

### DIFF
--- a/include/gridtools/common/omp.hpp
+++ b/include/gridtools/common/omp.hpp
@@ -12,7 +12,9 @@
 #ifdef _OPENMP
 #include <omp.h>
 #else
+extern "C" {
 inline int omp_get_thread_num() { return 0; }
 inline int omp_get_max_threads() { return 1; }
 inline double omp_get_wtime() { return 0; }
+}
 #endif

--- a/jenkins/envs/ault_hip.sh
+++ b/jenkins/envs/ault_hip.sh
@@ -15,15 +15,15 @@ export CXX=$(which hipcc)
 export CC=$(which gcc)
 export FC=$(which gfortran)
 
-export GTRUN_BUILD_COMMAND='srun -w ault20 --time=03:00:00 make -j 64'
+export GTRUN_BUILD_COMMAND='srun -p amdvega --time=03:00:00 make -j 64'
 export GTRUN_SBATCH_NTASKS=1
 export GTRUN_SBATCH_CPUS_PER_TASK=128
 export GTRUN_SBATCH_MEM_BIND=local
-export GTRUN_SBATCH_NODELIST=ault20
+export GTRUN_SBATCH_PARTITION=amdvega
 export GTRUN_SBATCH_TIME='00:30:00'
 export GTCMAKE_CMAKE_CXX_FLAGS_RELEASE='-O3 -DNDEBUG -march=znver1'
 
-export HIP_VISIBLE_DEVICES=0
+export HIP_VISIBLE_DEVICES=1
 export OMP_NUM_THREADS=64
 export OMP_PLACES='{0}:64'
 export HCC_AMDGPU_TARGET=gfx906


### PR DESCRIPTION
This enables all AMD GPU nodes on Ault for possible execution of the tests.