### PR TITLE
Fix __builtin_assume usage with CUDA

### DIFF
--- a/include/gridtools/common/defs.hpp
+++ b/include/gridtools/common/defs.hpp
@@ -28,7 +28,9 @@ namespace gridtools {
 #endif
 
 #if defined(__has_builtin)
-#if __has_builtin(__builtin_assume) || (defined(GT_CUDA_ARCH) && ((__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || __CUDACC_VER_MAJOR__ > 11))
+#if __has_builtin(__builtin_assume) \
+    || (defined(GT_CUDA_ARCH) && \
+        ((__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 2) || __CUDACC_VER_MAJOR__ >= 12))
 #define GT_ASSUME(x) __builtin_assume(x)
 #else
 #define GT_ASSUME(x)


### PR DESCRIPTION
It seems like the `nvcc` compiler for device code doesn't support the check `__has_builtin(__builtin_assume)` even if `__builtin_assume` is supported since CUDA 11.2.
Adding a check for `__CUDA_ARCH__` and the compiler version fixes the issue.
See [godbolt example](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXAMx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIAruiakl9ZATwDKjdAGFUtEywZ7HAGTwNMAHLuAEaYxCCSAGykAA6oCoR2DC5uHnpxCbYCvv5BLKHhUZaY1lkMQgRMxAQp7p5cxaVJFVUEOYEhYRHRCpXVtWkNva3teQXdAJSWqCbEyOwcAKQATJJ%2ByG5YANSLkk52vcSYrLvYixoAgudXq3hUW1g0/ugQAPqvCEwKr8EmdLYMCbXFZre7vT7fX7/PxvH5/WgA15fBTuTBAy4gx5%2BTBbADiABVXhchEI5ABZbAQVQTLbvKEIvxIhQothU9E3SQxYhMYAsJhbNjMnk4lbLOnwxHI1FbADuhAQMwIWyccgAIhctsgEJhkABrB6YJ6YdCi4GrEpKM2SLH%2BPGE4mkilsq1cnl8gWYIXAEXLMVw6EMJksnFyggKkxKlXqzXavVbAIAeXxBqNJt9VscdwztEtGNWNpxBKJJPJlOpGYY%2BCowLzoJT2Je4K%2B/oZgKtd1pH2b9IBsJ7jKlbBpiwA7E5R04thAC43XlGLkSAEpOAAS72Hy0iK0iU9h86cTleADVsIvXmSLgApBNn147SSq3aqrZcLg7Tfbzv7w8ns9kgCSia3veZwPlsyzDmOE5fmqFwHsep7nleN7vCBL5cBM7KYoa2J2sWjrYHOsFsp2/aBoOmDOrWrq8vygoKMK75%2BmRQbSqGCDKrBMY6vqM6mrWFqYFaBZ4Q6pZEeqVEcjR7r0YxorigGrFsLK8qcdGWo8fGSb1s8/Ecpm1YCTmQm1iJRZiRSEkXFJIKGTWC6vMAtCoMEYioQAbqgeDoFsuphP4tAQH4SrUjsI4AELXFsMWiSWTqqGhGhApIUWXLFcUEdZVJJSlaUarFXIhVQECmssACsJrlU4DCiqQWzlqlwIjo%2BGKXCFApMDCXk%2BZB%2BUZf5xCBbs457CNDQvqcU2SJSGG7Plo6tRcHBTLQnDlbwnjcLwqCcPOyorFFywRVsCgzHMPqSDwpAEJoK1TLqIDlRo%2BicAALLwLAgG9ACcAB0AAcXAVeVkjLD9XAaFwI7Q6QW1aKQu0cLwCggC9t0cFoUxwLAMCICgqAsDEdBhOQlBoETJPhAwHnIMgwNvSYDQ0AiYSoxAwR3aQwR%2BFUACenDXTzzDEHzCbBNoOoY9dFNsIICYMLQAuY7wWC/MAThiDmguq5gfJGOIKukPgRw2HgHmelzmCqDqEYLNdIUlFztB4ME3Kiy4WBcwQxB4F922kBbxDBPEmCqnrhjOX4oAq1MVAGMAChHngmAygmMSMDrMiCCIYjsFwb3Z/IShqFzugNAYRgoGYFgu8EqOQFMqAxGUqMcAAtO3Qch0oWztwAGi3qhfE%2BXc7UHvtYA3EBTFYUtJA4lYDPUpA%2BNiYxdA0GSJAIy/pPEO8MKMnThEMJTzwILT9K4dR6HPZuX30bTryfd9P3vQxP8f%2BSb7P53zBIVa61NpcyRvGI8B4XzLD%2Bm9P6b4IC4EICQd8V0Ji8AxljUgEAkBYA8ngeYZMIAU2JvQYgARWALACBAycwMYFwN1nggByh8T91XvgIgk89D8BzqIcQBci6KBUOoI25dGgX08BARwH9V6Vm/uMLeB8yjSO3mUORm8xEP3KO/G%2BgwNFlCvs/XIr9P6tGkcMaoajT5TB9pgTAPk0ZAI4BtOGoDODh0YTiZOqcwjgMgbQ2B8DEEcJQRNFwlNSEhLQTdO6mFSDaiYFgcIM9SCPWeq9DgH1SBfTeiOP6GgRxvWBr6KIkQYYuKNkjFGaNomxywXjbBIBFQxAjIQ4hVNyFsE4FQvx0CAm8GNEgzhzNZC5z4YXbhxchFlz0DKbkMQdaOOcfDHanAEwRmaUqVA9xuk0N6XAqcYSSE%2BJBBhdBMSpjxMSZQRxmSvrlWgT9CqAMRwvMiJIMGP1ykI0qZYapGD7opKei9NaHBJAgIqZwM5sdHHLHBd8yFNSsZTCDgkewb0gA).
