### PR TITLE
Fix perftests CMake target being empty: https://github.com/GridTools/gridtools/issues/1551

### DIFF
--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -5,7 +5,9 @@ file(WRITE
      "// This file is needed in some cases because CMake targets must have at least one .cpp source."
 )
 target_sources(perftests PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp")
-target_link_libraries(perftests gridtools _gridtools_cuda)
+if (TARGET _gridtools_cuda)
+    target_link_libraries(perftests gridtools _gridtools_cuda)
+endif()
 gridtools_set_gpu_arch_on_target(perftests "${GT_CUDA_ARCH}")
 
 target_link_libraries(perftests regression_main)

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_executable(perftests)
 
 file(WRITE 
-     "${CMAKE_BINARY_DIR}/perftests_dummy.cpp"
+     "${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp"
      "// This file is needed in some cases because CMake targets must have at least one .cpp source."
 )
-target_sources(perftests PRIVATE "${CMAKE_BINARY_DIR}/perftests_dummy.cpp")
+target_sources(perftests PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp")
 
 target_link_libraries(perftests regression_main)
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -5,6 +5,8 @@ file(WRITE
      "// This file is needed in some cases because CMake targets must have at least one .cpp source."
 )
 target_sources(perftests PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp")
+target_link_libraries(perftests GridToolsTest)
+gridtools_setup_target(perftests CUDA_ARCH ${GT_CUDA_ARCH})
 
 target_link_libraries(perftests regression_main)
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -6,7 +6,7 @@ file(WRITE
 )
 target_sources(perftests PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp")
 target_link_libraries(perftests gridtools _gridtools_cuda)
-gridtools_setup_target(perftests CUDA_ARCH ${GT_CUDA_ARCH})
+gridtools_set_gpu_arch_on_target(perftests "${GT_CUDA_ARCH}")
 
 target_link_libraries(perftests regression_main)
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,5 +1,11 @@
 add_executable(perftests)
 
+file(WRITE 
+     "${CMAKE_BINARY_DIR}/perftests_dummy.cpp"
+     "// This file is needed in some cases because CMake targets must have at least one .cpp source."
+)
+target_sources(perftests PRIVATE "${CMAKE_BINARY_DIR}/perftests_dummy.cpp")
+
 target_link_libraries(perftests regression_main)
 
 if(TARGET threadpool_hpx)

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -5,7 +5,7 @@ file(WRITE
      "// This file is needed in some cases because CMake targets must have at least one .cpp source."
 )
 target_sources(perftests PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp")
-target_link_libraries(perftests GridToolsTest)
+target_link_libraries(perftests gridtools GridToolsTest)
 gridtools_setup_target(perftests CUDA_ARCH ${GT_CUDA_ARCH})
 
 target_link_libraries(perftests regression_main)

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -5,7 +5,7 @@ file(WRITE
      "// This file is needed in some cases because CMake targets must have at least one .cpp source."
 )
 target_sources(perftests PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp")
-target_link_libraries(perftests gridtools GridToolsTest)
+target_link_libraries(perftests gridtools _gridtools_cuda)
 gridtools_setup_target(perftests CUDA_ARCH ${GT_CUDA_ARCH})
 
 target_link_libraries(perftests regression_main)


### PR DESCRIPTION
Fixes #1551. You cannot make a CMake target with no sources and no linker input, so this adds a dummy source file to the perftests target for when there are no linker inputs either.