### PR TITLE
CI: test CUDA 12.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     container: ghcr.io/gridtools/gridtools-base:${{ matrix.compiler }}
     strategy:
         matrix:
-            compiler: [gcc-8, gcc-9, gcc-10, gcc-11, gcc-12, gcc-13, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, clang-14-cuda-11, gcc-10-cuda-11.8, gcc-11-cuda-12.0, gcc-12-cuda-12.1, gcc-12-cuda-12.2, gcc-12-cuda-12.3, base-hip, gcc-10-hpx, nvhpc-23.3, nvhpc-23.9]
+            compiler: [gcc-8, gcc-9, gcc-10, gcc-11, gcc-12, gcc-13, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, clang-14-cuda-11, gcc-10-cuda-11.8, gcc-11-cuda-12.0, gcc-12-cuda-12.3, gcc-12-cuda-12.4, base-hip, gcc-10-hpx, nvhpc-23.3, nvhpc-23.9]
             build_type: [debug, release]
             exclude:
               - compiler: gcc-8

--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -52,7 +52,7 @@ namespace gridtools {
 #define GT_NVCC_DIAG_POP_SUPPRESS(x)
 #endif
 
-#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR__ <= 3)
+#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR__ <= 4)
 // enables workaround for CTAD/constexpr issues in CUDA 12.1, 12.2, 12.3 (https://github.com/GridTools/gridtools/issues/1766)
 #define GT_NVCC_WORKAROUND_1766 1
 #else

--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -53,7 +53,7 @@ namespace gridtools {
 #endif
 
 #if defined(__NVCC__) && (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 1 && __CUDACC_VER_MINOR__ <= 4)
-// enables workaround for CTAD/constexpr issues in CUDA 12.1, 12.2, 12.3 (https://github.com/GridTools/gridtools/issues/1766)
+// enables workaround for CTAD/constexpr issues in CUDA 12.1, 12.2, 12.3, 12.4 (https://github.com/GridTools/gridtools/issues/1766)
 #define GT_NVCC_WORKAROUND_1766 1
 #else
 #define GT_NVCC_WORKAROUND_1766 0


### PR DESCRIPTION
Partially fixes CUDA 12.4 problems. There are more problems which where not in 12.3, but these tests are not covered by GitHub action tests (which are only the perftests).