### PR TITLE
Fix performance with C++17

### DIFF
--- a/include/gridtools/sid/as_const.hpp
+++ b/include/gridtools/sid/as_const.hpp
@@ -72,7 +72,7 @@ namespace gridtools {
 
         template <class Src>
         decltype(auto) add_const(std::true_type, Src &&src) {
-            return as_const(std::forward<Src>(src));
+            return sid::as_const(std::forward<Src>(src));
         }
     } // namespace sid
 } // namespace gridtools


### PR DESCRIPTION
With C++17, `as_const` was added into the standard and if `as_const` is not called qualified, we end up with `std::as_const` (which is also a better match) in most cases because there is some `std` inside one of the template arguments.

By qualifying `as_const`, performance is fixed.

For GTBench, performance is identical with `-std=c++14` and `-std=c++17` now.