### PR TITLE
Intel with -qnextgen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ The GridTools libraries are currently nightly tested with the following compiler
 - CUDA 11.0.x has a severe issue, see https://github.com/GridTools/gridtools/issues/1522. Under certain conditions, GridTools code will not compile for this version of CUDA. CUDA 11.1.x and later should not be affected by this issue.
 - Cray Clang version 11.0.0 has a problem with the `gridtools::tuple` conversion constructor, see https://github.com/GridTools/gridtools/issues/1615.
 
+##### Partly supported (expected to work, but not tested regularly)
+
+| Compiler | Backend | Date | Comments |
+| --- | --- | --- | --- |
+| Intel 19.1.1.217 | all backends | 2021-09-30 | with `cmake . -DCMAKE_CXX_FLAGS=-qnextgen` |
 
 ##### Officially not supported (no workarounds implemented and planned)
 

--- a/docs_src/manuals/getting_started/CMakeLists.txt
+++ b/docs_src/manuals/getting_started/CMakeLists.txt
@@ -56,5 +56,6 @@ ExternalProject_Add(getting_started_cmake_test
     CMAKE_ARGS
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
         -DGridTools_DIR=${PROJECT_BINARY_DIR} # relies on the GridToolsConfig.cmake in the build directory (the one used for export(package))
+        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
     INSTALL_COMMAND ""
     )


### PR DESCRIPTION
Propagate `CMAKE_CXX_FLAGS` to examples sub-project.