### PR TITLE
Fix cuda 11 4

### DIFF
--- a/include/gridtools/common/for_each.hpp
+++ b/include/gridtools/common/for_each.hpp
@@ -13,6 +13,7 @@
 #define GT_COMMON_GENERIC_METAFUNCTIONS_FOR_EACH_HPP_
 
 #include "host_device.hpp"
+#include <utility>
 
 #define GT_FILENAME <gridtools/common/for_each.hpp>
 #include GT_ITERATE_ON_TARGETS()
@@ -53,8 +54,11 @@ namespace gridtools {
 #endif
         } // namespace for_each_impl_
 
-        template <class L>
-        constexpr for_each_impl_::for_each_f<L> for_each = {};
+        template <typename L, typename Args>
+        GT_TARGET GT_FORCE_INLINE GT_TARGET_CONSTEXPR void for_each(Args&& args) {
+            for_each_impl_::for_each_f<L>()(std::forward<Args&&>(args));
+
+        }
     }
 } // namespace gridtools
 

--- a/include/gridtools/common/for_each.hpp
+++ b/include/gridtools/common/for_each.hpp
@@ -13,7 +13,6 @@
 #define GT_COMMON_GENERIC_METAFUNCTIONS_FOR_EACH_HPP_
 
 #include "host_device.hpp"
-#include <utility>
 
 #define GT_FILENAME <gridtools/common/for_each.hpp>
 #include GT_ITERATE_ON_TARGETS()
@@ -54,11 +53,8 @@ namespace gridtools {
 #endif
         } // namespace for_each_impl_
 
-        template <typename L, typename Args>
-        GT_TARGET GT_FORCE_INLINE GT_TARGET_CONSTEXPR void for_each(Args&& args) {
-            for_each_impl_::for_each_f<L>()(std::forward<Args&&>(args));
-
-        }
+        template <class L>
+        GT_TARGET constexpr for_each_impl_::for_each_f<L> for_each = {};
     }
 } // namespace gridtools
 

--- a/include/gridtools/common/for_each.hpp
+++ b/include/gridtools/common/for_each.hpp
@@ -54,7 +54,10 @@ namespace gridtools {
         } // namespace for_each_impl_
 
         template <class L>
-        GT_TARGET constexpr for_each_impl_::for_each_f<L> for_each = {};
+#if defined(GT_TARGET_HAS_DEVICE) and defined(__NVCC__)
+        GT_DEVICE
+#endif
+        constexpr for_each_impl_::for_each_f<L> for_each = {};
     }
 } // namespace gridtools
 

--- a/include/gridtools/meta/macros.hpp
+++ b/include/gridtools/meta/macros.hpp
@@ -22,7 +22,7 @@
  *  NVCC bug workaround: sizeof... works incorrectly within template alias context.
  */
 #if defined(__CUDACC_VER_MAJOR__) && \
-    (__CUDACC_VER_MAJOR__ < 11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 3))
+    (__CUDACC_VER_MAJOR__ < 11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 5))
 
 namespace gridtools {
     namespace meta {

--- a/include/gridtools/reduction/gpu.hpp
+++ b/include/gridtools/reduction/gpu.hpp
@@ -350,7 +350,7 @@ namespace gridtools {
                 assert(warp_size == 32 || warp_size == 64);
                 ct_dispatch<2>(
                     [=](auto w) {
-                        constexpr size_t warp_size = w ? 64 : 32;
+                        constexpr size_t warp_size = decltype(w)::value ? 64 : 32;
                         ct_dispatch<int_log2(max_threads) + 1>(
                             [=](auto n) {
                                 constexpr size_t block_size = 1 << decltype(n)::value;


### PR DESCRIPTION
This are the changes needed for CUDA 11.4

- There is a problem with `for_each` being a constexpr value. This is reported and we will see whether this is considered part of CUDA constexpr interpretation.
- `sizeof...` is still not fixed ==> Will try to get an update on the state of the issue.
- reduction: There seems a problem in GCC 7.5, which is still used in some of our systems as a default. As this is a trivial workaround, I propose to do this.