### PR TITLE
Fix include for test_hugepage_alloc.cpp

### DIFF
--- a/tests/unit_tests/common/test_hugepage_alloc.cpp
+++ b/tests/unit_tests/common/test_hugepage_alloc.cpp
@@ -9,6 +9,7 @@
  */
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <set>
 
 #include <gridtools/common/hugepage_alloc.hpp>


### PR DESCRIPTION
test_hugepage_alloc.cpp is using uintptr_t (optional, btw). It seems like there is no implicit include of cstdint because we have a failure in very recent compilers.

3700 .../files/gridtools/sources/tests/unit_tests/common/test_hugepage_alloc.cpp(68): error: namespace "std" has no member "uintptr_t"
3701              reinterpret_cast<std::uintptr_t>(ptr) % hugepage_alloc_impl_::cache_line_size()