### PR TITLE
Using SIDs as neighbour tables in functional API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Willem Deconinck (wdeconinck), ECMWF
 Auriane Reverdell (aurianer), ETH Zurich (CSCS)
 Mikael Simberg (msimberg), ETH Zurich (CSCS)
 Till Ehrengruber (tehrengruber), ETH Zurich (CSCS)
+Péter Kardos (petiaccja), ETH Zurich (EXCLAIM)

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -9,22 +9,23 @@
  */
 #pragma once
 
-#include <cstdint>
-#include <gridtools/common/array.hpp>
-#include <gridtools/fn/unstructured.hpp>
-#include <gridtools/sid/concept.hpp>
+#include <cstddef>
 #include <type_traits>
+
+#include "../common/array.hpp"
+#include "../fn/unstructured.hpp"
+#include "../sid/concept.hpp"
 
 namespace gridtools::fn::sid_neighbor_table {
     namespace sid_neighbor_table_impl_ {
-        template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
+        template <class IndexDimension, class NeighborDimension, std::size_t MaxNumNeighbors, class Sid>
         struct sid_neighbor_table {
             Sid sid;
         };
 
-        template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
+        template <class IndexDimension, class NeighborDimension, std::size_t MaxNumNeighbors, class Sid>
         auto neighbor_table_neighbors(
-            sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, Sid> const &table, size_t index) {
+            sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, Sid> const &table, std::size_t index) {
             using element_type = sid::element_type<Sid>;
 
             const auto ptr = sid_get_origin(table.sid);
@@ -34,7 +35,7 @@ namespace gridtools::fn::sid_neighbor_table {
             const auto neighbour_stride = at_key<NeighborDimension>(strides);
 
             gridtools::array<element_type, MaxNumNeighbors> neighbors;
-            for (int32_t elementIdx = 0; elementIdx < MaxNumNeighbors; ++elementIdx) {
+            for (std::size_t elementIdx = 0; elementIdx < MaxNumNeighbors; ++elementIdx) {
                 const auto element_ptr = ptr + index * index_stride + elementIdx * neighbour_stride;
                 neighbors[elementIdx] = *element_ptr();
             }

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -25,19 +25,19 @@ namespace gridtools::fn::sid_neighbor_table {
 
         template <class IndexDimension, class NeighborDimension, std::size_t MaxNumNeighbors, class Sid>
         auto neighbor_table_neighbors(
-            sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, Sid> const &table, std::size_t index) {
+            sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, Sid> const &table,
+            std::size_t index) {
             using element_type = sid::element_type<Sid>;
 
-            const auto ptr = sid_get_origin(table.sid);
+            auto ptr = sid_get_origin(table.sid)();
             const auto strides = sid_get_strides(table.sid);
 
-            const auto index_stride = at_key<IndexDimension>(strides);
-            const auto neighbour_stride = at_key<NeighborDimension>(strides);
-
             gridtools::array<element_type, MaxNumNeighbors> neighbors;
+
+            sid::shift(ptr, sid::get_stride<IndexDimension>(strides), index);
             for (std::size_t elementIdx = 0; elementIdx < MaxNumNeighbors; ++elementIdx) {
-                const auto element_ptr = ptr + index * index_stride + elementIdx * neighbour_stride;
-                neighbors[elementIdx] = *element_ptr();
+                neighbors[elementIdx] = *ptr;
+                sid::shift(ptr, sid::get_stride<NeighborDimension>(strides), 1);
             }
             return neighbors;
         }

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -27,10 +27,7 @@ namespace gridtools::fn::sid_neighbor_table {
             PtrHolder origin;
             Strides strides;
 
-            GT_FUNCTION friend auto neighbor_table_neighbors(
-                sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, PtrHolder, Strides> const &table,
-                std::size_t index) {
-
+            GT_FUNCTION friend auto neighbor_table_neighbors(sid_neighbor_table const &table, std::size_t index) {
                 auto ptr = table.origin();
                 using element_type = std::remove_reference_t<decltype(*ptr)>;
 

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -35,8 +35,8 @@ namespace gridtools::fn::sid_neighbor_table {
             gridtools::array<element_type, MaxNumNeighbors> neighbors;
 
             sid::shift(ptr, sid::get_stride<IndexDimension>(strides), index);
-            for (std::size_t elementIdx = 0; elementIdx < MaxNumNeighbors; ++elementIdx) {
-                neighbors[elementIdx] = *ptr;
+            for (std::size_t element_idx = 0; element_idx < MaxNumNeighbors; ++element_idx) {
+                neighbors[element_idx] = *ptr;
                 sid::shift(ptr, sid::get_stride<NeighborDimension>(strides), 1);
             }
             return neighbors;

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -46,7 +46,12 @@ namespace gridtools::fn::sid_neighbor_table {
         };
 
         template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
-        auto as_neighbor_table(Sid &&sid) {
+        auto as_neighbor_table(Sid &&sid) -> sid_neighbor_table<IndexDimension,
+            NeighborDimension,
+            MaxNumNeighbors,
+            sid::ptr_holder_type<Sid>,
+            sid::strides_type<Sid>> {
+
             static_assert(gridtools::tuple_util::size<decltype(sid::get_strides(std::declval<Sid>()))>::value == 2,
                 "Neighbor tables must have exactly two dimensions: the index dimension and the neighbor dimension");
             static_assert(!std::is_same_v<IndexDimension, NeighborDimension>,
@@ -55,11 +60,7 @@ namespace gridtools::fn::sid_neighbor_table {
             const auto origin = sid::get_origin(sid);
             const auto strides = sid::get_strides(sid);
 
-            return sid_neighbor_table<IndexDimension,
-                NeighborDimension,
-                MaxNumNeighbors,
-                sid::ptr_holder_type<Sid>,
-                sid::strides_type<Sid>>{origin, strides};
+            return {origin, strides};
         }
     } // namespace sid_neighbor_table_impl_
 

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -9,31 +9,46 @@
  */
 #pragma once
 
+#include <cstdint>
+#include <gridtools/common/array.hpp>
+#include <gridtools/fn/unstructured.hpp>
 #include <gridtools/sid/concept.hpp>
 #include <type_traits>
 
 namespace gridtools::fn::sid_neighbor_table {
     namespace sid_neighbor_table_impl_ {
-        template <std::size_t MaxNumNeighbors, class Sid>
+        template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
         struct sid_neighbor_table {
             Sid sid;
         };
 
-        template <std::size_t MaxNumNeighbors, class Sid>
-        auto neighbor_table_neighbors(sid_neighbor_table<MaxNumNeighbors, Sid> const &table, size_t index) {
+        template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
+        auto neighbor_table_neighbors(
+            sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, Sid> const &table, size_t index) {
             using element_type = sid::element_type<Sid>;
+
             const auto ptr = sid_get_origin(table.sid);
-            const auto lower_bounds = sid_get_lower_bounds(table.sid);
-            const auto upper_bounds = sid_get_upper_bounds(table.sid);
             const auto strides = sid_get_strides(table.sid);
-            std::array<element_type, MaxNumNeighbors> neighbors;
-            std::fill(std::begin(neighbors), std::end(neighbors), element_type{-1});
+
+            const auto index_stride = at_key<IndexDimension>(strides);
+            const auto neighbour_stride = at_key<NeighborDimension>(strides);
+
+            gridtools::array<element_type, MaxNumNeighbors> neighbors;
+            for (int32_t elementIdx = 0; elementIdx < MaxNumNeighbors; ++elementIdx) {
+                const auto element_ptr = ptr + index * index_stride + elementIdx * neighbour_stride;
+                neighbors[elementIdx] = *element_ptr();
+            }
             return neighbors;
         }
 
-        template <std::size_t MaxNumNeighbors, class Sid>
+        template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
         auto as_neighbor_table(Sid sid) {
-            return sid_neighbor_table<MaxNumNeighbors, Sid>{std::move(sid)};
+            static_assert(gridtools::tuple_util::size<decltype(sid_get_strides(std::declval<Sid>()))>::value == 2,
+                "Neighbor tables must have exactly two dimensions: the index dimension and the neighbor dimension");
+            static_assert(!std::is_same_v<IndexDimension, NeighborDimension>,
+                "The index dimension and the neighbor dimension must be different.");
+
+            return sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, Sid>{std::move(sid)};
         }
     } // namespace sid_neighbor_table_impl_
 

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -27,7 +27,7 @@ namespace gridtools::fn::sid_neighbor_table {
             PtrHolder origin;
             Strides strides;
 
-            friend auto neighbor_table_neighbors(
+            GT_FUNCTION friend auto neighbor_table_neighbors(
                 sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, PtrHolder, Strides> const &table,
                 std::size_t index) {
 

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -42,7 +42,7 @@ namespace gridtools::fn::sid_neighbor_table {
             }
         };
 
-        template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
+        template <class IndexDimension, class NeighborDimension, std::size_t MaxNumNeighbors, class Sid>
         auto as_neighbor_table(Sid &&sid) -> sid_neighbor_table<IndexDimension,
             NeighborDimension,
             MaxNumNeighbors,

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -1,0 +1,42 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2022, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+#include <gridtools/sid/concept.hpp>
+#include <type_traits>
+
+namespace gridtools::fn::sid_neighbor_table {
+    namespace sid_neighbor_table_impl_ {
+        template <std::size_t MaxNumNeighbors, class Sid>
+        struct sid_neighbor_table {
+            Sid sid;
+        };
+
+        template <std::size_t MaxNumNeighbors, class Sid>
+        auto neighbor_table_neighbors(sid_neighbor_table<MaxNumNeighbors, Sid> const &table, size_t index) {
+            using element_type = sid::element_type<Sid>;
+            const auto ptr = sid_get_origin(table.sid);
+            const auto lower_bounds = sid_get_lower_bounds(table.sid);
+            const auto upper_bounds = sid_get_upper_bounds(table.sid);
+            const auto strides = sid_get_strides(table.sid);
+            std::array<element_type, MaxNumNeighbors> neighbors;
+            std::fill(std::begin(neighbors), std::end(neighbors), element_type{-1});
+            return neighbors;
+        }
+
+        template <std::size_t MaxNumNeighbors, class Sid>
+        auto as_neighbor_table(Sid sid) {
+            return sid_neighbor_table<MaxNumNeighbors, Sid>{std::move(sid)};
+        }
+    } // namespace sid_neighbor_table_impl_
+
+    using sid_neighbor_table_impl_::as_neighbor_table;
+
+} // namespace gridtools::fn::sid_neighbor_table

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -40,7 +40,7 @@ namespace gridtools::fn::sid_neighbor_table {
             using namespace gridtools::literals;
 
             auto ptr = table.origin();
-            using element_type = std::remove_reference_t<decltype(*ptr)>;
+            using element_type = std::decay_t<decltype(*ptr)>;
 
             gridtools::array<element_type, MaxNumNeighbors> neighbors;
 

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -26,29 +26,24 @@ namespace gridtools::fn::sid_neighbor_table {
         struct sid_neighbor_table {
             PtrHolder origin;
             Strides strides;
-        };
 
-        template <class IndexDimension,
-            class NeighborDimension,
-            std::size_t MaxNumNeighbors,
-            class PtrHolder,
-            class Strides>
-        auto neighbor_table_neighbors(
-            sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, PtrHolder, Strides> const &table,
-            std::size_t index) {
+            friend auto neighbor_table_neighbors(
+                sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, PtrHolder, Strides> const &table,
+                std::size_t index) {
 
-            auto ptr = table.origin();
-            using element_type = std::remove_reference_t<decltype(*ptr)>;
+                auto ptr = table.origin();
+                using element_type = std::remove_reference_t<decltype(*ptr)>;
 
-            gridtools::array<element_type, MaxNumNeighbors> neighbors;
+                gridtools::array<element_type, MaxNumNeighbors> neighbors;
 
-            sid::shift(ptr, sid::get_stride<IndexDimension>(table.strides), index);
-            for (std::size_t element_idx = 0; element_idx < MaxNumNeighbors; ++element_idx) {
-                neighbors[element_idx] = *ptr;
-                sid::shift(ptr, sid::get_stride<NeighborDimension>(table.strides), 1);
+                sid::shift(ptr, sid::get_stride<IndexDimension>(table.strides), index);
+                for (std::size_t element_idx = 0; element_idx < MaxNumNeighbors; ++element_idx) {
+                    neighbors[element_idx] = *ptr;
+                    sid::shift(ptr, sid::get_stride<NeighborDimension>(table.strides), 1);
+                }
+                return neighbors;
             }
-            return neighbors;
-        }
+        };
 
         template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
         auto as_neighbor_table(Sid &&sid) {

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -26,21 +26,29 @@ namespace gridtools::fn::sid_neighbor_table {
         struct sid_neighbor_table {
             PtrHolder origin;
             Strides strides;
-
-            GT_FUNCTION friend auto neighbor_table_neighbors(sid_neighbor_table const &table, int index) {
-                auto ptr = table.origin();
-                using element_type = std::remove_reference_t<decltype(*ptr)>;
-
-                gridtools::array<element_type, MaxNumNeighbors> neighbors;
-
-                sid::shift(ptr, sid::get_stride<IndexDimension>(table.strides), index);
-                for (std::size_t element_idx = 0; element_idx < MaxNumNeighbors; ++element_idx) {
-                    neighbors[element_idx] = *ptr;
-                    sid::shift(ptr, sid::get_stride<NeighborDimension>(table.strides), 1);
-                }
-                return neighbors;
-            }
         };
+
+        template <class IndexDimension,
+            class NeighborDimension,
+            std::size_t MaxNumNeighbors,
+            class PtrHolder,
+            class Strides>
+        GT_FUNCTION auto neighbor_table_neighbors(
+            sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, PtrHolder, Strides> const &table,
+            int index) {
+
+            auto ptr = table.origin();
+            using element_type = std::remove_reference_t<decltype(*ptr)>;
+
+            gridtools::array<element_type, MaxNumNeighbors> neighbors;
+
+            sid::shift(ptr, sid::get_stride<IndexDimension>(table.strides), index);
+            for (std::size_t element_idx = 0; element_idx < MaxNumNeighbors; ++element_idx) {
+                neighbors[element_idx] = *ptr;
+                sid::shift(ptr, sid::get_stride<NeighborDimension>(table.strides), 1);
+            }
+            return neighbors;
+        }
 
         template <class IndexDimension, class NeighborDimension, std::size_t MaxNumNeighbors, class Sid>
         auto as_neighbor_table(Sid &&sid) -> sid_neighbor_table<IndexDimension,

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -37,6 +37,8 @@ namespace gridtools::fn::sid_neighbor_table {
             sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, PtrHolder, Strides> const &table,
             int index) {
 
+            using namespace gridtools::literals;
+
             auto ptr = table.origin();
             using element_type = std::remove_reference_t<decltype(*ptr)>;
 
@@ -45,7 +47,7 @@ namespace gridtools::fn::sid_neighbor_table {
             sid::shift(ptr, sid::get_stride<IndexDimension>(table.strides), index);
             for (std::size_t element_idx = 0; element_idx < MaxNumNeighbors; ++element_idx) {
                 neighbors[element_idx] = *ptr;
-                sid::shift(ptr, sid::get_stride<NeighborDimension>(table.strides), 1);
+                sid::shift(ptr, sid::get_stride<NeighborDimension>(table.strides), 1_c);
             }
             return neighbors;
         }

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -29,8 +29,8 @@ namespace gridtools::fn::sid_neighbor_table {
             std::size_t index) {
             using element_type = sid::element_type<Sid>;
 
-            auto ptr = sid_get_origin(table.sid)();
-            const auto strides = sid_get_strides(table.sid);
+            auto ptr = sid::get_origin(table.sid)();
+            const auto strides = sid::get_strides(table.sid);
 
             gridtools::array<element_type, MaxNumNeighbors> neighbors;
 
@@ -43,13 +43,13 @@ namespace gridtools::fn::sid_neighbor_table {
         }
 
         template <class IndexDimension, class NeighborDimension, int32_t MaxNumNeighbors, class Sid>
-        auto as_neighbor_table(Sid sid) {
-            static_assert(gridtools::tuple_util::size<decltype(sid_get_strides(std::declval<Sid>()))>::value == 2,
+        auto as_neighbor_table(Sid &&sid) {
+            static_assert(gridtools::tuple_util::size<decltype(sid::get_strides(std::declval<Sid>()))>::value == 2,
                 "Neighbor tables must have exactly two dimensions: the index dimension and the neighbor dimension");
             static_assert(!std::is_same_v<IndexDimension, NeighborDimension>,
                 "The index dimension and the neighbor dimension must be different.");
 
-            return sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, Sid>{std::move(sid)};
+            return sid_neighbor_table<IndexDimension, NeighborDimension, MaxNumNeighbors, Sid>{std::forward<Sid>(sid)};
         }
     } // namespace sid_neighbor_table_impl_
 

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -27,7 +27,7 @@ namespace gridtools::fn::sid_neighbor_table {
             PtrHolder origin;
             Strides strides;
 
-            GT_FUNCTION friend auto neighbor_table_neighbors(sid_neighbor_table const &table, std::size_t index) {
+            GT_FUNCTION friend auto neighbor_table_neighbors(sid_neighbor_table const &table, int index) {
                 auto ptr = table.origin();
                 using element_type = std::remove_reference_t<decltype(*ptr)>;
 

--- a/tests/unit_tests/fn/CMakeLists.txt
+++ b/tests/unit_tests/fn/CMakeLists.txt
@@ -7,6 +7,7 @@ gridtools_add_unit_test(test_fn_run SOURCES test_fn_run.cpp)
 gridtools_add_unit_test(test_fn_column_stage SOURCES test_fn_column_stage.cpp)
 gridtools_add_unit_test(test_fn_stencil_stage SOURCES test_fn_stencil_stage.cpp LABELS fn)
 gridtools_add_unit_test(test_fn_unstructured SOURCES test_fn_unstructured.cpp LABELS fn)
+gridtools_add_unit_test(test_fn_sid_neighbor_table SOURCES test_fn_sid_neighbor_table.cpp LABELS fn)
 
 if(TARGET _gridtools_cuda)
     gridtools_add_unit_test(test_fn_backend_gpu_cuda

--- a/tests/unit_tests/fn/CMakeLists.txt
+++ b/tests/unit_tests/fn/CMakeLists.txt
@@ -30,4 +30,8 @@ if(TARGET _gridtools_cuda)
         SOURCES test_extents.cu
         LIBRARIES _gridtools_cuda
         LABELS cuda fn)
+    gridtools_add_unit_test(test_fn_sid_neighbor_table_cuda
+        SOURCES test_fn_sid_neighbor_table.cu
+        LIBRARIES _gridtools_cuda
+        LABELS cuda fn)
 endif()

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -16,11 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#include <gridtools/fn/unstructured.hpp>
-#include <gridtools/sid/allocator.hpp>
-#include <gridtools/sid/composite.hpp>
-#include <gridtools/sid/synthetic.hpp>
-
 namespace gridtools::fn {
     namespace {
 

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -27,7 +27,7 @@ namespace gridtools::fn {
         TEST(sid_neighbor_table, correctness) {
             constexpr std::size_t num_elements = 3;
             constexpr std::size_t num_neighbors = 2;
-            std::int32_t contents[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
+            int contents[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
             const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, num_neighbors>(contents);
 
             auto [n00, n01] = neighbor_table::neighbors(table, 0);

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -10,15 +10,15 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include <gridtools/fn/sid_neighbor_table.hpp>
 #include <gridtools/fn/unstructured.hpp>
 #include <gridtools/sid/allocator.hpp>
 #include <gridtools/sid/composite.hpp>
 #include <gridtools/sid/synthetic.hpp>
-
-#include <array>
-#include <cstddef>
-#include <cstdint>
-#include <gridtools/fn/sid_neighbor_table.hpp>
 
 using namespace gridtools;
 using namespace fn;
@@ -28,8 +28,8 @@ using edge_dim_t = unstructured::dim::horizontal;
 using edge_to_cell_dim_t = struct {};
 
 TEST(sid_neighbor_table, correctness) {
-    constexpr size_t numElements = 3;
-    constexpr size_t numNeighbors = 2;
+    constexpr std::size_t numElements = 3;
+    constexpr std::size_t numNeighbors = 2;
     std::array<int32_t, numElements *numNeighbors> data = {0, 1, 10, 11, 20, 21};
     using dim_hymap_t = hymap::keys<edge_dim_t, edge_to_cell_dim_t>;
     auto contents = sid::synthetic()

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -27,7 +27,7 @@ namespace gridtools::fn {
         TEST(sid_neighbor_table, correctness) {
             constexpr std::size_t num_elements = 3;
             constexpr std::size_t num_neighbors = 2;
-            int contents[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
+            const int contents[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
             const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, num_neighbors>(contents);
 
             auto [n00, n01] = neighbor_table::neighbors(table, 0);

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -30,10 +30,10 @@ namespace gridtools::fn {
         using edge_to_cell_dim_t = integral_constant<int_t, 1>;
 
         TEST(sid_neighbor_table, correctness) {
-            constexpr std::size_t numElements = 3;
-            constexpr std::size_t numNeighbors = 2;
-            std::int32_t contents[numElements][numNeighbors] = {{0, 1}, {10, 11}, {20, 21}};
-            const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, numNeighbors>(contents);
+            constexpr std::size_t num_elements = 3;
+            constexpr std::size_t num_neighbors = 2;
+            std::int32_t contents[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
+            const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, num_neighbors>(contents);
 
             auto [n00, n01] = neighbor_table_neighbors(table, 0);
             auto [n10, n11] = neighbor_table_neighbors(table, 1);

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -24,18 +24,18 @@ using namespace gridtools;
 using namespace fn;
 using sid_neighbor_table::as_neighbor_table;
 
+using edge_dim_t = unstructured::dim::horizontal;
+using edge_to_cell_dim_t = struct {};
+
 TEST(sid_neighbor_table, correctness) {
     constexpr size_t numElements = 3;
     constexpr size_t numNeighbors = 2;
     std::array<int32_t, numElements *numNeighbors> data = {0, 1, 10, 11, 20, 21};
-    using dim_hymap_t = hymap::keys<unstructured::dim::horizontal, unstructured::dim::vertical>;
+    using dim_hymap_t = hymap::keys<edge_dim_t, edge_to_cell_dim_t>;
     auto contents = sid::synthetic()
                         .set<sid::property::origin>(sid::host_device::simple_ptr_holder(data.data()))
-                        .set<sid::property::lower_bounds>(dim_hymap_t::make_values(0, 0))
-                        .set<sid::property::upper_bounds>(dim_hymap_t::make_values(numElements, numNeighbors))
-                        .set<sid::property::strides>(dim_hymap_t::make_values(3, 1));
-    const auto table = as_neighbor_table<numNeighbors>(contents);
-    sid_get_origin(contents);
+                        .set<sid::property::strides>(dim_hymap_t::make_values(numNeighbors, 1));
+    const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, numNeighbors>(contents);
 
     auto [n00, n01] = neighbor_table_neighbors(table, 0);
     auto [n10, n11] = neighbor_table_neighbors(table, 1);

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -21,30 +21,34 @@
 #include <gridtools/sid/composite.hpp>
 #include <gridtools/sid/synthetic.hpp>
 
-using namespace gridtools;
-using namespace fn;
-using sid_neighbor_table::as_neighbor_table;
+namespace gridtools::fn {
+    namespace {
 
-using edge_dim_t = unstructured::dim::horizontal;
-using edge_to_cell_dim_t = struct {};
+        using sid_neighbor_table::as_neighbor_table;
 
-TEST(sid_neighbor_table, correctness) {
-    constexpr std::size_t numElements = 3;
-    constexpr std::size_t numNeighbors = 2;
-    std::array<int32_t, numElements *numNeighbors> data = {0, 1, 10, 11, 20, 21};
-    using dim_hymap_t = hymap::keys<edge_dim_t, edge_to_cell_dim_t>;
-    auto contents = sid::synthetic()
-                        .set<sid::property::origin>(sid::host_device::simple_ptr_holder(data.data()))
-                        .set<sid::property::strides>(dim_hymap_t::make_values(numNeighbors, 1));
-    const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, numNeighbors>(contents);
+        using edge_dim_t = unstructured::dim::horizontal;
+        using edge_to_cell_dim_t = struct {};
 
-    auto [n00, n01] = neighbor_table_neighbors(table, 0);
-    auto [n10, n11] = neighbor_table_neighbors(table, 1);
-    auto [n20, n21] = neighbor_table_neighbors(table, 2);
-    EXPECT_EQ(n00, 0);
-    EXPECT_EQ(n01, 1);
-    EXPECT_EQ(n10, 10);
-    EXPECT_EQ(n11, 11);
-    EXPECT_EQ(n20, 20);
-    EXPECT_EQ(n21, 21);
-}
+        TEST(sid_neighbor_table, correctness) {
+            constexpr std::size_t numElements = 3;
+            constexpr std::size_t numNeighbors = 2;
+            std::array<int32_t, numElements *numNeighbors> data = {0, 1, 10, 11, 20, 21};
+            using dim_hymap_t = hymap::keys<edge_dim_t, edge_to_cell_dim_t>;
+            auto contents = sid::synthetic()
+                                .set<sid::property::origin>(sid::host_device::simple_ptr_holder(data.data()))
+                                .set<sid::property::strides>(dim_hymap_t::make_values(numNeighbors, 1));
+            const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, numNeighbors>(contents);
+
+            auto [n00, n01] = neighbor_table_neighbors(table, 0);
+            auto [n10, n11] = neighbor_table_neighbors(table, 1);
+            auto [n20, n21] = neighbor_table_neighbors(table, 2);
+            EXPECT_EQ(n00, 0);
+            EXPECT_EQ(n01, 1);
+            EXPECT_EQ(n10, 10);
+            EXPECT_EQ(n11, 11);
+            EXPECT_EQ(n20, 20);
+            EXPECT_EQ(n21, 21);
+        }
+
+    } // namespace
+} // namespace gridtools::fn

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -26,17 +26,13 @@ namespace gridtools::fn {
 
         using sid_neighbor_table::as_neighbor_table;
 
-        using edge_dim_t = unstructured::dim::horizontal;
-        using edge_to_cell_dim_t = struct {};
+        using edge_dim_t = integral_constant<int_t, 0>;
+        using edge_to_cell_dim_t = integral_constant<int_t, 1>;
 
         TEST(sid_neighbor_table, correctness) {
             constexpr std::size_t numElements = 3;
             constexpr std::size_t numNeighbors = 2;
-            std::array<int32_t, numElements *numNeighbors> data = {0, 1, 10, 11, 20, 21};
-            using dim_hymap_t = hymap::keys<edge_dim_t, edge_to_cell_dim_t>;
-            auto contents = sid::synthetic()
-                                .set<sid::property::origin>(sid::host_device::simple_ptr_holder(data.data()))
-                                .set<sid::property::strides>(dim_hymap_t::make_values(numNeighbors, 1));
+            std::int32_t contents[numElements][numNeighbors] = {{0, 1}, {10, 11}, {20, 21}};
             const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, numNeighbors>(contents);
 
             auto [n00, n01] = neighbor_table_neighbors(table, 0);

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -30,9 +30,9 @@ namespace gridtools::fn {
             std::int32_t contents[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
             const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, num_neighbors>(contents);
 
-            auto [n00, n01] = neighbor_table_neighbors(table, 0);
-            auto [n10, n11] = neighbor_table_neighbors(table, 1);
-            auto [n20, n21] = neighbor_table_neighbors(table, 2);
+            auto [n00, n01] = neighbor_table::neighbors(table, 0);
+            auto [n10, n11] = neighbor_table::neighbors(table, 1);
+            auto [n20, n21] = neighbor_table::neighbors(table, 2);
             EXPECT_EQ(n00, 0);
             EXPECT_EQ(n01, 1);
             EXPECT_EQ(n10, 10);

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -1,0 +1,49 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2022, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <gtest/gtest.h>
+
+#include <gridtools/fn/unstructured.hpp>
+#include <gridtools/sid/allocator.hpp>
+#include <gridtools/sid/composite.hpp>
+#include <gridtools/sid/synthetic.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <gridtools/fn/sid_neighbor_table.hpp>
+
+using namespace gridtools;
+using namespace fn;
+using sid_neighbor_table::as_neighbor_table;
+
+TEST(sid_neighbor_table, correctness) {
+    constexpr size_t numElements = 3;
+    constexpr size_t numNeighbors = 2;
+    std::array<int32_t, numElements *numNeighbors> data = {0, 1, 10, 11, 20, 21};
+    using dim_hymap_t = hymap::keys<unstructured::dim::horizontal, unstructured::dim::vertical>;
+    auto contents = sid::synthetic()
+                        .set<sid::property::origin>(sid::host_device::simple_ptr_holder(data.data()))
+                        .set<sid::property::lower_bounds>(dim_hymap_t::make_values(0, 0))
+                        .set<sid::property::upper_bounds>(dim_hymap_t::make_values(numElements, numNeighbors))
+                        .set<sid::property::strides>(dim_hymap_t::make_values(3, 1));
+    const auto table = as_neighbor_table<numNeighbors>(contents);
+    sid_get_origin(contents);
+
+    auto [n00, n01] = neighbor_table_neighbors(table, 0);
+    auto [n10, n11] = neighbor_table_neighbors(table, 1);
+    auto [n20, n21] = neighbor_table_neighbors(table, 2);
+    EXPECT_EQ(n00, 0);
+    EXPECT_EQ(n01, 1);
+    EXPECT_EQ(n10, 10);
+    EXPECT_EQ(n11, 11);
+    EXPECT_EQ(n20, 20);
+    EXPECT_EQ(n21, 21);
+}

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -8,11 +8,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <gtest/gtest.h>
-
 #include <array>
 #include <cstddef>
 #include <cstdint>
+
+#include <gtest/gtest.h>
 
 #include <gridtools/fn/sid_neighbor_table.hpp>
 #include <gridtools/fn/unstructured.hpp>

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -8,13 +8,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <gridtools/fn/sid_neighbor_table.hpp>
+
 #include <array>
 #include <cstddef>
 #include <cstdint>
 
 #include <gtest/gtest.h>
 
-#include <gridtools/fn/sid_neighbor_table.hpp>
 #include <gridtools/fn/unstructured.hpp>
 #include <gridtools/sid/allocator.hpp>
 #include <gridtools/sid/composite.hpp>

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
@@ -28,7 +28,7 @@ namespace gridtools::fn {
         using edge_to_cell_dim_t = integral_constant<int_t, 1>;
 
         template <class Table>
-        __device__ auto neighbor_table_neighbors_device(const Table &table, std::size_t index)
+        __device__ auto neighbor_table_neighbors_device(Table const &table, std::size_t index)
             -> array<std::int32_t, 2> {
             return neighbor_table::neighbors(table, index);
         }

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
@@ -1,0 +1,53 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2021, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <gridtools/fn/sid_neighbor_table.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+#include <cuda_test_helper.hpp>
+
+namespace gridtools::fn {
+    namespace {
+        using sid_neighbor_table::as_neighbor_table;
+
+        using edge_dim_t = integral_constant<int_t, 0>;
+        using edge_to_cell_dim_t = integral_constant<int_t, 1>;
+
+        template <class Table>
+        __device__ auto neighbor_table_neighbors_device(const Table &table, size_t index) -> array<std::int32_t, 2> {
+            return neighbor_table_neighbors(table, index);
+        }
+        constexpr std::size_t num_elements = 3;
+        constexpr std::size_t num_neighbors = 2;
+        __device__ std::int32_t contents[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
+
+        TEST(sid_neighbor_table, correctness_cuda) {
+            const auto table = as_neighbor_table<edge_dim_t, edge_to_cell_dim_t, num_neighbors>(contents);
+
+            const auto instantiation = &neighbor_table_neighbors_device<std::decay_t<decltype(table)>>;
+
+            auto [n00, n01] = on_device::exec(GT_MAKE_INTEGRAL_CONSTANT_FROM_VALUE(instantiation), table, 0);
+            auto [n10, n11] = on_device::exec(GT_MAKE_INTEGRAL_CONSTANT_FROM_VALUE(instantiation), table, 1);
+            auto [n20, n21] = on_device::exec(GT_MAKE_INTEGRAL_CONSTANT_FROM_VALUE(instantiation), table, 2);
+            EXPECT_EQ(n00, 0);
+            EXPECT_EQ(n01, 1);
+            EXPECT_EQ(n10, 10);
+            EXPECT_EQ(n11, 11);
+            EXPECT_EQ(n20, 20);
+            EXPECT_EQ(n21, 21);
+        }
+    } // namespace
+} // namespace gridtools::fn

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
@@ -30,7 +30,7 @@ namespace gridtools::fn {
         template <class Table>
         __device__ auto neighbor_table_neighbors_device(const Table &table, std::size_t index)
             -> array<std::int32_t, 2> {
-            return neighbor_table_neighbors(table, index);
+            return neighbor_table::neighbors(table, index);
         }
 
         TEST(sid_neighbor_table, correctness_cuda) {

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
@@ -28,7 +28,7 @@ namespace gridtools::fn {
         using edge_to_cell_dim_t = integral_constant<int_t, 1>;
 
         template <class Table>
-        __device__ auto neighbor_table_neighbors_device(Table const &table, std::size_t index)
+        __device__ auto neighbor_table_neighbors_device(Table const &table, int index)
             -> array<std::int32_t, 2> {
             return neighbor_table::neighbors(table, index);
         }

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
@@ -29,7 +29,7 @@ namespace gridtools::fn {
 
         template <class Table>
         __device__ auto neighbor_table_neighbors_device(Table const &table, int index)
-            -> array<std::int32_t, 2> {
+            -> array<int, 2> {
             return neighbor_table::neighbors(table, index);
         }
 
@@ -37,8 +37,8 @@ namespace gridtools::fn {
             constexpr std::size_t num_elements = 3;
             constexpr std::size_t num_neighbors = 2;
 
-            const std::int32_t data[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
-            const auto device_data = cuda_util::cuda_malloc<std::int32_t>(num_elements * num_neighbors);
+            const int data[num_elements][num_neighbors] = {{0, 1}, {10, 11}, {20, 21}};
+            const auto device_data = cuda_util::cuda_malloc<int>(num_elements * num_neighbors);
             GT_CUDA_CHECK(cudaMemcpy(device_data.get(), &data, sizeof data, cudaMemcpyHostToDevice));
             using dim_hymap_t = hymap::keys<edge_dim_t, edge_to_cell_dim_t>;
             auto contents = sid::synthetic()


### PR DESCRIPTION
Adds a simple class that wraps an SID and implements the neighbour table concept. This makes it possible to use Python buffers as neighbour tables by first wrapping them into an SID, but any SID is suitable as a neighbour table.