### PR TITLE
fn: allow setting CUDA stream

### DIFF
--- a/include/gridtools/common/cuda_util.hpp
+++ b/include/gridtools/common/cuda_util.hpp
@@ -74,34 +74,19 @@ namespace gridtools {
             return res;
         }
 
-// #ifdef GT_CUDACC
-//         template <class Kernel, class... Args>
-//         void launch(dim3 const &blocks, dim3 const &threads, size_t shared_memory_size, Kernel kernel, Args... args)
-//         {
-// #ifndef __HIPCC__
-//             GT_CUDA_CHECK(
-//                 cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
-// #endif
-//             kernel<<<blocks, threads, shared_memory_size>>>(std::move(args)...);
-//             GT_CUDA_CHECK(cudaGetLastError());
-// #ifndef NDEBUG
-//             GT_CUDA_CHECK(cudaDeviceSynchronize());
-// #endif
-//         }
-// #endif
 #ifdef GT_CUDACC
         template <class Kernel, class... Args>
         void launch(dim3 const &blocks,
             dim3 const &threads,
             size_t shared_memory_size,
-            cudaStream_t s,
+            cudaStream_t stream,
             Kernel kernel,
             Args... args) {
 #ifndef __HIPCC__
             GT_CUDA_CHECK(
                 cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
 #endif
-            kernel<<<blocks, threads, shared_memory_size, s>>>(std::move(args)...);
+            kernel<<<blocks, threads, shared_memory_size, stream>>>(std::move(args)...);
             GT_CUDA_CHECK(cudaGetLastError());
 #ifndef NDEBUG
             GT_CUDA_CHECK(cudaDeviceSynchronize());

--- a/include/gridtools/common/cuda_util.hpp
+++ b/include/gridtools/common/cuda_util.hpp
@@ -74,14 +74,34 @@ namespace gridtools {
             return res;
         }
 
+// #ifdef GT_CUDACC
+//         template <class Kernel, class... Args>
+//         void launch(dim3 const &blocks, dim3 const &threads, size_t shared_memory_size, Kernel kernel, Args... args)
+//         {
+// #ifndef __HIPCC__
+//             GT_CUDA_CHECK(
+//                 cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
+// #endif
+//             kernel<<<blocks, threads, shared_memory_size>>>(std::move(args)...);
+//             GT_CUDA_CHECK(cudaGetLastError());
+// #ifndef NDEBUG
+//             GT_CUDA_CHECK(cudaDeviceSynchronize());
+// #endif
+//         }
+// #endif
 #ifdef GT_CUDACC
         template <class Kernel, class... Args>
-        void launch(dim3 const &blocks, dim3 const &threads, size_t shared_memory_size, Kernel kernel, Args... args) {
+        void launch(dim3 const &blocks,
+            dim3 const &threads,
+            size_t shared_memory_size,
+            cudaStream_t s,
+            Kernel kernel,
+            Args... args) {
 #ifndef __HIPCC__
             GT_CUDA_CHECK(
                 cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_memory_size));
 #endif
-            kernel<<<blocks, threads, shared_memory_size>>>(std::move(args)...);
+            kernel<<<blocks, threads, shared_memory_size, s>>>(std::move(args)...);
             GT_CUDA_CHECK(cudaGetLastError());
 #ifndef NDEBUG
             GT_CUDA_CHECK(cudaDeviceSynchronize());

--- a/include/gridtools/fn/backend/gpu.hpp
+++ b/include/gridtools/fn/backend/gpu.hpp
@@ -141,7 +141,7 @@ namespace gridtools::fn::backend {
 
         template <class BlockSizes, class Sizes, class StencilStage, class MakeIterator, class Composite>
         void apply_stencil_stage(
-            gpu<BlockSizes> g, Sizes const &sizes, StencilStage, MakeIterator make_iterator, Composite &&composite) {
+            gpu<BlockSizes>const &g, Sizes const &sizes, StencilStage, MakeIterator make_iterator, Composite &&composite) {
             auto ptr_holder = sid::get_origin(std::forward<Composite>(composite));
             auto strides = sid::get_strides(std::forward<Composite>(composite));
 
@@ -180,7 +180,7 @@ namespace gridtools::fn::backend {
             class Composite,
             class Vertical,
             class Seed>
-        void apply_column_stage(gpu<BlockSizes> g,
+        void apply_column_stage(gpu<BlockSizes> const &g,
             Sizes const &sizes,
             ColumnStage,
             MakeIterator make_iterator,

--- a/include/gridtools/fn/backend/gpu.hpp
+++ b/include/gridtools/fn/backend/gpu.hpp
@@ -34,6 +34,7 @@ namespace gridtools::fn::backend {
         template <class BlockSizes>
         struct gpu {
             using block_sizes_t = BlockSizes;
+            cudaStream_t stream = 0;
         };
 
         template <class BlockSizes, class Dims, int I>
@@ -140,7 +141,7 @@ namespace gridtools::fn::backend {
 
         template <class BlockSizes, class Sizes, class StencilStage, class MakeIterator, class Composite>
         void apply_stencil_stage(
-            gpu<BlockSizes>, Sizes const &sizes, StencilStage, MakeIterator make_iterator, Composite &&composite) {
+            gpu<BlockSizes> g, Sizes const &sizes, StencilStage, MakeIterator make_iterator, Composite &&composite) {
             auto ptr_holder = sid::get_origin(std::forward<Composite>(composite));
             auto strides = sid::get_strides(std::forward<Composite>(composite));
 
@@ -148,6 +149,7 @@ namespace gridtools::fn::backend {
             cuda_util::launch(blocks,
                 threads,
                 0,
+                g.stream,
                 kernel<BlockSizes,
                     Sizes,
                     decltype(ptr_holder),
@@ -178,7 +180,7 @@ namespace gridtools::fn::backend {
             class Composite,
             class Vertical,
             class Seed>
-        void apply_column_stage(gpu<BlockSizes>,
+        void apply_column_stage(gpu<BlockSizes> g,
             Sizes const &sizes,
             ColumnStage,
             MakeIterator make_iterator,
@@ -194,6 +196,7 @@ namespace gridtools::fn::backend {
             cuda_util::launch(blocks,
                 threads,
                 0,
+                g.stream,
                 kernel<BlockSizes,
                     decltype(h_sizes),
                     decltype(ptr_holder),

--- a/include/gridtools/fn/backend/gpu.hpp
+++ b/include/gridtools/fn/backend/gpu.hpp
@@ -140,8 +140,11 @@ namespace gridtools::fn::backend {
         };
 
         template <class BlockSizes, class Sizes, class StencilStage, class MakeIterator, class Composite>
-        void apply_stencil_stage(
-            gpu<BlockSizes>const &g, Sizes const &sizes, StencilStage, MakeIterator make_iterator, Composite &&composite) {
+        void apply_stencil_stage(gpu<BlockSizes> const &g,
+            Sizes const &sizes,
+            StencilStage,
+            MakeIterator make_iterator,
+            Composite &&composite) {
             auto ptr_holder = sid::get_origin(std::forward<Composite>(composite));
             auto strides = sid::get_strides(std::forward<Composite>(composite));
 

--- a/include/gridtools/fn/cartesian.hpp
+++ b/include/gridtools/fn/cartesian.hpp
@@ -92,7 +92,7 @@ namespace gridtools::fn {
         };
 
         template <class Backend, class Sizes, class Offsets>
-        auto make_backend(Backend b, cartesian_domain<Sizes, Offsets> const &d) {
+        auto make_backend(Backend const &b, cartesian_domain<Sizes, Offsets> const &d) {
             auto allocator = tmp_allocator(Backend());
             return backend<Backend, cartesian_domain<Sizes, Offsets>, decltype(allocator)>{b, d, std::move(allocator)};
         }

--- a/include/gridtools/fn/cartesian.hpp
+++ b/include/gridtools/fn/cartesian.hpp
@@ -84,7 +84,6 @@ namespace gridtools::fn {
 
             template <class Vertical = dim::k>
             auto vertical_executor(Vertical = {}) const {
-                std::cout << m_backend.stream << std::endl;
                 return [&] {
                     return make_vertical_executor<Vertical>(
                         m_backend, m_domain.m_sizes, m_domain.m_offsets, make_iterator());

--- a/include/gridtools/fn/cartesian.hpp
+++ b/include/gridtools/fn/cartesian.hpp
@@ -72,28 +72,30 @@ namespace gridtools::fn {
 
         template <class Backend, class Domain, class TmpAllocator>
         struct backend {
+            Backend m_backend;
             Domain m_domain;
             TmpAllocator m_allocator;
 
             auto stencil_executor() const {
                 return [&] {
-                    return make_stencil_executor(Backend(), m_domain.m_sizes, m_domain.m_offsets, make_iterator());
+                    return make_stencil_executor(m_backend, m_domain.m_sizes, m_domain.m_offsets, make_iterator());
                 };
             }
 
             template <class Vertical = dim::k>
             auto vertical_executor(Vertical = {}) const {
+                std::cout << m_backend.stream << std::endl;
                 return [&] {
                     return make_vertical_executor<Vertical>(
-                        Backend(), m_domain.m_sizes, m_domain.m_offsets, make_iterator());
+                        m_backend, m_domain.m_sizes, m_domain.m_offsets, make_iterator());
                 };
             }
         };
 
         template <class Backend, class Sizes, class Offsets>
-        auto make_backend(Backend, cartesian_domain<Sizes, Offsets> const &d) {
+        auto make_backend(Backend b, cartesian_domain<Sizes, Offsets> const &d) {
             auto allocator = tmp_allocator(Backend());
-            return backend<Backend, cartesian_domain<Sizes, Offsets>, decltype(allocator)>{d, std::move(allocator)};
+            return backend<Backend, cartesian_domain<Sizes, Offsets>, decltype(allocator)>{b, d, std::move(allocator)};
         }
     } // namespace cartesian_impl_
     using cartesian_impl_::cartesian_domain;

--- a/include/gridtools/fn/executor.hpp
+++ b/include/gridtools/fn/executor.hpp
@@ -17,7 +17,6 @@
 #include "./column_stage.hpp"
 #include "./run.hpp"
 #include "./stencil_stage.hpp"
-#include <iostream>
 
 namespace gridtools::fn {
     namespace executor_impl_ {
@@ -34,7 +33,6 @@ namespace gridtools::fn {
             Offsets m_offsets;
             MakeIterator m_make_iterator;
             Args m_args = {};
-            // using backend_t = Backend;
             using arg_offset_t = std::integral_constant<int, ArgOffset>;
             using specs_t = Specs;
 
@@ -136,7 +134,6 @@ namespace gridtools::fn {
             Backend backend, Sizes const &sizes, Offsets const &offsets, MakeIterator const &make_iterator) {
             executor_data<Backend, ArgOffset, Sizes, Offsets, MakeIterator> data{
                 backend, sizes, offsets, make_iterator};
-            std::cout << backend.stream << std::endl;
             return vertical_executor<Vertical, decltype(data)>{std::move(data)};
         }
     } // namespace executor_impl_

--- a/include/gridtools/fn/executor.hpp
+++ b/include/gridtools/fn/executor.hpp
@@ -131,7 +131,7 @@ namespace gridtools::fn {
         // ArgOffset allows passing some args for backend usage while keeping them hidden from the user
         template <class Vertical, int ArgOffset = 0, class Backend, class Sizes, class Offsets, class MakeIterator>
         auto make_vertical_executor(
-            Backend backend, Sizes const &sizes, Offsets const &offsets, MakeIterator const &make_iterator) {
+            Backend const &backend, Sizes const &sizes, Offsets const &offsets, MakeIterator const &make_iterator) {
             executor_data<Backend, ArgOffset, Sizes, Offsets, MakeIterator> data{
                 backend, sizes, offsets, make_iterator};
             return vertical_executor<Vertical, decltype(data)>{std::move(data)};

--- a/include/gridtools/fn/run.hpp
+++ b/include/gridtools/fn/run.hpp
@@ -26,7 +26,7 @@ namespace gridtools::fn {
 
         template <class Backend, class StageSpecs, class MakeIterator, class Domain, class Sids>
         void run_stencil_stages(
-            Backend backend, StageSpecs, MakeIterator const &make_iterator, Domain const &domain, Sids &&sids) {
+            Backend const &backend, StageSpecs, MakeIterator const &make_iterator, Domain const &domain, Sids &&sids) {
             auto composite = make_composite(std::forward<Sids>(sids));
             tuple_util::for_each(
                 [&](auto stage) { apply_stencil_stage(backend, domain, std::move(stage), make_iterator, composite); },
@@ -40,7 +40,7 @@ namespace gridtools::fn {
             class Vertical,
             class Sids,
             class Seeds>
-        void run_column_stages(Backend backend,
+        void run_column_stages(Backend const &backend,
             StageSpecs,
             MakeIterator const &make_iterator,
             Domain const &domain,

--- a/include/gridtools/fn/run.hpp
+++ b/include/gridtools/fn/run.hpp
@@ -26,10 +26,10 @@ namespace gridtools::fn {
 
         template <class Backend, class StageSpecs, class MakeIterator, class Domain, class Sids>
         void run_stencil_stages(
-            Backend, StageSpecs, MakeIterator const &make_iterator, Domain const &domain, Sids &&sids) {
+            Backend backend, StageSpecs, MakeIterator const &make_iterator, Domain const &domain, Sids &&sids) {
             auto composite = make_composite(std::forward<Sids>(sids));
             tuple_util::for_each(
-                [&](auto stage) { apply_stencil_stage(Backend(), domain, std::move(stage), make_iterator, composite); },
+                [&](auto stage) { apply_stencil_stage(backend, domain, std::move(stage), make_iterator, composite); },
                 meta::rename<std::tuple, StageSpecs>());
         }
 
@@ -40,7 +40,7 @@ namespace gridtools::fn {
             class Vertical,
             class Sids,
             class Seeds>
-        void run_column_stages(Backend,
+        void run_column_stages(Backend backend,
             StageSpecs,
             MakeIterator const &make_iterator,
             Domain const &domain,
@@ -51,7 +51,7 @@ namespace gridtools::fn {
             tuple_util::for_each(
                 [&](auto stage, auto seed) {
                     apply_column_stage(
-                        Backend(), domain, std::move(stage), make_iterator, composite, Vertical(), std::move(seed));
+                        backend, domain, std::move(stage), make_iterator, composite, Vertical(), std::move(seed));
                 },
                 meta::rename<std::tuple, StageSpecs>(),
                 std::forward<Seeds>(seeds));

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -162,7 +162,7 @@ namespace gridtools::fn {
         };
 
         template <class Backend, class Tables, class Sizes, class Offsets>
-        auto make_backend(Backend b, domain_with_offsets<Tables, Sizes, Offsets> const &d) {
+        auto make_backend(Backend const &b, domain_with_offsets<Tables, Sizes, Offsets> const &d) {
             auto allocator = tmp_allocator(Backend());
             return backend<Backend, domain_with_offsets<Tables, Sizes, Offsets>, decltype(allocator)>{
                 std::move(b), d, std::move(allocator)};

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -137,6 +137,7 @@ namespace gridtools::fn {
 
         template <class Backend, class Domain, class TmpAllocator>
         struct backend {
+            Backend m_backend;
             Domain m_domain;
             TmpAllocator m_allocator;
 
@@ -145,7 +146,7 @@ namespace gridtools::fn {
             auto stencil_executor() const {
                 return [&] {
                     return make_stencil_executor<1>(
-                        Backend(), m_domain.m_sizes, m_domain.m_offsets, make_iterator(m_domain.without_offsets()))
+                        m_backend, m_domain.m_sizes, m_domain.m_offsets, make_iterator(m_domain.without_offsets()))
                         .arg(index); // the horizontal index is passed as the first argument
                 };
             }
@@ -154,17 +155,17 @@ namespace gridtools::fn {
             auto vertical_executor(Vertical = {}) const {
                 return [&] {
                     return make_vertical_executor<Vertical, 1>(
-                        Backend(), m_domain.m_sizes, m_domain.m_offsets, make_iterator(m_domain.without_offsets()))
+                        m_backend, m_domain.m_sizes, m_domain.m_offsets, make_iterator(m_domain.without_offsets()))
                         .arg(index); // the horizontal index is passed as the first argument
                 };
             }
         };
 
         template <class Backend, class Tables, class Sizes, class Offsets>
-        auto make_backend(Backend, domain_with_offsets<Tables, Sizes, Offsets> const &d) {
+        auto make_backend(Backend b, domain_with_offsets<Tables, Sizes, Offsets> const &d) {
             auto allocator = tmp_allocator(Backend());
             return backend<Backend, domain_with_offsets<Tables, Sizes, Offsets>, decltype(allocator)>{
-                d, std::move(allocator)};
+                std::move(b), d, std::move(allocator)};
         }
     } // namespace unstructured_impl_
 

--- a/include/gridtools/stencil/gpu/launch_kernel.hpp
+++ b/include/gridtools/stencil/gpu/launch_kernel.hpp
@@ -158,6 +158,7 @@ namespace gridtools {
                     cuda_util::launch(blocks,
                         threads,
                         shared_memory_size,
+                        0, // if required propagate CUDA stream
                         wrapper<num_threads, BlockSizeI, BlockSizeJ, Extent, Fun>,
                         std::move(fun),
                         i_size,
@@ -184,6 +185,7 @@ namespace gridtools {
                     cuda_util::launch(blocks,
                         threads,
                         shared_memory_size,
+                        0, // if required propagate CUDA stream
                         zero_extent_wrapper<num_threads, BlockSizeI, BlockSizeJ, Fun>,
                         std::move(fun),
                         i_size,

--- a/include/gridtools/stencil/gpu_horizontal/launch_kernel.hpp
+++ b/include/gridtools/stencil/gpu_horizontal/launch_kernel.hpp
@@ -61,6 +61,7 @@ namespace gridtools {
                         dim3((i_size + BlockSizeI - 1) / BlockSizeI, (j_size + BlockSizeJ - 1) / BlockSizeJ, zblocks),
                         dim3(BlockSizeI, 1, 1),
                         0,
+                        0, // if required propagate CUDA stream
                         wrapper<BlockSizeI, BlockSizeI, BlockSizeJ, Fun>,
                         std::move(fun),
                         i_size,

--- a/tests/regression/fn/fn_tridiagonal_solve.cpp
+++ b/tests/regression/fn/fn_tridiagonal_solve.cpp
@@ -96,10 +96,7 @@ namespace {
         using float_t = typename TypeParam::float_t;
 
         auto fencil = [&](auto sizes, auto const &a, auto const &b, auto const &c, auto const &d, auto &x) {
-            cudaStream_t s;
-            cudaStreamCreate(&s);
-            std::cout << s << std::endl;
-            auto be = fn_backend_t{s}; // TODO undo
+            auto be = fn_backend_t();
             auto domain = cartesian_domain(sizes);
             auto backend = make_backend(be, domain);
             auto alloc = tmp_allocator(be);
@@ -124,10 +121,7 @@ namespace {
 
         auto fencil =
             [&](int nvertices, int nlevels, auto const &a, auto const &b, auto const &c, auto const &d, auto &x) {
-                cudaStream_t s;
-                cudaStreamCreate(&s);
-                std::cout << s << std::endl;
-                auto be = fn_backend_t{s};
+                auto be = fn_backend_t();
                 auto domain = unstructured_domain({nvertices, nlevels}, {});
                 auto backend = make_backend(be, domain);
                 auto alloc = tmp_allocator(be);

--- a/tests/regression/fn/fn_tridiagonal_solve.cpp
+++ b/tests/regression/fn/fn_tridiagonal_solve.cpp
@@ -96,7 +96,10 @@ namespace {
         using float_t = typename TypeParam::float_t;
 
         auto fencil = [&](auto sizes, auto const &a, auto const &b, auto const &c, auto const &d, auto &x) {
-            auto be = fn_backend_t();
+            cudaStream_t s;
+            cudaStreamCreate(&s);
+            std::cout << s << std::endl;
+            auto be = fn_backend_t{s}; // TODO undo
             auto domain = cartesian_domain(sizes);
             auto backend = make_backend(be, domain);
             auto alloc = tmp_allocator(be);
@@ -121,7 +124,10 @@ namespace {
 
         auto fencil =
             [&](int nvertices, int nlevels, auto const &a, auto const &b, auto const &c, auto const &d, auto &x) {
-                auto be = fn_backend_t();
+                cudaStream_t s;
+                cudaStreamCreate(&s);
+                std::cout << s << std::endl;
+                auto be = fn_backend_t{s};
                 auto domain = unstructured_domain({nvertices, nlevels}, {});
                 auto backend = make_backend(be, domain);
                 auto alloc = tmp_allocator(be);


### PR DESCRIPTION
The `fn::gpu` backend now supports setting the CUDA stream in which the kernel is launched.