### PR TITLE
total_size(tuple<>) == 1

### DIFF
--- a/include/gridtools/common/stride_util.hpp
+++ b/include/gridtools/common/stride_util.hpp
@@ -53,7 +53,7 @@ namespace gridtools {
 
         template <class Sizes>
         auto total_size(Sizes const &sizes) {
-            return tuple_util::fold([](auto l, auto r) { return l * r; }, sizes);
+            return tuple_util::fold([](auto l, auto r) { return l * r; }, 1, sizes);
         }
     } // namespace stride_util
 } // namespace gridtools


### PR DESCRIPTION
Allows to call `total_size` with empty tuple, returns 1.