### PR TITLE
Fix CUDA 12.0 compilation

### DIFF
--- a/include/gridtools/fn/column_stage.hpp
+++ b/include/gridtools/fn/column_stage.hpp
@@ -48,7 +48,9 @@ namespace gridtools::fn {
                 Seed seed, std::size_t size, MakeIterator &&make_iterator, Ptr ptr, Strides const &strides) const {
                 constexpr std::size_t prologue_size = std::tuple_size_v<decltype(ScanOrFold::prologue())>;
                 constexpr std::size_t epilogue_size = std::tuple_size_v<decltype(ScanOrFold::epilogue())>;
+                GT_NVCC_DIAG_PUSH_SUPPRESS(186) // pointless comparison of unsigned with 0
                 assert(size >= prologue_size + epilogue_size);
+                GT_NVCC_DIAG_POP_SUPPRESS(186)
                 using step_t = integral_constant<int, ScanOrFold::value ? -1 : 1>;
                 auto const &v_stride = sid::get_stride<Vertical>(strides);
                 auto inc = [&] { sid::shift(ptr, v_stride, step_t()); };

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -53,11 +53,7 @@ namespace gridtools::fn::sid_neighbor_table {
         }
 
         template <class IndexDimension, class NeighborDimension, std::size_t MaxNumNeighbors, class Sid>
-        auto as_neighbor_table(Sid &&sid) -> sid_neighbor_table<IndexDimension,
-            NeighborDimension,
-            MaxNumNeighbors,
-            sid::ptr_holder_type<Sid>,
-            sid::strides_type<Sid>> {
+        auto as_neighbor_table(Sid &&sid) {
 
             static_assert(gridtools::tuple_util::size<decltype(sid::get_strides(std::declval<Sid>()))>::value == 2,
                 "Neighbor tables must have exactly two dimensions: the index dimension and the neighbor dimension");
@@ -67,7 +63,12 @@ namespace gridtools::fn::sid_neighbor_table {
             const auto origin = sid::get_origin(sid);
             const auto strides = sid::get_strides(sid);
 
-            return {origin, strides};
+            return sid_neighbor_table<IndexDimension,
+                NeighborDimension,
+                MaxNumNeighbors,
+                sid::ptr_holder_type<Sid>,
+                sid::strides_type<Sid>>{
+                origin, strides}; // Note: putting the return type into the function signature will crash nvcc 12.0
         }
     } // namespace sid_neighbor_table_impl_
 

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -111,7 +111,10 @@ namespace gridtools::fn {
             } else {
                 return unstructured_impl_::shift(non_horizontal_shift(it, Dim(), offset), offsets...);
             }
+            // disable incorrect warning "missing return statement at end of non-void function"
+            GT_NVCC_DIAG_PUSH_SUPPRESS(940)
         }
+        GT_NVCC_DIAG_POP_SUPPRESS(940)
 
         template <class Domain>
         struct make_iterator {


### PR DESCRIPTION
nvcc 12.0 crashes in the test_fn_sid_neighbor_table

Additionally: suppress some invalid nvcc warnings