### PR TITLE
Update hip container label, according to latest updates in gridtools-docker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     container: ghcr.io/gridtools/gridtools-base:${{ matrix.compiler }}
     strategy:
         matrix:
-            compiler: [gcc-8, gcc-9, gcc-10, clang-9, clang-10, clang-11, clang-9-cuda-11, gcc-9-cuda-11, hip, gcc-10-hpx]
+            compiler: [gcc-8, gcc-9, gcc-10, clang-9, clang-10, clang-11, clang-9-cuda-11, gcc-9-cuda-11, base-hip, gcc-10-hpx]
             build_type: [debug, release]
             exclude:
               - compiler: gcc-8


### PR DESCRIPTION
I recently updated the `gridtools-docker` repository and changed the tag of the former hip container, due to a second hip instance needed for the GHEX CI. I can easily revert back to the previous one in case of any issue.