### PR TITLE
Explicitly Use __ldg on Pointer Derefs

### DIFF
--- a/include/gridtools/fn/cartesian.hpp
+++ b/include/gridtools/fn/cartesian.hpp
@@ -16,6 +16,10 @@
 #include "./common_interface.hpp"
 #include "./executor.hpp"
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 350
+#include "../common/cuda_type_traits.hpp"
+#endif
+
 namespace gridtools::fn {
     namespace cartesian::dim {
         using i = integral_constant<int, 0>;
@@ -44,6 +48,12 @@ namespace gridtools::fn {
 
         template <class Tag, class Ptr, class Strides>
         GT_FUNCTION auto deref(iterator<Tag, Ptr, Strides> const &it) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 350
+            if constexpr (std::is_pointer_v<decltype(it.m_ptr)> &&
+                          is_texture_type<std::decay_t<std::remove_pointer_t<decltype(it.m_ptr)>>>::value) {
+                return __ldg(it.m_ptr);
+            }
+#endif
             return *it.m_ptr;
         }
 


### PR DESCRIPTION
Used the `__ldg` intrinsic on (scalar) pointer derefs in SID neighbor tables and derefs within the fn cartesian and unstructured backends.