### PR TITLE
Fix gtest dependency if compiling with gcc 11.1.0

### DIFF
--- a/cmake/internal/FetchGoogletest.cmake
+++ b/cmake/internal/FetchGoogletest.cmake
@@ -17,4 +17,5 @@ function(fetch_googletest)
         GIT_TAG        release-1.10.0
     )
     FetchContent_MakeAvailable(googletest)
+    target_compile_options(gtest PRIVATE "-w")
 endfunction()


### PR DESCRIPTION
Error message:
```
/home/tille/Development/gridtools/build/_deps/pybind11-src/include/pybind11/detail/internals.h: In function ‘pybind11::detail::internals& pybind11::detail::get_internals()’:
/home/tille/Development/gridtools/build/_deps/pybind11-src/include/pybind11/detail/internals.h:276:27: warning: ‘void PyEval_InitThreads()’ is deprecated [-Wdeprecated-declarations]
  276 |         PyEval_InitThreads();
      |         ~~~~~~~~~~~~~~~~~~^~
In file included from /usr/include/python3.9/Python.h:145,
                 from /home/tille/Development/gridtools/build/_deps/pybind11-src/include/pybind11/detail/common.h:112,
                 from /home/tille/Development/gridtools/build/_deps/pybind11-src/include/pybind11/pytypes.h:12,
                 from /home/tille/Development/gridtools/build/_deps/pybind11-src/include/pybind11/cast.h:13,
                 from /home/tille/Development/gridtools/build/_deps/pybind11-src/include/pybind11/attr.h:13,
                 from /home/tille/Development/gridtools/build/_deps/pybind11-src/include/pybind11/pybind11.h:44,
                 from /home/tille/Development/gridtools/include/gridtools/storage/adapter/python_sid_adapter.hpp:23,
                 from /home/tille/Development/gridtools/tests/regression/py_bindings/implementation.cpp:11:
/usr/include/python3.9/ceval.h:130:37: note: declared here
  130 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
      |                                     ^~~~~~~~~~~~~~~~~~
In file included from /home/tille/Development/gridtools/build/_deps/googletest-src/googletest/src/gtest-all.cc:42:
/home/tille/Development/gridtools/build/_deps/googletest-src/googletest/src/gtest-death-test.cc: In function ‘bool testing::internal::StackGrowsDown()’:
/home/tille/Development/gridtools/build/_deps/googletest-src/googletest/src/gtest-death-test.cc:1301:24: error: ‘dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
 1301 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/home/tille/Development/gridtools/build/_deps/googletest-src/googletest/src/gtest-death-test.cc:1290:13: note: by argument 1 of type ‘const void*’ to ‘void testing::internal::StackLowerThanAddress(const void*, bool*)’ declared here
 1290 | static void StackLowerThanAddress(const void* ptr, bool* result) {
      |             ^~~~~~~~~~~~~~~~~~~~~
/home/tille/Development/gridtools/build/_deps/googletest-src/googletest/src/gtest-death-test.cc:1299:7: note: ‘dummy’ declared here
 1299 |   int dummy;
```