### PR TITLE
CTAD for simple_ptr_holder

### DIFF
--- a/include/gridtools/sid/allocator.hpp
+++ b/include/gridtools/sid/allocator.hpp
@@ -124,7 +124,7 @@ namespace gridtools {
                     using type = typename LazyT::type;
                     auto ptr = self.m_impl(sizeof(type) * size);
                     self.m_buffers.push_back(self.m_impl(sizeof(type) * size));
-                    return make_simple_ptr_holder(reinterpret_cast<type *>(self.m_buffers.back().get()));
+                    return simple_ptr_holder(reinterpret_cast<type *>(self.m_buffers.back().get()));
                 }
             };
 

--- a/include/gridtools/sid/simple_ptr_holder.hpp
+++ b/include/gridtools/sid/simple_ptr_holder.hpp
@@ -36,6 +36,7 @@ namespace gridtools {
 #else
                 // Enables CTAD in C++17.
                 GT_TARGET GT_FORCE_INLINE constexpr simple_ptr_holder(T const &ptr) : m_val{ptr} {}
+                GT_TARGET GT_FORCE_INLINE constexpr simple_ptr_holder() = default;
 #endif
                 GT_TARGET GT_FORCE_INLINE constexpr T const &operator()() const { return m_val; }
             };

--- a/include/gridtools/sid/simple_ptr_holder.hpp
+++ b/include/gridtools/sid/simple_ptr_holder.hpp
@@ -35,8 +35,8 @@ namespace gridtools {
 // CTAD for aggregates works
 #else
                 // Enables CTAD in C++17.
+                simple_ptr_holder() = default;
                 GT_TARGET GT_FORCE_INLINE constexpr simple_ptr_holder(T const &ptr) : m_val{ptr} {}
-                GT_TARGET GT_FORCE_INLINE constexpr simple_ptr_holder() = default;
 #endif
                 GT_TARGET GT_FORCE_INLINE constexpr T const &operator()() const { return m_val; }
             };

--- a/include/gridtools/sid/simple_ptr_holder.hpp
+++ b/include/gridtools/sid/simple_ptr_holder.hpp
@@ -30,22 +30,30 @@ namespace gridtools {
             template <class T>
             struct simple_ptr_holder {
                 T m_val;
+
+#if defined(__cpp_deduction_guides) and __cpp_deduction_guides >= 201907
+// CTAD for aggregates works
+#else
+                // Enables CTAD in C++17.
+                GT_TARGET GT_FORCE_INLINE constexpr simple_ptr_holder(T const &ptr) : m_val{ptr} {}
+#endif
                 GT_TARGET GT_FORCE_INLINE constexpr T const &operator()() const { return m_val; }
             };
 
             template <class T>
-            constexpr simple_ptr_holder<T> make_simple_ptr_holder(T const &ptr) {
+            [[deprecated("use simple_ptr_holder class template argument deduction")]] constexpr simple_ptr_holder<T>
+            make_simple_ptr_holder(T const &ptr) {
                 return {ptr};
             }
 
             template <class T, class Arg>
             constexpr auto operator+(simple_ptr_holder<T> const &obj, Arg &&arg) {
-                return make_simple_ptr_holder(obj.m_val + std::forward<Arg>(arg));
+                return simple_ptr_holder(obj.m_val + std::forward<Arg>(arg));
             }
 
             template <class T, class Arg>
             constexpr auto operator+(simple_ptr_holder<T> &&obj, Arg &&arg) {
-                return make_simple_ptr_holder(std::move(obj).m_val + std::forward<Arg>(arg));
+                return simple_ptr_holder(std::move(obj).m_val + std::forward<Arg>(arg));
             }
         }
     } // namespace sid

--- a/tests/unit_tests/sid/test_sid_as_const.cpp
+++ b/tests/unit_tests/sid/test_sid_as_const.cpp
@@ -24,7 +24,7 @@ namespace gridtools {
 
         TEST(as_const, smoke) {
             double data = 42;
-            auto src = sid::synthetic().set<property::origin>(sid::host_device::make_simple_ptr_holder(&data));
+            auto src = sid::synthetic().set<property::origin>(sid::host_device::simple_ptr_holder(&data));
             auto testee = sid::as_const(src);
             using testee_t = decltype(testee);
 

--- a/tests/unit_tests/sid/test_sid_composite.cpp
+++ b/tests/unit_tests/sid/test_sid_composite.cpp
@@ -51,8 +51,8 @@ namespace gridtools {
             double const src = 42;
             double dst = 0;
             sid::composite::keys<a, b>::values(
-                sid::synthetic().set<property::origin>(sid::host_device::make_simple_ptr_holder(&src)),
-                sid::synthetic().set<property::origin>(sid::host_device::make_simple_ptr_holder(&dst)));
+                sid::synthetic().set<property::origin>(sid::host_device::simple_ptr_holder(&src)),
+                sid::synthetic().set<property::origin>(sid::host_device::simple_ptr_holder(&dst)));
         }
 #endif
 
@@ -61,8 +61,8 @@ namespace gridtools {
             double dst = 0;
 
             auto testee = sid::composite::keys<a, b>::make_values(
-                sid::synthetic().set<property::origin>(sid::host_device::make_simple_ptr_holder(&src)),
-                sid::synthetic().set<property::origin>(sid::host_device::make_simple_ptr_holder(&dst)));
+                sid::synthetic().set<property::origin>(sid::host_device::simple_ptr_holder(&src)),
+                sid::synthetic().set<property::origin>(sid::host_device::simple_ptr_holder(&dst)));
             static_assert(is_sid<decltype(testee)>());
 
             auto ptrs = sid::get_origin(testee)();
@@ -88,23 +88,23 @@ namespace gridtools {
 
             auto my_strides = array{1, 5, 15};
 
-            auto testee = sid::composite::keys<a, b, c, d>::make_values(                              //
-                sid::synthetic()                                                                      //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&one[0]))         //
-                    .set<property::strides>(tuple(1_c))                                               //
-                ,                                                                                     //
-                sid::synthetic()                                                                      //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&two))            //
-                ,                                                                                     //
-                sid::synthetic()                                                                      //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&three[0][0][0])) //
-                    .set<property::strides>(my_strides)                                               //
-                    .set<property::strides_kind, my_strides_kind>()                                   //
-                ,                                                                                     //
-                sid::synthetic()                                                                      //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&four[0][0][0]))  //
-                    .set<property::strides>(my_strides)                                               //
-                    .set<property::strides_kind, my_strides_kind>()                                   //
+            auto testee = sid::composite::keys<a, b, c, d>::make_values(                         //
+                sid::synthetic()                                                                 //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&one[0]))         //
+                    .set<property::strides>(tuple(1_c))                                          //
+                ,                                                                                //
+                sid::synthetic()                                                                 //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&two))            //
+                ,                                                                                //
+                sid::synthetic()                                                                 //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&three[0][0][0])) //
+                    .set<property::strides>(my_strides)                                          //
+                    .set<property::strides_kind, my_strides_kind>()                              //
+                ,                                                                                //
+                sid::synthetic()                                                                 //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&four[0][0][0]))  //
+                    .set<property::strides>(my_strides)                                          //
+                    .set<property::strides_kind, my_strides_kind>()                              //
             );
             static_assert(is_sid<decltype(testee)>());
 
@@ -178,21 +178,21 @@ namespace gridtools {
             char four[6][4][5] = {};
             auto strides_four = hymap::keys<dim_y, dim_z, dim_x>::make_values(1_c, 5_c, 20_c);
 
-            auto testee = sid::composite::keys<a, b, c, d>::make_values(                              //
-                sid::synthetic()                                                                      //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&one[0]))         //
-                    .set<property::strides>(strides_one)                                              //
-                ,                                                                                     //
-                sid::synthetic()                                                                      //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&two))            //
-                ,                                                                                     //
-                sid::synthetic()                                                                      //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&three[0][0][0])) //
-                    .set<property::strides>(strides_three)                                            //
-                ,                                                                                     //
-                sid::synthetic()                                                                      //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&four[0][0][0]))  //
-                    .set<property::strides>(strides_four)                                             //
+            auto testee = sid::composite::keys<a, b, c, d>::make_values(                         //
+                sid::synthetic()                                                                 //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&one[0]))         //
+                    .set<property::strides>(strides_one)                                         //
+                ,                                                                                //
+                sid::synthetic()                                                                 //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&two))            //
+                ,                                                                                //
+                sid::synthetic()                                                                 //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&three[0][0][0])) //
+                    .set<property::strides>(strides_three)                                       //
+                ,                                                                                //
+                sid::synthetic()                                                                 //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&four[0][0][0]))  //
+                    .set<property::strides>(strides_four)                                        //
             );
 
             auto &&strides = sid::get_strides(testee);
@@ -216,14 +216,14 @@ namespace gridtools {
             int one[1] = {};
             int two[1][1] = {};
 
-            auto testee = sid::composite::keys<a, b>::make_values(                               //
-                sid::synthetic()                                                                 //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&one[0]))    //
-                    .set<property::strides>(tuple(1))                                            //
-                    .set<property::strides_kind, sid::unknown_kind>(),                           //
-                sid::synthetic()                                                                 //
-                    .set<property::origin>(sid::host_device::make_simple_ptr_holder(&two[0][0])) //
-                    .set<property::strides>(tuple(1, 1))                                         //
+            auto testee = sid::composite::keys<a, b>::make_values(                          //
+                sid::synthetic()                                                            //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&one[0]))    //
+                    .set<property::strides>(tuple(1))                                       //
+                    .set<property::strides_kind, sid::unknown_kind>(),                      //
+                sid::synthetic()                                                            //
+                    .set<property::origin>(sid::host_device::simple_ptr_holder(&two[0][0])) //
+                    .set<property::strides>(tuple(1, 1))                                    //
                     .set<property::strides_kind, sid::unknown_kind>());
 
             auto &&strides = sid::get_strides(testee);

--- a/tests/unit_tests/sid/test_sid_delegate.cpp
+++ b/tests/unit_tests/sid/test_sid_delegate.cpp
@@ -46,7 +46,7 @@ namespace gridtools {
         TEST(delegate, smoke) {
             double data[3][5];
             auto src = sid::synthetic()
-                           .set<property::origin>(sid::host_device::make_simple_ptr_holder(&data[0][0]))
+                           .set<property::origin>(sid::host_device::simple_ptr_holder(&data[0][0]))
                            .set<property::strides>(tuple(5_c, 1_c));
             EXPECT_EQ(&data[0][0], sid::get_origin(src)());
 
@@ -77,7 +77,7 @@ namespace gridtools {
         TEST(delegate, do_nothing) {
             double data[3][5];
             auto src = sid::synthetic()
-                           .set<property::origin>(sid::host_device::make_simple_ptr_holder(&data[0][0]))
+                           .set<property::origin>(sid::host_device::simple_ptr_holder(&data[0][0]))
                            .set<property::strides>(tuple(5_c, 1_c));
             auto testee = just_delegate(src);
             static_assert(is_sid<decltype(testee)>());

--- a/tests/unit_tests/sid/test_sid_rename_dimensions.cpp
+++ b/tests/unit_tests/sid/test_sid_rename_dimensions.cpp
@@ -34,7 +34,7 @@ namespace gridtools {
             double data[3][5][7];
 
             auto src = sid::synthetic()
-                           .set<property::origin>(sid::make_simple_ptr_holder(&data[0][0][0]))
+                           .set<property::origin>(sid::simple_ptr_holder(&data[0][0][0]))
                            .set<property::strides>(hymap::keys<a, b, c>::make_values(5_c * 7_c, 7_c, 1_c))
                            .set<property::upper_bounds>(hymap::keys<a, b>::make_values(3, 5));
 
@@ -77,7 +77,7 @@ namespace gridtools {
         TEST(rename_dimensions, rename_twice_and_make_composite) {
             double data[3][5][7];
             auto src = sid::synthetic()
-                           .set<property::origin>(sid::host_device::make_simple_ptr_holder(&data[0][0][0]))
+                           .set<property::origin>(sid::host_device::simple_ptr_holder(&data[0][0][0]))
                            .set<property::strides>(hymap::keys<a, b, c>::make_values(5_c * 7_c, 7_c, 1_c))
                            .set<property::upper_bounds>(hymap::keys<a, b>::make_values(3, 5));
             auto testee = sid::rename_dimensions<a, c, b, d>(src);

--- a/tests/unit_tests/sid/test_sid_shift_sid_origin.cpp
+++ b/tests/unit_tests/sid/test_sid_shift_sid_origin.cpp
@@ -28,7 +28,7 @@ namespace gridtools {
             double data[3][5][7];
 
             auto src = sid::synthetic()
-                           .set<property::origin>(sid::make_simple_ptr_holder(&data[0][0][0]))
+                           .set<property::origin>(sid::simple_ptr_holder(&data[0][0][0]))
                            .set<property::strides>(tuple(5_c * 7_c, 7_c, 1_c))
                            .set<property::upper_bounds>(tuple(3));
 

--- a/tests/unit_tests/sid/test_sid_synthetic.cpp
+++ b/tests/unit_tests/sid/test_sid_synthetic.cpp
@@ -24,7 +24,7 @@ namespace gridtools {
 
         TEST(sid_synthetic, smoke) {
             double a = 100;
-            auto testee = sid::synthetic().set<property::origin>(sid::host_device::make_simple_ptr_holder(&a));
+            auto testee = sid::synthetic().set<property::origin>(sid::host_device::simple_ptr_holder(&a));
             static_assert(is_sid<decltype(testee)>::value);
 
             EXPECT_EQ(a, *sid::get_origin(testee)());
@@ -55,7 +55,7 @@ namespace gridtools {
                 strides the_strides = {stride{3}, stride{4}};
 
                 auto the_testee = sid::synthetic()
-                                      .set<property::origin>(sid::host_device::make_simple_ptr_holder(the_origin))
+                                      .set<property::origin>(sid::host_device::simple_ptr_holder(the_origin))
                                       .set<property::strides>(the_strides)
                                       .set<property::ptr_diff, ptr_diff>()
                                       .set<property::strides_kind, strides_kind>();


### PR DESCRIPTION
Not sure if it's worth trading aggregate for CTAD. When I looked at make_simple_ptr_holder, I missed that aggregate CTAD is a C++20 feature.