### PR TITLE
Extensions to meta and hymap

### DIFF
--- a/include/gridtools/common/hymap.hpp
+++ b/include/gridtools/common/hymap.hpp
@@ -159,8 +159,12 @@ namespace gridtools {
         template <class T>
         using get_from_keys_values =
             decltype(::gridtools::hymap_impl_::get_from_keys_values_fun(std::declval<T const &>()));
+
+        template <class Key, class Map>
+        using element_at = tuple_util::element<meta::st_position<get_keys<Map>, Key>::value, Map>;
     } // namespace hymap_impl_
 
+    using hymap_impl_::element_at;
     using hymap_impl_::get_from_keys_values;
     using hymap_impl_::get_keys;
 
@@ -191,7 +195,8 @@ namespace gridtools {
 
         template <class MetaMap,
             template <class...> class KeyCtor = keys,
-            class KeysAndValues = meta::transpose<MetaMap>>
+            class KeysAndValues =
+                meta::if_<meta::is_empty<MetaMap>, meta::list<meta::list<>, meta::list<>>, meta::transpose<MetaMap>>>
         using from_meta_map = from_keys_values<meta::first<KeysAndValues>, meta::second<KeysAndValues>, KeyCtor>;
 
         namespace hymap_impl_ {

--- a/include/gridtools/meta.hpp
+++ b/include/gridtools/meta.hpp
@@ -160,4 +160,5 @@
 #include "meta/transform.hpp"
 #include "meta/trim.hpp"
 #include "meta/type_traits.hpp"
+#include "meta/val.hpp"
 #include "meta/zip.hpp"

--- a/include/gridtools/meta/val.hpp
+++ b/include/gridtools/meta/val.hpp
@@ -17,6 +17,26 @@
 
 namespace gridtools::meta {
 
+    /**
+     * Maps compile time values to a type.
+     *
+     * Motivation:
+     *  In `meta` library types are first class citizens, values are not.
+     *  All algorithms  are defined in terms of types.
+     *  If you need a compile time map for example and you want to store values in there you can use `val`:
+     *
+     *  // maps arity to functions
+     *  using my_map_t = list<
+     *      list<val<1>, val<[](auto x) { return 42; }>>,
+     *      list<val<2>, val<[](auto x, auto y) { return 88; }>>
+     *  >;
+     *
+     *  auto foo(auto... args) {
+     *      // dispatch on the arity of args...;
+     *      return second<mp_find<my_map_t, val<sizeof...(args)>>>::value(args...);
+     *  }
+     *
+     */
     template <auto...>
     struct val {};
 
@@ -29,6 +49,17 @@ namespace gridtools::meta {
         static constexpr type value = V;
     };
 
+    /**
+     * `vl_split` splits `val<V0, V1, V2>` into the type list:  `list<val<V0>, val<V1>, val<V2>>`.
+     * `vl_merge` does the opposite.
+     *
+     * Useful if you need to process values within the `val` in compile time using some `meta` infrastructure.
+     * Example:
+     *
+     * template <class T>
+     * using dedup_val = vl_merge<dedup<vl_split<T>>>;
+     *
+     */
     namespace lazy {
         template <class>
         struct vl_split;
@@ -37,8 +68,18 @@ namespace gridtools::meta {
         struct vl_split<H<Vs...>> {
             using type = list<H<Vs>...>;
         };
+
+        template <class>
+        struct vl_merge;
+
+        template <template <class...> class L, template <auto...> class H, auto... Vs>
+        struct vl_merge<L<H<Vs>...>> {
+            using type = H<Vs...>;
+        };
+
     } // namespace lazy
     GT_META_DELEGATE_TO_LAZY(vl_split, class T, T);
+    GT_META_DELEGATE_TO_LAZY(vl_merge, class T, T);
 } // namespace gridtools::meta
 
 #endif

--- a/include/gridtools/meta/val.hpp
+++ b/include/gridtools/meta/val.hpp
@@ -1,0 +1,44 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2021, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#if __cplusplus >= 201703
+
+#include "list.hpp"
+#include "macros.hpp"
+
+namespace gridtools::meta {
+
+    template <auto...>
+    struct val {};
+
+    template <auto... Vs>
+    constexpr val<Vs...> constant = {};
+
+    template <auto V>
+    struct val<V> {
+        using type = decltype(V);
+        static constexpr type value = V;
+    };
+
+    namespace lazy {
+        template <class>
+        struct vl_split;
+
+        template <template <auto...> class H, auto... Vs>
+        struct vl_split<H<Vs...>> {
+            using type = list<H<Vs>...>;
+        };
+    } // namespace lazy
+    GT_META_DELEGATE_TO_LAZY(vl_split, class T, T);
+} // namespace gridtools::meta
+
+#endif

--- a/include/gridtools/sid/concept.hpp
+++ b/include/gridtools/sid/concept.hpp
@@ -612,8 +612,8 @@ namespace gridtools {
             using is_sid = conjunction<
 
                 // `is_trivially_copyable` check is applied to the types that are will be passed from host to device
-                std::is_trivially_copyable<PtrHolder>,
-                std::is_trivially_copyable<StridesType>,
+                std::is_trivially_copy_constructible<PtrHolder>,
+                std::is_trivially_copy_constructible<StridesType>,
 
                 // verify that `PtrDiff` is sane
                 std::is_default_constructible<PtrDiff>,

--- a/tests/unit_tests/common/test_hymap.cpp
+++ b/tests/unit_tests/common/test_hymap.cpp
@@ -115,6 +115,13 @@ namespace gridtools {
                 std::is_same<typename std::decay<decltype(at_key<b>(std::declval<dst_t>()))>::type, double>(), "");
         }
 
+        TEST(from_meta_map, empty) {
+            using src_t = meta::list<>;
+            using dst_t = hymap::from_meta_map<src_t>;
+
+            static_assert(tuple_util::size<dst_t>() == 0);
+        }
+
         struct add_3_f {
             template <class Key, class Value>
             Value operator()(Value x) const {


### PR DESCRIPTION
- add `element_at` to `hymap` library
- introduce `meta::val` and friends
- fix a bug in `hymap::from_meta_map`
- soften sid value type requirements from `std::trivaly_copyablle`  to `std::trivially_copy_constructible`