### PR TITLE
Support for Compile-Time Unit Stride Dimension for Python SID Adapter

### DIFF
--- a/tests/regression/py_bindings/driver.py
+++ b/tests/regression/py_bindings/driver.py
@@ -8,20 +8,26 @@ import py_implementation as testee
 
 def test_3d():
     src = np.fromfunction(lambda i, j, k : i + j + k, (3, 4, 5), dtype=np.double)
-    dst = np.empty_like(src)
+    dst = np.zeros_like(src)
     testee.copy_from_3D(src, dst)
+    assert np.all(dst == src)
+
+def test_3d_with_unit_stride():
+    src = np.fromfunction(lambda i, j, k : i + j + k, (3, 4, 5), dtype=np.double)
+    dst = np.zeros_like(src)
+    testee.copy_from_3D_with_unit_stride(src, dst)
     assert np.all(dst == src)
 
 def test_1d():
     shape = (3, 4, 5)
     src = np.arange(shape[0], dtype=np.double)
-    dst = np.empty(shape, dtype=np.double)
+    dst = np.zeros(shape, dtype=np.double)
     testee.copy_from_1D(src, dst)
     expected = np.fromfunction(lambda i, j, k : i, shape, dtype=np.double)
     assert np.all(dst == expected)
 
 def test_scalar():
-    dst = np.empty((3, 4, 5), dtype=np.double)
+    dst = np.zeros((3, 4, 5), dtype=np.double)
     testee.copy_from_scalar(42., dst)
     assert np.all(dst == 42.)
 
@@ -50,6 +56,7 @@ def test_cuda_sid():
     testee.check_cuda_sid(mock, 0xDEADBEAF, (4 * 5, 5, 1), (3, 4, 5))
 
 test_3d()
+test_3d_with_unit_stride()
 test_1d()
 test_scalar()
 test_cuda_sid()

--- a/tests/regression/py_bindings/implementation.cpp
+++ b/tests/regression/py_bindings/implementation.cpp
@@ -90,16 +90,27 @@ void check_cuda_sid(T &&testee,
 // The differences between exported functions are in the way how parameters model the SID concept.
 // Note that the generic algorithm stays the same.
 PYBIND11_MODULE(py_implementation, m) {
-    m.def("copy_from_3D",
+    m.def(
+        "copy_from_3D",
         [](py::buffer from, py::buffer to) { copy(as_sid<double const, 3>(from), as_sid<double, 3>(to)); },
         "Copy from one 3D buffer of doubles to another.");
-    m.def("copy_from_1D",
+    m.def(
+        "copy_from_3D_with_unit_stride",
+        [](py::buffer from, py::buffer to) {
+            copy(as_sid<double const, 3, void, 2>(from), as_sid<double, 3, void, 2>(to));
+        },
+        "Copy from one 3D buffer of doubles to another, requires `from.strides[2] == to.strides[2] == "
+        "sizeof(double)`.");
+    m.def(
+        "copy_from_1D",
         [](py::buffer from, py::buffer to) { copy(as_sid<double const, 1>(from), as_sid<double, 3>(to)); },
         "Copy from the 1D double buffer to a 3D one.");
-    m.def("copy_from_scalar",
+    m.def(
+        "copy_from_scalar",
         [](double from, py::buffer to) { copy(make_global_parameter(from), as_sid<double, 3>(to)); },
         "Copy from the scalar to a 3D buffer of doubles.");
-    m.def("check_cuda_sid",
+    m.def(
+        "check_cuda_sid",
         [](py::object testeee, size_t ptr, std::vector<size_t> const &strides, std::vector<size_t> const &dims) {
             check_cuda_sid(as_cuda_sid<double const, 3>(testeee), ptr, strides, dims);
         },


### PR DESCRIPTION
Adds `UnitStrideDim` argument to Python SID adapter to support the same unit-stride assumptions in GT4Py as with GT 1.1.