### PR TITLE
Improve neighbor loads in `horizontal_shift` of `gtfn`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Mikael Simberg (msimberg), ETH Zurich (CSCS)
 Till Ehrengruber (tehrengruber), ETH Zurich (CSCS)
 Péter Kardos (petiaccja), ETH Zurich (EXCLAIM)
 Stefano Ubbiali (stubbiali), ETH Zurich
+Ioannis Magkanaris (iomaganaris), ETH Zurich (CSCS)

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -84,7 +84,8 @@ namespace gridtools::fn {
         template <class Tag, class Ptr, class Strides, class Domain, class Conn, class Offset>
         GT_FUNCTION constexpr auto horizontal_shift(iterator<Tag, Ptr, Strides, Domain> const &it, Conn, Offset) {
             auto const &table = host_device::at_key<Conn>(it.m_domain.m_tables);
-            auto new_index = it.m_index == -1 ? -1 : get<Offset::value>(neighbor_table::neighbors(table, it.m_index));
+            const auto neighbor = get<Offset::value>(neighbor_table::neighbors(table, it.m_index));
+            const auto new_index = it.m_index == -1 ? -1 : neighbor;
             auto shifted = it;
             shifted.m_index = new_index;
             return shifted;

--- a/include/gridtools/storage/gpu.hpp
+++ b/include/gridtools/storage/gpu.hpp
@@ -44,6 +44,7 @@ namespace gridtools {
                 T *m_ptr;
                 Info m_info;
 
+#ifdef GT_CUDACC
                 GT_FUNCTION_DEVICE auto *data() const { return m_ptr; }
                 GT_FUNCTION_DEVICE auto const &info() const { return m_info; }
 
@@ -61,6 +62,7 @@ namespace gridtools {
                 GT_FUNCTION_DEVICE decltype(auto) operator()(array<int, Info::ndims> const &arg) const {
                     return m_ptr[m_info.index_from_tuple(arg)];
                 }
+#endif
             };
         } // namespace gpu_impl_
 

--- a/include/gridtools/storage/gpu.hpp
+++ b/include/gridtools/storage/gpu.hpp
@@ -44,7 +44,6 @@ namespace gridtools {
                 T *m_ptr;
                 Info m_info;
 
-#ifdef GT_CUDACC
                 GT_FUNCTION_DEVICE auto *data() const { return m_ptr; }
                 GT_FUNCTION_DEVICE auto const &info() const { return m_info; }
 
@@ -62,7 +61,6 @@ namespace gridtools {
                 GT_FUNCTION_DEVICE decltype(auto) operator()(array<int, Info::ndims> const &arg) const {
                     return m_ptr[m_info.index_from_tuple(arg)];
                 }
-#endif
             };
         } // namespace gpu_impl_
 


### PR DESCRIPTION
- Define separately neighbor variable to avoid extra memory loads in horizontal_shift()