### PR TITLE
Use clang-format 21

### DIFF
--- a/include/gridtools/common/hymap.hpp
+++ b/include/gridtools/common/hymap.hpp
@@ -305,7 +305,7 @@ namespace gridtools {
                 using apply = typename get_from_keys_values<meta::first<Maps>>::template apply<Keys, Values>;
             };
         } // namespace impl_
-    }     // namespace hymap
+    } // namespace hymap
 } // namespace gridtools
 
 #define GT_FILENAME <gridtools/common/hymap.hpp>
@@ -464,11 +464,11 @@ namespace gridtools {
 
                 template <size_t I>
                 GT_TARGET GT_FORCE_INLINE constexpr decltype(auto) source() const {
-                    return tuple_util::GT_TARGET_NAMESPACE_NAME::get < is_primary_index<I>::value ? 0 : 1 > (base());
+                    return tuple_util::GT_TARGET_NAMESPACE_NAME::get<is_primary_index<I>::value ? 0 : 1>(base());
                 }
                 template <size_t I>
                 GT_TARGET GT_FORCE_INLINE constexpr decltype(auto) source() {
-                    return tuple_util::GT_TARGET_NAMESPACE_NAME::get < is_primary_index<I>::value ? 0 : 1 > (base());
+                    return tuple_util::GT_TARGET_NAMESPACE_NAME::get<is_primary_index<I>::value ? 0 : 1>(base());
                 }
 
                 template <size_t I>

--- a/include/gridtools/common/int_vector.hpp
+++ b/include/gridtools/common/int_vector.hpp
@@ -99,7 +99,7 @@ namespace gridtools {
          * The keys of the resulting `int_vector` are the union of the keys of the operands.
          */
         template <class... Vecs>
-        GT_FUNCTION constexpr auto plus(Vecs && ...vecs) {
+        GT_FUNCTION constexpr auto plus(Vecs &&...vecs) {
             using merged_meta_map_t = meta::mp_make<impl_::merger_t, meta::concat<hymap::to_meta_map<Vecs>...>>;
             using keys_t = meta::transform<meta::first, merged_meta_map_t>;
             using generators = meta::transform<impl_::add_f, keys_t>;
@@ -111,7 +111,7 @@ namespace gridtools {
          * @brief Returns `int_vector` with elements multiplied by an integral scalar
          */
         template <class Vec, class Scalar>
-        GT_FUNCTION constexpr auto multiply(Vec && vec, Scalar scalar) {
+        GT_FUNCTION constexpr auto multiply(Vec &&vec, Scalar scalar) {
             return tuple_util::host_device::transform([scalar](auto v) { return v * scalar; }, std::forward<Vec>(vec));
         }
 
@@ -119,7 +119,7 @@ namespace gridtools {
          * @brief Returns `int_vector` with elements removed that are `integral_constant<T, 0>`
          */
         template <class Vec>
-        GT_FUNCTION constexpr auto prune_zeros(Vec && vec) {
+        GT_FUNCTION constexpr auto prune_zeros(Vec &&vec) {
             using filtered_map_t = meta::filter<meta::not_<impl_::is_constant_zero>::apply, hymap::to_meta_map<Vec>>;
             using keys_t = meta::transform<meta::first, filtered_map_t>;
             using generators = meta::transform<impl_::at_key_f, keys_t>;
@@ -173,5 +173,5 @@ namespace gridtools {
             }
 
         } // namespace arithmetic
-    }     // namespace int_vector
+    } // namespace int_vector
 } // namespace gridtools

--- a/include/gridtools/common/integral_constant.hpp
+++ b/include/gridtools/common/integral_constant.hpp
@@ -165,7 +165,7 @@ namespace gridtools {
 
         template <char... Chars>
         constexpr GT_FUNCTION integral_constant<literals_impl_::literal_int_t, literals_impl_::parser<Chars...>::value>
-        operator"" _c() {
+        operator""_c() {
             return {};
         }
     } // namespace literals

--- a/include/gridtools/common/tuple_util.hpp
+++ b/include/gridtools/common/tuple_util.hpp
@@ -137,27 +137,27 @@
 
 #define GT_STRUCT_TUPLE_IMPL_DECL_(r, data, elem) GT_PP_TUPLE_ELEM(0, elem) GT_PP_TUPLE_ELEM(1, elem);
 #define GT_STRUCT_TUPLE_IMPL_TYPE_(s, data, elem) GT_PP_TUPLE_ELEM(0, elem)
-#define GT_STRUCT_TUPLE_IMPL_GETS_(s, name, i, elem)                                                        \
+#define GT_STRUCT_TUPLE_IMPL_GETS_(s, name, i, elem)                                                     \
     template <::std::size_t I, ::std::enable_if_t<I == i, int> = 0, class T = GT_PP_TUPLE_ELEM(0, elem)> \
-    static constexpr GT_FUNCTION T const &get(name const &obj) {                                            \
+    static constexpr GT_FUNCTION T const &get(name const &obj) {                                         \
         return obj.GT_PP_TUPLE_ELEM(1, elem);                                                            \
-    }                                                                                                       \
+    }                                                                                                    \
     template <::std::size_t I, ::std::enable_if_t<I == i, int> = 0, class T = GT_PP_TUPLE_ELEM(0, elem)> \
-    static constexpr GT_FUNCTION T &get(name &obj) {                                                        \
+    static constexpr GT_FUNCTION T &get(name &obj) {                                                     \
         return obj.GT_PP_TUPLE_ELEM(1, elem);                                                            \
-    }                                                                                                       \
+    }                                                                                                    \
     template <::std::size_t I, ::std::enable_if_t<I == i, int> = 0, class T = GT_PP_TUPLE_ELEM(0, elem)> \
-    static constexpr GT_FUNCTION T &&get(name &&obj) {                                                      \
+    static constexpr GT_FUNCTION T &&get(name &&obj) {                                                   \
         return static_cast<T &&>(obj.GT_PP_TUPLE_ELEM(1, elem));                                         \
     }
-#define GT_STRUCT_TUPLE_IMPL_(name, members)                                                                          \
-    GT_PP_SEQ_FOR_EACH(GT_STRUCT_TUPLE_IMPL_DECL_, _, members)                                                     \
-    struct gt_##name##_tuple_getter {                                                                                 \
-        GT_PP_SEQ_FOR_EACH_I(GT_STRUCT_TUPLE_IMPL_GETS_, name, members)                                            \
-    };                                                                                                                \
-    friend gt_##name##_tuple_getter tuple_getter(name);                                                               \
+#define GT_STRUCT_TUPLE_IMPL_(name, members)                                                                    \
+    GT_PP_SEQ_FOR_EACH(GT_STRUCT_TUPLE_IMPL_DECL_, _, members)                                                  \
+    struct gt_##name##_tuple_getter {                                                                           \
+        GT_PP_SEQ_FOR_EACH_I(GT_STRUCT_TUPLE_IMPL_GETS_, name, members)                                         \
+    };                                                                                                          \
+    friend gt_##name##_tuple_getter tuple_getter(name);                                                         \
     friend ::gridtools::meta::list<GT_PP_SEQ_ENUM(GT_PP_SEQ_TRANSFORM(GT_STRUCT_TUPLE_IMPL_TYPE_, _, members))> \
-        tuple_to_types(name);                                                                                         \
+        tuple_to_types(name);                                                                                   \
     friend ::gridtools::meta::always<name> tuple_from_types(name)
 
 /*
@@ -466,7 +466,8 @@ namespace gridtools {
         concept tuple_like = is_tuple_like<T>::value;
 
         template <class T, class... Ts>
-        concept tuple_like_of = tuple_like<T> &&
+        concept tuple_like_of =
+            tuple_like<T> &&
             std::is_same_v<meta::rename<meta::list, tuple_util::traits::to_types<T>>, meta::list<Ts...>>;
     } // namespace concepts
 #endif

--- a/include/gridtools/fn/neighbor_table.hpp
+++ b/include/gridtools/fn/neighbor_table.hpp
@@ -61,8 +61,8 @@ namespace gridtools::fn::neighbor_table {
         }
 
         template <class NeighborTable>
-        GT_FUNCTION constexpr auto neighbors(
-            NeighborTable const &nt, int index) -> decltype(neighbor_table_neighbors(nt, index)) {
+        GT_FUNCTION constexpr auto neighbors(NeighborTable const &nt, int index)
+            -> decltype(neighbor_table_neighbors(nt, index)) {
             return neighbor_table_neighbors(nt, index);
         }
 

--- a/include/gridtools/gcl/high_level/call_generic.hpp
+++ b/include/gridtools/gcl/high_level/call_generic.hpp
@@ -37,8 +37,8 @@
 
 template <GT_PP_ENUM_PARAMS(GCL_NOI, typename FOTF_T)>
 void GCL_PACK_F_NAME(GCL_KERNEL_TYPE)(
-    GT_PP_ENUM_BINARY_PARAMS(GCL_NOI, FOTF_T, const &field), void **d_msgbufTab, const int *d_msgsize) {
-    // GCL_PRINT_FIELDS(GCL_NOI);
+    GT_PP_ENUM_BINARY_PARAMS(GCL_NOI, FOTF_T, const &field), void **d_msgbufTab, const int *d_msgsize){
+// GCL_PRINT_FIELDS(GCL_NOI);
 
 #define GCL_QUOTE(x) #x
 #define _GCL_QUOTE(x) GCL_QUOTE(x)

--- a/include/gridtools/gcl/high_level/descriptor_generic_manual.hpp
+++ b/include/gridtools/gcl/high_level/descriptor_generic_manual.hpp
@@ -794,5 +794,5 @@ namespace gridtools {
 #include "non_vect_interface.hpp"
         };
 #endif // cudacc
-    }  // namespace gcl
+    } // namespace gcl
 } // namespace gridtools

--- a/include/gridtools/gcl/high_level/descriptors.hpp
+++ b/include/gridtools/gcl/high_level/descriptors.hpp
@@ -60,12 +60,12 @@ namespace gridtools {
             template <typename iterator_in, typename iterator_out>
             void pack(array<int, 3> const &eta, iterator_in const *field_ptr, iterator_out *&it) const {
                 for (int k = halos[2].loop_low_bound_inside(eta[2]); k <= halos[2].loop_high_bound_inside(eta[2]);
-                     ++k) {
+                    ++k) {
                     for (int j = halos[1].loop_low_bound_inside(eta[1]); j <= halos[1].loop_high_bound_inside(eta[1]);
-                         ++j) {
+                        ++j) {
                         for (int i = halos[0].loop_low_bound_inside(eta[0]);
-                             i <= halos[0].loop_high_bound_inside(eta[0]);
-                             ++i) {
+                            i <= halos[0].loop_high_bound_inside(eta[0]);
+                            ++i) {
                             *(reinterpret_cast<iterator_in *>(it)) =
                                 field_ptr[access(i, j, k, halos[0].total_length(), halos[1].total_length())];
                             reinterpret_cast<char *&>(it) += sizeof(iterator_in);
@@ -77,12 +77,12 @@ namespace gridtools {
             template <typename iterator_in, typename iterator_out>
             void unpack(array<int, 3> const &eta, iterator_in *field_ptr, iterator_out *&it) const {
                 for (int k = halos[2].loop_low_bound_outside(eta[2]); k <= halos[2].loop_high_bound_outside(eta[2]);
-                     ++k) {
+                    ++k) {
                     for (int j = halos[1].loop_low_bound_outside(eta[1]); j <= halos[1].loop_high_bound_outside(eta[1]);
-                         ++j) {
+                        ++j) {
                         for (int i = halos[0].loop_low_bound_outside(eta[0]);
-                             i <= halos[0].loop_high_bound_outside(eta[0]);
-                             ++i) {
+                            i <= halos[0].loop_high_bound_outside(eta[0]);
+                            ++i) {
                             field_ptr[access(i, j, k, halos[0].total_length(), halos[1].total_length())] =
                                 *(reinterpret_cast<iterator_in *>(it));
                             reinterpret_cast<char *&>(it) += sizeof(iterator_in);
@@ -420,8 +420,8 @@ namespace gridtools {
                \param[in] _pid Integer identifier of the process calling the constructor
              */
             explicit hndlr_dynamic_ut(typename grid_type::period_type const &c, int _P, int _pid)
-                : halo(), base_type::m_haloexch(grid_type(c, _P, _pid)), send_buffer{nullptr},
-                  recv_buffer{nullptr}, send_size{0}, recv_size{0} {}
+                : halo(), base_type::m_haloexch(grid_type(c, _P, _pid)), send_buffer{nullptr}, recv_buffer{nullptr},
+                  send_size{0}, recv_size{0} {}
 
             /**
                Constructor
@@ -429,8 +429,8 @@ namespace gridtools {
                \param[in] g A processor grid that will execute the pattern
              */
             explicit hndlr_dynamic_ut(grid_type const &g)
-                : halo(), base_type::m_haloexch(g), send_buffer{nullptr}, recv_buffer{nullptr}, send_size{0}, recv_size{
-                                                                                                                  0} {}
+                : halo(), base_type::m_haloexch(g), send_buffer{nullptr}, recv_buffer{nullptr}, send_size{0},
+                  recv_size{0} {}
 
             /**
                Function to setup internal data structures for data exchange and preparing eventual underlying layers

--- a/include/gridtools/meta/combine.hpp
+++ b/include/gridtools/meta/combine.hpp
@@ -53,8 +53,7 @@ namespace gridtools {
                 using type = F<T1, T2>;
             };
             template <template <class...> class F,
-                template <class...>
-                class L,
+                template <class...> class L,
                 class T1,
                 class T2,
                 class T3,
@@ -63,8 +62,7 @@ namespace gridtools {
                 using type = F<T1, F<T2, T3>>;
             };
             template <template <class...> class F,
-                template <class...>
-                class L,
+                template <class...> class L,
                 class T1,
                 class T2,
                 class T3,
@@ -80,5 +78,5 @@ namespace gridtools {
             template <template <class...> class F, class List>
             struct combine<F, List> : combine_impl<F, List, length<List>::value> {};
         } // namespace lazy
-    }     // namespace meta
+    } // namespace meta
 } // namespace gridtools

--- a/include/gridtools/meta/concat.hpp
+++ b/include/gridtools/meta/concat.hpp
@@ -40,5 +40,5 @@ namespace gridtools {
             template <class List, class... Lists>
             struct concat<List, Lists...> : foldl<meta::concat, List, list<Lists...>> {};
         } // namespace lazy
-    }     // namespace meta
+    } // namespace meta
 } // namespace gridtools

--- a/include/gridtools/meta/debug.hpp
+++ b/include/gridtools/meta/debug.hpp
@@ -27,10 +27,9 @@
  *  Works also with parameter packs. I.e you can both `GT_META_PRINT_VALUE(SomeValue)` and
  * `GT_META_PRINT_VALUE(SomeValues...)`
  */
-#define GT_META_PRINT_VALUE(x)                                                                                \
-    static_assert(                                                                                            \
-        ::gridtools::meta::debug::value<decltype(::gridtools::meta::debug::first(GT_PP_REMOVE_PARENS(x))), \
-            GT_PP_REMOVE_PARENS(x)>::_)
+#define GT_META_PRINT_VALUE(x)                                                                                       \
+    static_assert(::gridtools::meta::debug::value<decltype(::gridtools::meta::debug::first(GT_PP_REMOVE_PARENS(x))), \
+        GT_PP_REMOVE_PARENS(x)>::_)
 
 namespace gridtools {
     namespace meta {
@@ -43,5 +42,5 @@ namespace gridtools {
             template <class T, T...>
             struct value {};
         } // namespace debug
-    }     // namespace meta
+    } // namespace meta
 } // namespace gridtools

--- a/include/gridtools/meta/filter.hpp
+++ b/include/gridtools/meta/filter.hpp
@@ -44,5 +44,5 @@ namespace gridtools {
             struct filter<Pred, L<Ts...>> : concat<L<>, typename wrap_if_impl<Pred<Ts>::type::value, L, Ts>::type...> {
             };
         } // namespace lazy
-    }     // namespace meta
+    } // namespace meta
 } // namespace gridtools

--- a/include/gridtools/meta/fold.hpp
+++ b/include/gridtools/meta/fold.hpp
@@ -52,8 +52,7 @@ namespace gridtools {
             };
             template <template <class...> class F,
                 class S,
-                template <class...>
-                class L,
+                template <class...> class L,
                 class T1,
                 class T2,
                 class T3,
@@ -83,8 +82,7 @@ namespace gridtools {
             };
             template <template <class...> class F,
                 class S,
-                template <class...>
-                class L,
+                template <class...> class L,
                 class T1,
                 class T2,
                 class T3,
@@ -111,8 +109,7 @@ namespace gridtools {
 
             template <template <class...> class F,
                 class S,
-                template <class...>
-                class L,
+                template <class...> class L,
                 class T1,
                 class T2,
                 class T3,
@@ -126,8 +123,7 @@ namespace gridtools {
 
             template <template <class...> class F,
                 class S,
-                template <class...>
-                class L,
+                template <class...> class L,
                 class T1,
                 class T2,
                 class T3,
@@ -145,5 +141,5 @@ namespace gridtools {
                         T1>;
             };
         } // namespace lazy
-    }     // namespace meta
+    } // namespace meta
 } // namespace gridtools

--- a/include/gridtools/meta/group.hpp
+++ b/include/gridtools/meta/group.hpp
@@ -39,18 +39,15 @@ namespace gridtools {
             struct continue_grouping_impl<Pred, L<T, Ts...>, meta::list<Us...>> : Pred<T, Us...> {};
 
             template <template <class...> class Pred,
-                template <class...>
-                class F,
+                template <class...> class F,
                 class List,
                 class Group,
                 bool = continue_grouping_impl<Pred, List, Group>::value>
             struct group_helper : push_front<typename group<Pred, F, List>::type, meta::rename<F, Group>> {};
 
             template <template <class...> class Pred,
-                template <class...>
-                class F,
-                template <class...>
-                class L,
+                template <class...> class F,
+                template <class...> class L,
                 class T,
                 class... Ts,
                 class Group>
@@ -58,10 +55,8 @@ namespace gridtools {
                 : group_helper<Pred, F, L<Ts...>, typename push_back<Group, T>::type> {};
 
             template <template <class...> class Pred,
-                template <class...>
-                class F,
-                template <class...>
-                class L,
+                template <class...> class F,
+                template <class...> class L,
                 class T,
                 class... Ts>
             struct group<Pred, F, L<T, Ts...>> : group_helper<Pred, F, L<Ts...>, list<T>> {};

--- a/include/gridtools/meta/internal/inherit.hpp
+++ b/include/gridtools/meta/internal/inherit.hpp
@@ -16,5 +16,5 @@ namespace gridtools {
             template <class... Ts>
             struct inherit : Ts... {};
         } // namespace internal
-    }     // namespace meta
+    } // namespace meta
 } // namespace gridtools

--- a/include/gridtools/meta/iseq_to_list.hpp
+++ b/include/gridtools/meta/iseq_to_list.hpp
@@ -26,10 +26,8 @@ namespace gridtools {
             template <template <class T, T...> class ISec,
                 class Int,
                 Int... Is,
-                template <class...>
-                class L,
-                template <class T, T>
-                class C>
+                template <class...> class L,
+                template <class T, T> class C>
             struct iseq_to_list<ISec<Int, Is...>, L, C> {
                 using type = L<C<Int, Is>...>;
             };

--- a/include/gridtools/meta/macros.hpp
+++ b/include/gridtools/meta/macros.hpp
@@ -15,7 +15,7 @@
 #include <gridtools/preprocessor/punctuation/remove_parens.hpp>
 
 #define GT_META_DELEGATE_TO_LAZY(fun, signature, args) \
-    template <GT_PP_REMOVE_PARENS(signature)>       \
+    template <GT_PP_REMOVE_PARENS(signature)>          \
     using fun = typename lazy::fun<GT_PP_REMOVE_PARENS(args)>::type
 
 /**

--- a/include/gridtools/meta/rename.hpp
+++ b/include/gridtools/meta/rename.hpp
@@ -35,5 +35,5 @@ namespace gridtools {
                 using type = curry_fun<meta::rename, To>;
             };
         } // namespace lazy
-    }     // namespace meta
+    } // namespace meta
 } // namespace gridtools

--- a/include/gridtools/meta/take.hpp
+++ b/include/gridtools/meta/take.hpp
@@ -48,8 +48,7 @@ namespace gridtools {
             };
 
             template <size_t N,
-                template <class...>
-                class L,
+                template <class...> class L,
                 class T0,
                 class T1,
                 class T2,

--- a/include/gridtools/meta/transform.hpp
+++ b/include/gridtools/meta/transform.hpp
@@ -43,11 +43,9 @@ namespace gridtools {
                 using type = L<F<Ts>...>;
             };
             template <template <class...> class F,
-                template <class...>
-                class L1,
+                template <class...> class L1,
                 class... T1s,
-                template <class...>
-                class L2,
+                template <class...> class L2,
                 class... T2s>
             struct transform<F, L1<T1s...>, L2<T2s...>> {
                 using type = L1<F<T1s, T2s>...>;

--- a/include/gridtools/sid/allocator.hpp
+++ b/include/gridtools/sid/allocator.hpp
@@ -94,7 +94,7 @@ namespace gridtools {
                 }
             };
         } // namespace allocator_impl_
-    }     // namespace sid
+    } // namespace sid
 } // namespace gridtools
 
 #define GT_FILENAME <gridtools/sid/allocator.hpp>

--- a/include/gridtools/sid/concept.hpp
+++ b/include/gridtools/sid/concept.hpp
@@ -473,7 +473,7 @@ namespace gridtools {
             template <class T,
                 class Stride,
                 class Offset,
-                int_t PtrOffset = get_static_const_value<Stride>::value *Offset::value>
+                int_t PtrOffset = get_static_const_value<Stride>::value * Offset::value>
             GT_FUNCTION
                 std::enable_if_t<need_shift<T, Stride, Offset>::value && is_default_shiftable<T, Stride>::value &&
                                  !(has_inc<T>::value && PtrOffset == 1) && !(has_dec<T>::value && PtrOffset == -1)>
@@ -487,7 +487,7 @@ namespace gridtools {
             template <class T,
                 class Stride,
                 class Offset,
-                int_t PtrOffset = get_static_const_value<Stride>::value *Offset::value>
+                int_t PtrOffset = get_static_const_value<Stride>::value * Offset::value>
             GT_FUNCTION std::enable_if_t<need_shift<T, Stride, Offset>::value &&
                                          is_default_shiftable<T, Stride>::value && has_inc<T>::value && PtrOffset == 1>
             shift(T &obj, Stride, Offset) {
@@ -500,7 +500,7 @@ namespace gridtools {
             template <class T,
                 class Stride,
                 class Offset,
-                int_t PtrOffset = get_static_const_value<Stride>::value *Offset::value>
+                int_t PtrOffset = get_static_const_value<Stride>::value * Offset::value>
             GT_FUNCTION std::enable_if_t<need_shift<T, Stride, Offset>::value &&
                                          is_default_shiftable<T, Stride>::value && has_dec<T>::value && PtrOffset == -1>
             shift(T &obj, Stride, Offset) {

--- a/include/gridtools/sid/synthetic.hpp
+++ b/include/gridtools/sid/synthetic.hpp
@@ -94,12 +94,12 @@ namespace gridtools {
             template <>
             struct synthetic<> {
                 template <property Property, class T>
-                constexpr synthetic<unique_mixin<Property, T>> set() const &&noexcept {
+                constexpr synthetic<unique_mixin<Property, T>> set() const && noexcept {
                     return synthetic{};
                 }
 
                 template <property Property, class T>
-                constexpr synthetic<unique_mixin<Property, std::decay_t<T>>> set(T &&val) const &&noexcept {
+                constexpr synthetic<unique_mixin<Property, std::decay_t<T>>> set(T &&val) const && noexcept {
                     return {std::forward<T>(val), synthetic{}};
                 }
             };
@@ -115,13 +115,13 @@ namespace gridtools {
 
                 template <property Property, class T>
                 constexpr synthetic<unique_mixin<Property, T>, Mixin, Mixins...> set(
-                    meta::lazy::id<T> = {}, property_constant<Property> = {}) const &&noexcept {
+                    meta::lazy::id<T> = {}, property_constant<Property> = {}) const && noexcept {
                     return {std::move(*this)};
                 }
 
                 template <property Property, class T>
                 constexpr synthetic<unique_mixin<Property, std::decay_t<T>>, Mixin, Mixins...> set(
-                    T &&val, property_constant<Property> = {}) const &&noexcept {
+                    T &&val, property_constant<Property> = {}) const && noexcept {
                     return {std::forward<T>(val), std::move(*this)};
                 }
             };

--- a/include/gridtools/stencil/be_api.hpp
+++ b/include/gridtools/stencil/be_api.hpp
@@ -419,5 +419,5 @@ namespace gridtools {
             using core::interval;
             using core::level;
         } // namespace be_api
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/common/caches.hpp
+++ b/include/gridtools/stencil/common/caches.hpp
@@ -26,5 +26,5 @@ namespace gridtools {
             // and do not require synchronization. GPU backend uses registers.
             struct k {};
         } // namespace cache_type
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/common/dim.hpp
+++ b/include/gridtools/stencil/common/dim.hpp
@@ -22,5 +22,5 @@ namespace gridtools {
 
             struct thread;
         } // namespace dim
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/backend.hpp
+++ b/include/gridtools/stencil/core/backend.hpp
@@ -52,5 +52,5 @@ namespace gridtools {
             } // namespace backend_impl_
             using backend_impl_::call_entry_point_f;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/cache_info.hpp
+++ b/include/gridtools/stencil/core/cache_info.hpp
@@ -21,5 +21,5 @@ namespace gridtools {
                 using cache_io_policies_t = CacheIOPolicies;
             };
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/compute_extents_metafunctions.hpp
+++ b/include/gridtools/stencil/core/compute_extents_metafunctions.hpp
@@ -119,5 +119,5 @@ namespace gridtools {
             using compute_extents_metafunctions_impl_::lookup_extent_map;
             using compute_extents_metafunctions_impl_::lookup_extent_map_f;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/convert_fe_to_be_spec.hpp
+++ b/include/gridtools/stencil/core/convert_fe_to_be_spec.hpp
@@ -102,5 +102,5 @@ namespace gridtools {
             } // namespace convert_fe_to_be_spec_impl_
             using convert_fe_to_be_spec_impl_::convert_fe_to_be_spec;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/esf.hpp
+++ b/include/gridtools/stencil/core/esf.hpp
@@ -22,5 +22,5 @@ namespace gridtools {
                 using extent_t = Extent;
             };
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/esf_metafunctions.hpp
+++ b/include/gridtools/stencil/core/esf_metafunctions.hpp
@@ -73,5 +73,5 @@ namespace gridtools {
                 class AllRwArgs = meta::transform<meta::first, AllRwItems>>
             using compute_readwrite_args = meta::dedup<AllRwArgs>;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/execution_types.hpp
+++ b/include/gridtools/stencil/core/execution_types.hpp
@@ -33,5 +33,5 @@ namespace gridtools {
             template <class T>
             constexpr integral_constant<int_t, is_backward<T>::value ? -1 : 1> step = {};
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/functor_metafunctions.hpp
+++ b/include/gridtools/stencil/core/functor_metafunctions.hpp
@@ -239,5 +239,5 @@ namespace gridtools {
             using functor_metafunctions_impl_::check_valid_apply_overloads;
             using functor_metafunctions_impl_::make_functor_map;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/grid.hpp
+++ b/include/gridtools/stencil/core/grid.hpp
@@ -130,5 +130,5 @@ namespace gridtools {
             template <class T>
             using is_grid = meta::is_instantiation_of<grid, T>;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/interval.hpp
+++ b/include/gridtools/stencil/core/interval.hpp
@@ -121,5 +121,5 @@ namespace gridtools {
             template <class... Ts>
             using enclosing_interval = typename interval_impl::enclosing_interval<Ts...>::type;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/is_tmp_arg.hpp
+++ b/include/gridtools/stencil/core/is_tmp_arg.hpp
@@ -22,5 +22,5 @@ namespace gridtools {
             template <class T>
             struct is_tmp_arg<T, std::void_t<typename T::tmp_tag>> : std::true_type {};
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/level.hpp
+++ b/include/gridtools/stencil/core/level.hpp
@@ -67,5 +67,5 @@ namespace gridtools {
                 level_impl_::get_offset_from_index(Index::value, Index::offset_limit),
                 Index::offset_limit>;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/mss.hpp
+++ b/include/gridtools/stencil/core/mss.hpp
@@ -19,5 +19,5 @@ namespace gridtools {
                 using cache_map_t = CacheMap;
             };
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/need_sync.hpp
+++ b/include/gridtools/stencil/core/need_sync.hpp
@@ -54,5 +54,5 @@ namespace gridtools {
                 class FinalState = meta::foldl<need_sync_impl_::folding_fun, InitialState, Esfs>>
             using need_sync = meta::replace_at_c<meta::first<FinalState>, 0, need_sync_impl_::has_ij_cache<CacheMap>>;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/core/stage.hpp
+++ b/include/gridtools/stencil/core/stage.hpp
@@ -19,7 +19,7 @@ namespace gridtools {
                 struct meta_stage;
 
                 template <template <class...> class L, class... Ts>
-                struct meta_stage<L<Ts...>> : decltype(get_stage(std::declval<Ts>()...)) {};
+                struct meta_stage<L<Ts...>> : decltype(get_stage(std::declval<Ts>()...)){};
 
                 template <class Keys>
                 struct make_stage_f {
@@ -31,5 +31,5 @@ namespace gridtools {
             template <class Functors, class Keys>
             using make_stages = meta::transform<stage_impl_::make_stage_f<Keys>::template apply, Functors>;
         } // namespace core
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/cpu_ifirst/execinfo.hpp
+++ b/include/gridtools/stencil/cpu_ifirst/execinfo.hpp
@@ -115,5 +115,5 @@ namespace gridtools {
                 GT_FORCE_INLINE int_t j_block_size() const { return m_j_block_size; }
             };
         } // namespace cpu_ifirst_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/cpu_ifirst/loops.hpp
+++ b/include/gridtools/stencil/cpu_ifirst/loops.hpp
@@ -164,5 +164,5 @@ namespace gridtools {
             using loops_impl_::make_loop;
             using loops_impl_::run_loops;
         } // namespace cpu_ifirst_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/cpu_ifirst/pos3.hpp
+++ b/include/gridtools/stencil/cpu_ifirst/pos3.hpp
@@ -22,5 +22,5 @@ namespace gridtools {
                 return {i, j, k};
             }
         } // namespace cpu_ifirst_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/cpu_ifirst/tmp_storage_sid.hpp
+++ b/include/gridtools/stencil/cpu_ifirst/tmp_storage_sid.hpp
@@ -139,5 +139,5 @@ namespace gridtools {
                     .template set<sid::property::ptr_diff, int_t>();
             }
         } // namespace cpu_ifirst_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/dump.hpp
+++ b/include/gridtools/stencil/dump.hpp
@@ -70,8 +70,7 @@ namespace gridtools {
             }
 
             template <template <class...> class L,
-                template <class...>
-                class LL,
+                template <class...> class LL,
                 class Plh,
                 class... Caches,
                 class IsTmp,
@@ -117,8 +116,7 @@ namespace gridtools {
             }
 
             template <template <class...> class L,
-                template <class...>
-                class LL,
+                template <class...> class LL,
                 class... FunCalls,
                 class Interval,
                 class... PlhInfos,

--- a/include/gridtools/stencil/frontend/cartesian/accessor.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/accessor.hpp
@@ -197,5 +197,5 @@ namespace gridtools {
             template <uint_t ID, typename Extent = extent<>, size_t Number = accessor_impl_::minimal_dim<Extent>::value>
             using inout_accessor = accessor<ID, intent::inout, Extent, Number>;
         } // namespace cartesian
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/dimension.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/dimension.hpp
@@ -33,5 +33,5 @@ namespace gridtools {
                 friend GT_FUNCTION constexpr dimension operator-(dimension, int_t offset) { return {-offset}; }
             };
         } // namespace cartesian
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/expressions/expr_base.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/expressions/expr_base.hpp
@@ -75,7 +75,7 @@ namespace gridtools {
                         return Op()(apply_eval(eval, std::move(arg.m_lhs)), apply_eval(eval, std::move(arg.m_rhs)));
                     }
                 } // namespace evaluation
-            }     // namespace expressions
-        }         // namespace cartesian
-    }             // namespace stencil
+            } // namespace expressions
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/expressions/expr_divide.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/expressions/expr_divide.hpp
@@ -30,6 +30,6 @@ namespace gridtools {
                     return make_expr(divide_f(), lhs, rhs);
                 }
             } // namespace expressions
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/expressions/expr_minus.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/expressions/expr_minus.hpp
@@ -37,6 +37,6 @@ namespace gridtools {
                     return make_expr(minus_f(), arg);
                 }
             } // namespace expressions
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/expressions/expr_plus.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/expressions/expr_plus.hpp
@@ -38,6 +38,6 @@ namespace gridtools {
                     return make_expr(plus_f(), arg);
                 }
             } // namespace expressions
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/expressions/expr_pow.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/expressions/expr_pow.hpp
@@ -30,6 +30,6 @@ namespace gridtools {
                     return make_expr(pow_f<I>(), arg);
                 }
             } // namespace expressions
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/expressions/expr_times.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/expressions/expr_times.hpp
@@ -29,6 +29,6 @@ namespace gridtools {
                     return make_expr(times_f(), lhs, rhs);
                 }
             } // namespace expressions
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/stage.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/stage.hpp
@@ -82,5 +82,5 @@ namespace gridtools {
             template <class... Ts>
             meta::curry<stage_impl_::stage> get_stage(Ts &&...);
         } // namespace cartesian
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/stencil_functions.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/stencil_functions.hpp
@@ -241,5 +241,5 @@ namespace gridtools {
                 }
             };
         } // namespace cartesian
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/cartesian/tmp_arg.hpp
+++ b/include/gridtools/stencil/frontend/cartesian/tmp_arg.hpp
@@ -21,16 +21,16 @@
 #define GT_INTERNAL_DECLARE_TMP(r, type, name) \
     constexpr ::gridtools::stencil::cartesian::tmp_arg<__COUNTER__, GT_PP_REMOVE_PARENS(type)> name = {};
 
-#define GT_DECLARE_TMP(type, ...)                                                               \
+#define GT_DECLARE_TMP(type, ...)                                                         \
     GT_PP_SEQ_FOR_EACH(GT_INTERNAL_DECLARE_TMP, type, GT_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
     static_assert(1)
 
-#define GT_INTERNAL_DECLARE_EXPANDABLE_TMP(r, type, name)                                    \
-    constexpr ::gridtools::stencil::expandable<                                              \
+#define GT_INTERNAL_DECLARE_EXPANDABLE_TMP(r, type, name)                                 \
+    constexpr ::gridtools::stencil::expandable<                                           \
         ::gridtools::stencil::cartesian::tmp_arg<__COUNTER__, GT_PP_REMOVE_PARENS(type)>> \
         name = {};
 
-#define GT_DECLARE_EXPANDABLE_TMP(type, ...)                                                               \
+#define GT_DECLARE_EXPANDABLE_TMP(type, ...)                                                         \
     GT_PP_SEQ_FOR_EACH(GT_INTERNAL_DECLARE_EXPANDABLE_TMP, type, GT_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
     static_assert(1)
 
@@ -44,5 +44,5 @@ namespace gridtools {
                 using tmp_tag = std::true_type;
             };
         } // namespace cartesian
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/icosahedral/accessor.hpp
+++ b/include/gridtools/stencil/frontend/icosahedral/accessor.hpp
@@ -37,5 +37,5 @@ namespace gridtools {
             template <uint_t ID, typename LocationType>
             using inout_accessor = accessor<ID, intent::inout, LocationType, extent<>>;
         } // namespace icosahedral
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/icosahedral/connectivity.hpp
+++ b/include/gridtools/stencil/frontend/icosahedral/connectivity.hpp
@@ -396,5 +396,5 @@ namespace gridtools {
             using connectivity_impl_::neighbors_extent;
 
         } // namespace icosahedral
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/icosahedral/location_type.hpp
+++ b/include/gridtools/stencil/frontend/icosahedral/location_type.hpp
@@ -30,5 +30,5 @@ namespace gridtools {
             template <>
             struct is_location_type<vertices> : std::true_type {};
         } // namespace icosahedral
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/icosahedral/stage.hpp
+++ b/include/gridtools/stencil/frontend/icosahedral/stage.hpp
@@ -120,5 +120,5 @@ namespace gridtools {
             template <class... Ts>
             meta::curry<stage_impl_::stage> get_stage(Ts &&...);
         } // namespace icosahedral
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/frontend/icosahedral/tmp_arg.hpp
+++ b/include/gridtools/stencil/frontend/icosahedral/tmp_arg.hpp
@@ -19,22 +19,21 @@
 
 #define GT_INTERNAL_DECLARE_EXPANDABLE_ICO_TMP(r, type_location, name)                                 \
     constexpr ::gridtools::stencil::expandable<::gridtools::stencil::icosahedral::tmp_arg<__COUNTER__, \
-        GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(2, 1, type_location)),                              \
-        GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(2, 0, type_location))>>                             \
+        GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(2, 1, type_location)),                                    \
+        GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(2, 0, type_location))>>                                   \
         name = {};
 
-#define GT_DECLARE_EXPANDABLE_ICO_TMP(type, location, ...)                                               \
-    GT_PP_SEQ_FOR_EACH(                                                                               \
-        GT_INTERNAL_DECLARE_EXPANDABLE_ICO_TMP, (type, location), GT_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
+#define GT_DECLARE_EXPANDABLE_ICO_TMP(type, location, ...)                                                           \
+    GT_PP_SEQ_FOR_EACH(GT_INTERNAL_DECLARE_EXPANDABLE_ICO_TMP, (type, location), GT_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
     static_assert(1)
 
-#define GT_INTERNAL_DECLARE_ICO_TMP(r, type_location, name)               \
-    constexpr ::gridtools::stencil::icosahedral::tmp_arg<__COUNTER__,     \
-        GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(2, 1, type_location)), \
-        GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(2, 0, type_location))> \
+#define GT_INTERNAL_DECLARE_ICO_TMP(r, type_location, name)           \
+    constexpr ::gridtools::stencil::icosahedral::tmp_arg<__COUNTER__, \
+        GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(2, 1, type_location)),   \
+        GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(2, 0, type_location))>   \
         name = {};
 
-#define GT_DECLARE_ICO_TMP(type, location, ...)                                                                 \
+#define GT_DECLARE_ICO_TMP(type, location, ...)                                                           \
     GT_PP_SEQ_FOR_EACH(GT_INTERNAL_DECLARE_ICO_TMP, (type, location), GT_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
     static_assert(1)
 
@@ -48,5 +47,5 @@ namespace gridtools {
                 using tmp_tag = std::true_type;
             };
         } // namespace icosahedral
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu/entry_point.hpp
+++ b/include/gridtools/stencil/gpu/entry_point.hpp
@@ -216,8 +216,7 @@ namespace gridtools {
                 }
 
                 template <class Deref,
-                    template <class...>
-                    class L,
+                    template <class...> class L,
                     class Grid,
                     class DataStores,
                     class PrevKernel = no_kernel>
@@ -226,8 +225,7 @@ namespace gridtools {
                 }
 
                 template <class Deref,
-                    template <class...>
-                    class L,
+                    template <class...> class L,
                     class Mss,
                     class... Msses,
                     class Grid,

--- a/include/gridtools/stencil/gpu/fill_flush.hpp
+++ b/include/gridtools/stencil/gpu/fill_flush.hpp
@@ -399,6 +399,6 @@ namespace gridtools {
                 using impl_::transform_spec;
                 using impl_::validate_k_bounds;
             } // namespace fill_flush
-        }     // namespace gpu_backend
-    }         // namespace stencil
+        } // namespace gpu_backend
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu/ij_cache.hpp
+++ b/include/gridtools/stencil/gpu/ij_cache.hpp
@@ -49,5 +49,5 @@ namespace gridtools {
 
             using ij_cache_impl_::make_ij_cache;
         } // namespace gpu_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu/k_cache.hpp
+++ b/include/gridtools/stencil/gpu/k_cache.hpp
@@ -94,5 +94,5 @@ namespace gridtools {
             using k_cache_impl_::has_k_caches;
             using k_cache_impl_::k_caches_type;
         } // namespace gpu_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu/launch_kernel.hpp
+++ b/include/gridtools/stencil/gpu/launch_kernel.hpp
@@ -219,5 +219,5 @@ namespace gridtools {
              */
             using launch_kernel_impl_::launch_kernel;
         } // namespace gpu_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu/make_kernel_fun.hpp
+++ b/include/gridtools/stencil/gpu/make_kernel_fun.hpp
@@ -157,5 +157,5 @@ namespace gridtools {
             } // namespace make_kernel_fun_impl_
             using make_kernel_fun_impl_::make_kernel_fun;
         } // namespace gpu_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu/shared_allocator.hpp
+++ b/include/gridtools/stencil/gpu/shared_allocator.hpp
@@ -52,5 +52,5 @@ namespace gridtools {
                 size_t size() const { return m_offset; }
             };
         } // namespace gpu_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu/tmp_storage_sid.hpp
+++ b/include/gridtools/stencil/gpu/tmp_storage_sid.hpp
@@ -67,5 +67,5 @@ namespace gridtools {
                     tmp_impl_::origin_offset(extent));
             }
         } // namespace gpu_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu_horizontal/j_cache.hpp
+++ b/include/gridtools/stencil/gpu_horizontal/j_cache.hpp
@@ -124,5 +124,5 @@ namespace gridtools {
 
             using j_cache_impl_::j_caches_type;
         } // namespace gpu_horizontal_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/stencil/gpu_horizontal/launch_kernel.hpp
+++ b/include/gridtools/stencil/gpu_horizontal/launch_kernel.hpp
@@ -71,5 +71,5 @@ namespace gridtools {
 
             using launch_kernel_impl_::launch_kernel;
         } // namespace gpu_horizontal_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/include/gridtools/storage/traits.hpp
+++ b/include/gridtools/storage/traits.hpp
@@ -107,5 +107,5 @@ namespace gridtools {
                 return storage_make_target_view(Traits(), ptr, info);
             }
         } // namespace traits
-    }     // namespace storage
+    } // namespace storage
 } // namespace gridtools

--- a/tests/include/reduction_select.hpp
+++ b/tests/include/reduction_select.hpp
@@ -80,5 +80,5 @@ namespace gridtools {
             timer_cuda backend_timer_impl(gpu);
             inline char const *backend_name(gpu const &) { return "gpu"; }
         } // namespace gpu_backend
-    }     // namespace reduction
+    } // namespace reduction
 } // namespace gridtools

--- a/tests/include/stencil_select.hpp
+++ b/tests/include/stencil_select.hpp
@@ -228,5 +228,5 @@ namespace gridtools {
                 return "gpu_horizontal";
             }
         } // namespace gpu_horizontal_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/include/test_environment.hpp
+++ b/tests/include/test_environment.hpp
@@ -40,19 +40,18 @@
 #define GT_ENVIRONMENT_TEST_CONCAT_TUPLES_(s, state, x) (GT_PP_TUPLE_ENUM(state), GT_PP_TUPLE_ENUM(x))
 
 #define GT_ENVIRONMENT_TEST_ENUM_(seq) \
-    GT_PP_TUPLE_ENUM(               \
-        GT_PP_TUPLE_POP_FRONT(GT_PP_SEQ_FOLD_LEFT(GT_ENVIRONMENT_TEST_CONCAT_TUPLES_, (dummy), seq)))
+    GT_PP_TUPLE_ENUM(GT_PP_TUPLE_POP_FRONT(GT_PP_SEQ_FOLD_LEFT(GT_ENVIRONMENT_TEST_CONCAT_TUPLES_, (dummy), seq)))
 
-#define GT_ENVIRONMENT_TEST_MAKE_TEST_PARAM_(_, data, params)                                                          \
+#define GT_ENVIRONMENT_TEST_MAKE_TEST_PARAM_(_, data, params)                                              \
     (GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(0, data))::apply<GT_PP_REMOVE_PARENS(GT_PP_TUPLE_ELEM(1, data)), \
-        GT_PP_TUPLE_ELEM(0, params),                                                                                \
+        GT_PP_TUPLE_ELEM(0, params),                                                                       \
         ::gridtools::test_environment_impl_::GT_PP_TUPLE_ENUM(GT_PP_TUPLE_POP_FRONT(params))>)
 
 #define GT_ENVIRONMENT_TEST_BODY_(case, test) case##_##test##_test_body
 
-#define GT_ENVIRONMENT_TEST_SUITE(name, env, backend, ...)                                              \
-    template <class T>                                                                                  \
-    using name = ::gridtools::test_environment_impl_::regression_test<T>;                               \
+#define GT_ENVIRONMENT_TEST_SUITE(name, env, backend, ...)                                           \
+    template <class T>                                                                               \
+    using name = ::gridtools::test_environment_impl_::regression_test<T>;                            \
     using name##_types_t = ::testing::Types<GT_ENVIRONMENT_TEST_ENUM_(GT_PP_SEQ_TRANSFORM(           \
         GT_ENVIRONMENT_TEST_MAKE_TEST_PARAM_, (env, backend), GT_PP_VARIADIC_TO_SEQ(__VA_ARGS__)))>; \
     TYPED_TEST_SUITE(name, name##_types_t, ::gridtools::test_environment_impl_::test_environment_names)

--- a/tests/regression/vertical_advection_repository.hpp
+++ b/tests/regression/vertical_advection_repository.hpp
@@ -48,7 +48,9 @@ namespace gridtools {
                 auto column = m_fun(i, j);
                 double res = column[k];
 #pragma omp critical
-                { m_cache.insert({{i, j}, std::move(column)}); }
+                {
+                    m_cache.insert({{i, j}, std::move(column)});
+                }
                 return res;
             }
         };

--- a/tests/unit_tests/common/test_stride_util.cpp
+++ b/tests/unit_tests/common/test_stride_util.cpp
@@ -70,5 +70,5 @@ namespace gridtools {
                 EXPECT_EQ(24000, testee);
             }
         } // namespace
-    }     // namespace stride_util
+    } // namespace stride_util
 } // namespace gridtools

--- a/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
+++ b/tests/unit_tests/fn/test_fn_sid_neighbor_table.cu
@@ -32,7 +32,8 @@ namespace gridtools::fn {
             return neighbor_table::neighbors(table, index);
         }
 
-#if defined(__NVCC__) && defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ < 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ > 8))
+#if defined(__NVCC__) && defined(__CUDACC_VER_MAJOR__) && \
+    (__CUDACC_VER_MAJOR__ < 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ > 8))
         TEST(sid_neighbor_table, correctness_cuda) {
             constexpr std::size_t num_elements = 3;
             constexpr std::size_t num_neighbors = 2;

--- a/tests/unit_tests/sid/test_sid_synthetic.cpp
+++ b/tests/unit_tests/sid/test_sid_synthetic.cpp
@@ -75,5 +75,5 @@ namespace gridtools {
                 EXPECT_EQ(4, tuple_util::get<1>(sid::get_strides(the_testee)).val);
             }
         } // namespace custom
-    }     // namespace
+    } // namespace
 } // namespace gridtools

--- a/tests/unit_tests/stencil/core/test_esf_metafunctions.cpp
+++ b/tests/unit_tests/stencil/core/test_esf_metafunctions.cpp
@@ -116,13 +116,13 @@ typedef p<9> in2;
 typedef p<10> in3;
 
 using mss_t = meta::first<decltype(execute_parallel()
-                                       .stage(functor0(), in0(), in1(), in2(), o0())
-                                       .stage(functor1(), in3(), o1(), in0(), o0())
-                                       .stage(functor2(), o0(), o1(), o2())
-                                       .stage(functor3(), in1(), in2(), o3(), o2())
-                                       .stage(functor4(), o0(), o1(), o3(), o4())
-                                       .stage(functor5(), in3(), o4(), in0(), o5())
-                                       .stage(functor6(), o6(), o5(), in1(), in2()))>;
+        .stage(functor0(), in0(), in1(), in2(), o0())
+        .stage(functor1(), in3(), o1(), in0(), o0())
+        .stage(functor2(), o0(), o1(), o2())
+        .stage(functor3(), in1(), in2(), o3(), o2())
+        .stage(functor4(), o0(), o1(), o3(), o4())
+        .stage(functor5(), in3(), o4(), in0(), o5())
+        .stage(functor6(), o6(), o5(), in1(), in2()))>;
 
 template <class Arg, int_t... ExpectedExtentValues>
 using testee = std::is_same<lookup_extent_map<get_extent_map_from_mss<mss_t>, Arg>, extent<ExpectedExtentValues...>>;

--- a/tests/unit_tests/stencil/core/test_functor_metafunctions.cpp
+++ b/tests/unit_tests/stencil/core/test_functor_metafunctions.cpp
@@ -134,6 +134,6 @@ namespace gridtools {
                 };
                 //                static_assert(check_valid_apply_overloads<bad_to_level, interval_t>::value);
             } // namespace
-        }     // namespace core
-    }         // namespace stencil
+        } // namespace core
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/frontend/cartesian/test_call_interfaces.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_call_interfaces.cpp
@@ -307,5 +307,5 @@ namespace gridtools {
                 do_test<call_with_offsets_call_with_offsets_copy_functor>();
             }
         } // namespace cartesian
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/frontend/cartesian/test_call_interfaces.hpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_call_interfaces.hpp
@@ -68,5 +68,5 @@ namespace gridtools {
                 fun_t shifted = [this](int i, int j, int k) { return input(i + 1, j + 1, k); };
             };
         } // namespace cartesian
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/frontend/cartesian/test_call_proc_interfaces.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_call_proc_interfaces.cpp
@@ -230,6 +230,6 @@ namespace gridtools {
                     verify(out1, [](int, int, int) { return 1; });
                 }
             } // namespace
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/frontend/cartesian/test_expressions.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_expressions.cpp
@@ -96,6 +96,6 @@ namespace gridtools {
                     ASSERT_DOUBLE_EQ(result, 3);
                 }
             } // namespace
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/frontend/cartesian/test_expressions.cu
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_expressions.cu
@@ -23,5 +23,5 @@ namespace gridtools {
                     on_device::exec(GT_MAKE_INTEGRAL_CONSTANT_FROM_VALUE(&test_with_parenthesis_accessors)), -3);
             }
         } // namespace cartesian
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/frontend/cartesian/test_multi_types.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_multi_types.cpp
@@ -197,6 +197,6 @@ namespace gridtools {
                 TEST(multitypes, procedure) { do_test<call_type::procedure>(); }
 
             } // namespace
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/frontend/cartesian/test_stage_with_extents.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_stage_with_extents.cpp
@@ -41,6 +41,6 @@ namespace gridtools {
                 static_assert(testee<c, -3, 3>);
                 static_assert(testee<d>);
             } // namespace
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/frontend/cartesian/test_stencils.cpp
+++ b/tests/unit_tests/stencil/frontend/cartesian/test_stencils.cpp
@@ -136,6 +136,6 @@ namespace gridtools {
                     do_test(l<-1, -1, -1>, l<2, 0, 1>, [](int, int, int) { return i_max + j_max + k_max; });
                 }
             } // namespace
-        }     // namespace cartesian
-    }         // namespace stencil
+        } // namespace cartesian
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/gpu/test_ij_cache.cu
+++ b/tests/unit_tests/stencil/gpu/test_ij_cache.cu
@@ -128,5 +128,5 @@ namespace gridtools {
                     strides2));
             }
         } // namespace gpu_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/gpu/test_launch_kernel.cu
+++ b/tests/unit_tests/stencil/gpu/test_launch_kernel.cu
@@ -113,5 +113,5 @@ namespace gridtools {
                 EXPECT_EQ(0, cuda_util::from_clone(failures));
             }
         } // namespace gpu_backend
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/gpu/test_shared_allocator.cu
+++ b/tests/unit_tests/stencil/gpu/test_shared_allocator.cu
@@ -96,6 +96,6 @@ namespace gridtools {
                     GT_CUDA_CHECK(cudaFree(result));
                 }
             } // namespace
-        }     // namespace gpu_backend
-    }         // namespace stencil
+        } // namespace gpu_backend
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/gpu/test_tmp_storage_sid.cpp
+++ b/tests/unit_tests/stencil/gpu/test_tmp_storage_sid.cpp
@@ -121,6 +121,6 @@ namespace gridtools {
                                         }
                 }
             } // namespace
-        }     // namespace gpu_backend
-    }         // namespace stencil
+        } // namespace gpu_backend
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/gpu/test_tmp_storage_sid.cu
+++ b/tests/unit_tests/stencil/gpu/test_tmp_storage_sid.cu
@@ -44,7 +44,7 @@ namespace gridtools {
                 EXPECT_TRUE(on_device::exec(smoke_f{}, sid::get_origin(testee), sid::get_strides(testee)));
             }
         } // namespace
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools
 
 #include "test_tmp_storage_sid.cpp"

--- a/tests/unit_tests/stencil/test_global_parameter.cpp
+++ b/tests/unit_tests/stencil/test_global_parameter.cpp
@@ -32,5 +32,5 @@ namespace gridtools {
                 EXPECT_EQ(42., *sid::get_origin(testee)());
             }
         } // namespace
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/stencil/test_positional.cpp
+++ b/tests/unit_tests/stencil/test_positional.cpp
@@ -46,5 +46,5 @@ namespace gridtools {
                 EXPECT_EQ(*ptr, -33);
             }
         } // namespace
-    }     // namespace stencil
+    } // namespace stencil
 } // namespace gridtools

--- a/tests/unit_tests/storage/test_storage_facility.cpp
+++ b/tests/unit_tests/storage/test_storage_facility.cpp
@@ -24,8 +24,7 @@ template <class View>
 #ifdef GT_STORAGE_GPU
 __global__
 #endif
-    void
-    computation(View v) {
+    void computation(View v) {
     for (int i = 0; i < 3; ++i)
         for (int j = 0; j < 3; ++j)
             for (int k = 0; k < 3; ++k)

--- a/tests/unit_tests/storage/test_storage_info.cpp
+++ b/tests/unit_tests/storage/test_storage_info.cpp
@@ -181,5 +181,5 @@ namespace gridtools {
                 }
             }
         } // namespace
-    }     // namespace storage
+    } // namespace storage
 } // namespace gridtools

--- a/tests/unit_tests/test_defs.cpp
+++ b/tests/unit_tests/test_defs.cpp
@@ -20,9 +20,8 @@
 #if !defined(GT_ASSUME)
 #error "GT_ASSUME is undefined"
 #else
-static_assert(std::string_view(GT_PP_STRINGIZE(GT_ASSUME(x))) ==
-    std::string_view(GT_PP_STRINGIZE(__builtin_assume(x))),
-        GT_PP_STRINGIZE(GT_ASSUME(x)) " != " GT_PP_STRINGIZE(__builtin_assume(x)));
+static_assert(std::string_view(GT_PP_STRINGIZE(GT_ASSUME(x))) == std::string_view(GT_PP_STRINGIZE(__builtin_assume(x))),
+    GT_PP_STRINGIZE(GT_ASSUME(x)) " != " GT_PP_STRINGIZE(__builtin_assume(x)));
 #endif
 
 #endif

--- a/tools/git_hooks/pre-commit
+++ b/tools/git_hooks/pre-commit
@@ -19,7 +19,7 @@ CLANG_FORMAT=`which clang-format`
 
 ## parsing the clang format version from an output like
 ## Ubuntu clang-format version 3.7.1-2ubuntu2
-CLANG_FORMAT_VERSION=`${CLANG_FORMAT} --version | sed 's/.*clang-format version \([[:digit:]]\.[[:digit:]]\).*/\1/g'`
+CLANG_FORMAT_VERSION=`${CLANG_FORMAT} --version | sed 's/.*clang-format version \([[:digit:]]\+\.[[:digit:]]\+\).*/\1/g'`
 
 # remove any older patches from previous commits. Set to true or false.
 # DELETE_OLD_PATCHES=false
@@ -88,7 +88,7 @@ matches_extension() {
     return 1
 }
 
-if [[ "${CLANG_FORMAT_VERSION}" != "6.0" ]]; then
+if [[ "${CLANG_FORMAT_VERSION}" != "21.1" ]]; then
     echo "Clang format version ${CLANG_FORMAT_VERSION} not supported"
     exit 1
 fi


### PR DESCRIPTION
Silences many warnings about deprecated `operator"" _c()` in newer Clang versions.