### PR TITLE
Check for __CUDA_ARCH_LIST__ for setting GT_CUDA_ARCH

### DIFF
--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -18,6 +18,8 @@ namespace gridtools {
 #define GT_CUDACC
 #ifdef __CUDA_ARCH__
 #define GT_CUDA_ARCH __CUDA_ARCH__
+#elif defined(__CUDA_ARCH_LIST__)
+#define GT_CUDA_ARCH __CUDA_ARCH_LIST__
 #endif
 #elif defined(__HIP__)
 #define GT_CUDACC


### PR DESCRIPTION
For some reason `__CUDA_ARCH__` isn't set for the compilation of all intermediate files generated by `nvcc`. Meanwhile `__CUDA_ARCH_LIST__` is.
This generates compilation errors for projects with `GridTools` (and more specifically ones that include [storage/gpu.hpp](https://github.com/GridTools/gridtools/blob/master/include/gridtools/storage/gpu.hpp)) since code that needs to be generated for the GPU that is under a `GT_CUDA_ARCH` `#ifdef` isn't compiled.
Behavior was tested using `CUDA 12.3` in various systems. Below is an example of the `nvcc` compilation command with the `--verbose` flag.
```
#$ gcc -std=c++20 -D__CUDA_ARCH__=600 -D__CUDA_ARCH_LIST__=600 -E -x c++  -DCUDA_DOUBLE_MATH_FUNCTIONS -D__CUDACC__ -D__NVCC__  -I"/scratch/snx3000/ioannmag/cycle21/icon_structured_benchmark/include" -I"/scratch/snx3000/ioannmag/cycle21/icon_structured_benchmark/GridTools" -I"/scratch/snx3000/ioannmag/cycle21/icon_structured_benchmark/build_gpu/_deps/gridtools-src/include" "-I/scratch/snx3000/ioannmag/spack/opt/spack/cray-cnl7-haswell/intel-2022.1.0/cuda-12.3.0-wagarpvzjr6mefjj42ym5343h3dketrg/bin/../targets/x86_64-linux/include"   -isystem "/scratch/snx3000/ioannmag/spack/opt/spack/cray-cnl7-haswell/intel-2022.1.0/boost-1.84.0-uw2w34r3fsrqlahxynev3rmv4oi55lq7/include" -isystem "/scratch/snx3000/ioannmag/spack/opt/spack/cray-cnl7-haswell/intel-2022.1.0/cuda-12.3.0-wagarpvzjr6mefjj42ym5343h3dketrg/targets/x86_64-linux/include"  -D "BOOST_PP_VARIADICS=1" -D__CUDACC_VER_MAJOR__=12 -D__CUDACC_VER_MINOR__=3 -D__CUDACC_VER_BUILD__=52 -D__CUDA_API_VER_MAJOR__=12 -D__CUDA_API_VER_MINOR__=3 -D__NVCC_DIAG_PRAGMA_SUPPORT__=1 -include "cuda_runtime.h" -m64 "/scratch/snx3000/ioannmag/cycle21/icon_structured_benchmark/src/wrapper.cpp" -o "wrapper.cpp1.ii"
#$ gcc -std=c++20 -D__CUDA_ARCH_LIST__=600 -E -x c++ -D__CUDACC__ -D__NVCC__  -I"/scratch/snx3000/ioannmag/cycle21/icon_structured_benchmark/include" -I"/scratch/snx3000/ioannmag/cycle21/icon_structured_benchmark/GridTools" -I"/scratch/snx3000/ioannmag/cycle21/icon_structured_benchmark/build_gpu/_deps/gridtools-src/include" "-I/scratch/snx3000/ioannmag/spack/opt/spack/cray-cnl7-haswell/intel-2022.1.0/cuda-12.3.0-wagarpvzjr6mefjj42ym5343h3dketrg/bin/../targets/x86_64-linux/include"   -isystem "/scratch/snx3000/ioannmag/spack/opt/spack/cray-cnl7-haswell/intel-2022.1.0/boost-1.84.0-uw2w34r3fsrqlahxynev3rmv4oi55lq7/include" -isystem "/scratch/snx3000/ioannmag/spack/opt/spack/cray-cnl7-haswell/intel-2022.1.0/cuda-12.3.0-wagarpvzjr6mefjj42ym5343h3dketrg/targets/x86_64-linux/include"  -D "BOOST_PP_VARIADICS=1" -D__CUDACC_VER_MAJOR__=12 -D__CUDACC_VER_MINOR__=3 -D__CUDACC_VER_BUILD__=52 -D__CUDA_API_VER_MAJOR__=12 -D__CUDA_API_VER_MINOR__=3 -D__NVCC_DIAG_PRAGMA_SUPPORT__=1 -include "cuda_runtime.h" -m64 "/scratch/snx3000/ioannmag/cycle21/icon_structured_benchmark/src/wrapper.cpp" -o "wrapper.cpp4.ii"
#$ -- Filter Dependencies -- > CMakeFiles/benchmark.dir/src/wrapper.cpp.o.d
```
For the use of `gridtools::storage::gpu` in the above example see https://github.com/GridTools/icon_structured_benchmark/blob/ioannmag/gpu/CMakeLists.txt, https://github.com/GridTools/icon_structured_benchmark/blob/ioannmag/gpu/include/nabla4_gridtools.hpp and https://github.com/GridTools/icon_structured_benchmark/blob/ioannmag/gpu/include/nabla4_structured_torus_gridtools_halo.hpp