### PR TITLE
Pybind11: ignore mismatch on integer representation for boolean type

### DIFF
--- a/include/gridtools/storage/adapter/python_sid_adapter.hpp
+++ b/include/gridtools/storage/adapter/python_sid_adapter.hpp
@@ -137,7 +137,7 @@ namespace gridtools {
                 // direct format comparison in not enough, for details see
                 // https://github.com/pybind/pybind11/issues/1806 and https://github.com/pybind/pybind11/issues/1908
                 // ignore this check for boolean type
-                if (std::islower(*int_char) != std::islower(*expected_int_char) && std::islower(*int_char) != 'b')
+                if (std::islower(*int_char) != std::islower(*expected_int_char) && std::tolower(*int_char) != 'b')
                     throw std::domain_error("incompatible integer formats: " + info.format + " and " + expected_format);
             } else if (info.format != expected_format) {
                 throw std::domain_error(

--- a/include/gridtools/storage/adapter/python_sid_adapter.hpp
+++ b/include/gridtools/storage/adapter/python_sid_adapter.hpp
@@ -136,7 +136,8 @@ namespace gridtools {
                 // just check upper/lower case for integer formats which indicates signedness (itemsize already checked)
                 // direct format comparison in not enough, for details see
                 // https://github.com/pybind/pybind11/issues/1806 and https://github.com/pybind/pybind11/issues/1908
-                if (std::islower(*int_char) != std::islower(*expected_int_char))
+                // ignore this check for boolean type
+                if (std::islower(*int_char) != std::islower(*expected_int_char) && std::islower(*int_char) != 'b')
                     throw std::domain_error("incompatible integer formats: " + info.format + " and " + expected_format);
             } else if (info.format != expected_format) {
                 throw std::domain_error(


### PR DESCRIPTION
In pybind11 bindings, allow both `int8_t` and `uint8_t` representations for boolean type. The mismatch on the signess of the integer type, in this case, should not lead to an error.