### PR TITLE
Workarounds for CUDA 12.1 and 12.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     container: ghcr.io/gridtools/gridtools-base:${{ matrix.compiler }}
     strategy:
         matrix:
-            compiler: [gcc-8, gcc-9, gcc-10, gcc-11, gcc-12, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, clang-14-cuda-11, gcc-10-cuda-11.8, gcc-11-cuda-12.0, base-hip, gcc-10-hpx, nvhpc-23.3]
+            compiler: [gcc-8, gcc-9, gcc-10, gcc-11, gcc-12, gcc-13, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, clang-14-cuda-11, gcc-10-cuda-11.8, gcc-11-cuda-12.0, base-hip, gcc-10-hpx, nvhpc-23.3]
             build_type: [debug, release]
             exclude:
               - compiler: gcc-8
@@ -20,6 +20,8 @@ jobs:
               - compiler: gcc-9
                 build_type: debug
               - compiler: gcc-10
+                build_type: debug
+              - compiler: gcc-11
                 build_type: debug
               - compiler: clang-13
                 build_type: debug

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     container: ghcr.io/gridtools/gridtools-base:${{ matrix.compiler }}
     strategy:
         matrix:
-            compiler: [gcc-8, gcc-9, gcc-10, gcc-11, gcc-12, gcc-13, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, clang-14-cuda-11, gcc-10-cuda-11.8, gcc-11-cuda-12.0, base-hip, gcc-10-hpx, nvhpc-23.3]
+            compiler: [gcc-8, gcc-9, gcc-10, gcc-11, gcc-12, gcc-13, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, clang-14-cuda-11, gcc-10-cuda-11.8, gcc-11-cuda-12.0, base-hip, gcc-10-hpx, nvhpc-23.3, nvhpc-23.7]
             build_type: [debug, release]
             exclude:
               - compiler: gcc-8

--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -51,3 +51,10 @@ namespace gridtools {
 #define GT_NVCC_DIAG_PUSH_SUPPRESS(x)
 #define GT_NVCC_DIAG_POP_SUPPRESS(x)
 #endif
+
+#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR__ <= 2)
+// enables workaround for CTAD/constexpr issues in CUDA 12.1, 12.2 (https://github.com/GridTools/gridtools/issues/1766)
+#define GT_NVCC_WORKAROUND_1766 1
+#else
+#define GT_NVCC_WORKAROUND_1766 0
+#endif

--- a/include/gridtools/fn/column_stage.hpp
+++ b/include/gridtools/fn/column_stage.hpp
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "../common/defs.hpp"
 #include "../common/functional.hpp"
 #include "../common/integral_constant.hpp"
 #include "../common/tuple.hpp"
@@ -101,8 +102,8 @@ namespace gridtools::fn {
     using column_stage_impl_::column_stage;
     using column_stage_impl_::fwd;
     using column_stage_impl_::merged_column_stage;
-#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR__ <= 2)
-    // workaround CTAD issue in CUDA 12.1, 12.2 (https://github.com/GridTools/gridtools/issues/1766)
+
+#if GT_NVCC_WORKAROUND_1766
     template <class F, class Projector = host_device::identity>
     GT_FUNCTION constexpr auto scan_pass(F &&f, Projector &&p = {}) {
         return column_stage_impl_::scan_pass(std::forward<F>(f), std::forward<Projector>(p));

--- a/include/gridtools/fn/column_stage.hpp
+++ b/include/gridtools/fn/column_stage.hpp
@@ -101,5 +101,13 @@ namespace gridtools::fn {
     using column_stage_impl_::column_stage;
     using column_stage_impl_::fwd;
     using column_stage_impl_::merged_column_stage;
+#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR__ <= 2)
+    // workaround CTAD issue in CUDA 12.1, 12.2 (https://github.com/GridTools/gridtools/issues/1766)
+    template <class F, class Projector = host_device::identity>
+    GT_FUNCTION constexpr auto scan_pass(F &&f, Projector &&p = {}) {
+        return column_stage_impl_::scan_pass(std::forward<F>(f), std::forward<Projector>(p));
+    }
+#else
     using column_stage_impl_::scan_pass;
+#endif
 } // namespace gridtools::fn

--- a/include/gridtools/storage/builder.hpp
+++ b/include/gridtools/storage/builder.hpp
@@ -316,8 +316,15 @@ namespace gridtools {
 
                 auto operator()() const { return build(); }
             };
+#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR__ <= 2)
+            // workaround constexpr issue in CUDA 12.1, 12.2 (maybe related
+            // tohttps://github.com/GridTools/gridtools/issues/1766)
+            template <class Traits>
+            builder_type<Traits, keys<>::values<>> builder = {};
+#else
             template <class Traits>
             constexpr builder_type<Traits, keys<>::values<>> builder = {};
+#endif
         } // namespace builder_impl_
         using builder_impl_::builder;
     } // namespace storage

--- a/include/gridtools/storage/builder.hpp
+++ b/include/gridtools/storage/builder.hpp
@@ -316,9 +316,8 @@ namespace gridtools {
 
                 auto operator()() const { return build(); }
             };
-#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR__ <= 2)
-            // workaround constexpr issue in CUDA 12.1, 12.2 (maybe related
-            // tohttps://github.com/GridTools/gridtools/issues/1766)
+#if GT_NVCC_WORKAROUND_1766
+            // not sure if the same bug as https://github.com/GridTools/gridtools/issues/1766
             template <class Traits>
             builder_type<Traits, keys<>::values<>> builder = {};
 #else

--- a/include/gridtools/storage/data_store.hpp
+++ b/include/gridtools/storage/data_store.hpp
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/tests/include/nvcc_workarounds.hpp
+++ b/tests/include/nvcc_workarounds.hpp
@@ -1,0 +1,22 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2021, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <gridtools/common/tuple.hpp>
+
+namespace gridtools {
+    namespace nvcc_workarounds {
+
+        // see https://github.com/GridTools/gridtools/issues/1766
+        template <class T>
+        constexpr auto make_1_tuple(T &&t) {
+            return tuple(t);
+        }
+    } // namespace nvcc_workarounds
+} // namespace gridtools

--- a/tests/include/nvcc_workarounds.hpp
+++ b/tests/include/nvcc_workarounds.hpp
@@ -16,7 +16,7 @@ namespace gridtools {
         // see https://github.com/GridTools/gridtools/issues/1766
         template <class T>
         constexpr auto make_1_tuple(T &&t) {
-            return tuple(t);
+            return tuple(std::forward<T>(t));
         }
     } // namespace nvcc_workarounds
 } // namespace gridtools

--- a/tests/regression/fn/fn_cartesian_vertical_advection.cpp
+++ b/tests/regression/fn/fn_cartesian_vertical_advection.cpp
@@ -14,6 +14,7 @@
 #include <gridtools/stencil/global_parameter.hpp>
 
 #include <fn_select.hpp>
+#include <nvcc_workarounds.hpp>
 #include <test_environment.hpp>
 
 #include "../vertical_advection_repository.hpp"
@@ -27,7 +28,7 @@ namespace {
 
     struct u_forward_scan : fwd {
         static GT_FUNCTION constexpr auto prologue() {
-            return tuple(scan_pass(
+            return nvcc_workarounds::make_1_tuple(scan_pass(
                 [](auto /*acc*/,
                     auto const &utens_stage,
                     auto const &utens,
@@ -80,7 +81,7 @@ namespace {
         }
 
         static GT_FUNCTION constexpr auto epilogue() {
-            return tuple(scan_pass(
+            return nvcc_workarounds::make_1_tuple(scan_pass(
                 [](auto acc,
                     auto const &utens_stage,
                     auto const &utens,
@@ -107,7 +108,7 @@ namespace {
 
     struct u_backward_scan : bwd {
         static GT_FUNCTION constexpr auto prologue() {
-            return tuple(scan_pass(
+            return nvcc_workarounds::make_1_tuple(scan_pass(
                 [](auto /*acc*/, auto const &cd, auto const &u_pos, auto const &dtr_stage) {
                     auto d = tuple_get(1_c, deref(cd));
                     return make_tuple(deref(dtr_stage) * (d - deref(u_pos)), d);

--- a/tests/regression/fn/fn_domain.cpp
+++ b/tests/regression/fn/fn_domain.cpp
@@ -13,6 +13,7 @@
 #include <gridtools/fn/unstructured.hpp>
 
 #include <fn_select.hpp>
+#include <nvcc_workarounds.hpp>
 #include <test_environment.hpp>
 
 namespace {
@@ -51,7 +52,7 @@ namespace {
 
     struct empty_column : fwd {
         static GT_FUNCTION constexpr auto prologue() {
-            return tuple(scan_pass([](auto acc) { return acc; }, host_device::identity()));
+            return nvcc_workarounds::make_1_tuple(scan_pass([](auto acc) { return acc; }, host_device::identity()));
         }
 
         static GT_FUNCTION constexpr auto body() {

--- a/tests/regression/fn/fn_tridiagonal_solve.cpp
+++ b/tests/regression/fn/fn_tridiagonal_solve.cpp
@@ -14,6 +14,7 @@
 #include <gridtools/fn/unstructured.hpp>
 
 #include <fn_select.hpp>
+#include <nvcc_workarounds.hpp>
 #include <test_environment.hpp>
 
 namespace {
@@ -23,7 +24,7 @@ namespace {
 
     struct forward_scan : fwd {
         static GT_FUNCTION constexpr auto prologue() {
-            return tuple(scan_pass(
+            return nvcc_workarounds::make_1_tuple(scan_pass(
                 [](auto /*acc*/, auto const & /*a*/, auto const &b, auto const &c, auto const &d) {
                     return tuple(deref(c) / deref(b), deref(d) / deref(b));
                 },
@@ -43,7 +44,7 @@ namespace {
 
     struct backward_scan : bwd {
         static GT_FUNCTION constexpr auto prologue() {
-            return tuple(scan_pass(
+            return nvcc_workarounds::make_1_tuple(scan_pass(
                 [](auto /*xp*/, auto const &cpdp) {
                     auto [cp, dp] = deref(cpdp);
                     return dp;

--- a/tests/unit_tests/common/test_tuple.cpp
+++ b/tests/unit_tests/common/test_tuple.cpp
@@ -331,5 +331,13 @@ namespace gridtools {
             EXPECT_EQ(a, 42);
             EXPECT_EQ(b, 2.5);
         }
+
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR <= 2
+#else
+        TEST(ctad, lambda) {
+            auto testee = tuple([](int i) { return i; });
+            EXPECT_EQ(1, get<0>(testee)(1));
+        }
+#endif
     } // namespace
 } // namespace gridtools

--- a/tests/unit_tests/common/test_tuple.cpp
+++ b/tests/unit_tests/common/test_tuple.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <gridtools/common/defs.hpp>
 #include <gridtools/common/tuple_util.hpp>
 #include <gridtools/meta/macros.hpp>
 
@@ -332,8 +333,7 @@ namespace gridtools {
             EXPECT_EQ(b, 2.5);
         }
 
-#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR <= 2
-#else
+#if not GT_NVCC_WORKAROUND_1766
         TEST(ctad, lambda) {
             auto testee = tuple([](int i) { return i; });
             EXPECT_EQ(1, get<0>(testee)(1));

--- a/tests/unit_tests/common/test_tuple.cpp
+++ b/tests/unit_tests/common/test_tuple.cpp
@@ -333,7 +333,7 @@ namespace gridtools {
             EXPECT_EQ(b, 2.5);
         }
 
-#if not GT_NVCC_WORKAROUND_1766
+#if !GT_NVCC_WORKAROUND_1766
         TEST(ctad, lambda) {
             auto testee = tuple([](int i) { return i; });
             EXPECT_EQ(1, get<0>(testee)(1));

--- a/tests/unit_tests/fn/test_fn_column_stage.cpp
+++ b/tests/unit_tests/fn/test_fn_column_stage.cpp
@@ -14,6 +14,8 @@
 #include <gridtools/sid/composite.hpp>
 #include <gridtools/sid/synthetic.hpp>
 
+#include <nvcc_workarounds.hpp>
+
 namespace gridtools::fn {
     namespace {
         using namespace literals;
@@ -35,10 +37,10 @@ namespace gridtools::fn {
 
         struct sum_fold_with_logues : sum_fold {
             static GT_FUNCTION constexpr auto prologue() {
-                return tuple([](auto acc, auto const &iter) { return acc + 2 * *iter; });
+                return nvcc_workarounds::make_1_tuple([](auto acc, auto const &iter) { return acc + 2 * *iter; });
             }
             static GT_FUNCTION constexpr auto epilogue() {
-                return tuple([](auto acc, auto const &iter) { return acc + 3 * *iter; });
+                return nvcc_workarounds::make_1_tuple([](auto acc, auto const &iter) { return acc + 3 * *iter; });
             }
         };
 


### PR DESCRIPTION
CUDA 12.1 and 12.2 have a problem with constexpr, e.g. in the context of CTAD, see #1766. The workaround is to do pre-C++17 `make_tuple`-construction or construct from a (possibly moved-from) lvalue.

CI: add GCC + CUDA 12.1/12.2 and NVHPC 23.7