### PR TITLE
Fix sid_neighbor_table

### DIFF
--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cpp
@@ -21,8 +21,8 @@ namespace gridtools::fn {
 
         using sid_neighbor_table::as_neighbor_table;
 
-        using edge_dim_t = integral_constant<int_t, 0>;
-        using edge_to_cell_dim_t = integral_constant<int_t, 1>;
+        struct edge_dim_t{};
+        struct edge_to_cell_dim_t{};
 
         TEST(sid_neighbor_table, correctness) {
             constexpr std::size_t num_elements = 3;


### PR DESCRIPTION
TODO: Make sure this test works by renaming dimensions or errors because of mismatching dimension names.